### PR TITLE
remove CODEWONERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @vtex-apps/framework-team


### PR DESCRIPTION
We only needed to put framework-team as codeowners while the migration from `search-graphql` to `search-resolver` was in progress. Now things can go back to normal.