### PR TITLE
Fix source language from tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Uses locale from tenant instead of binding in strings translations
 
 ## [0.3.2] - 2020-04-29
 ### Changed

--- a/node/package.json
+++ b/node/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.25.0",
+    "@vtex/api": "6.27.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -1,6 +1,9 @@
-import { formatTranslatableStringV2 } from '@vtex/api'
 import { compose, last, map, omit, pathOr, propOr, split } from 'ramda'
 
+import {
+  addContextToTranslatableString,
+  formatTranslatableProp,
+} from '../../utils/i18n'
 import { getBenefits } from '../benefits'
 import { buildCategoryMap } from './utils'
 
@@ -117,6 +120,11 @@ const productCategoriesToCategoryTree = async (
 
 export const resolvers = {
   Product: {
+    brand: formatTranslatableProp<SearchProduct, 'brand', 'brandId'>(
+      'brand',
+      'brandId'
+    ),
+
     benefits: ({ productId }: SearchProduct, _: any, ctx: Context) =>
       getBenefits(productId, ctx),
 
@@ -157,29 +165,29 @@ export const resolvers = {
 
     recommendations: (product: SearchProduct) => product,
 
-    description: ({ productId, description }: SearchProduct) => formatTranslatableStringV2({
-      content: description,
-      context: productId,
-    }),
+    description: formatTranslatableProp<SearchProduct, 'description', 'productId'>(
+      'description',
+      'productId'
+    ),
 
-    metaTagDescription: ({ productId, metaTagDescription }: SearchProduct) => formatTranslatableStringV2({
-      content: metaTagDescription,
-      context: productId,
-    }),
+    metaTagDescription: formatTranslatableProp<SearchProduct, 'metaTagDescription', 'productId'>(
+      'metaTagDescription',
+      'productId'
+    ),
 
-    titleTag: (product: SearchProduct) => {
-      const { productId, productTitle, productName } = product
+    titleTag: ({ productId, productTitle, productName }: SearchProduct, _: unknown, ctx: Context) =>
+      addContextToTranslatableString(
+        {
+          content: productTitle ?? productName ?? '',
+          context: productId
+        },
+        ctx
+      ),
 
-      return formatTranslatableStringV2({
-        content: productTitle ?? productName ?? '',
-        context: productId,
-      })
-    },
-
-    productName: ({ productId, productName }: SearchProduct) => formatTranslatableStringV2({
-      content: productName,
-      context: productId,
-    }),
+    productName: formatTranslatableProp<SearchProduct, 'productName', 'productId'>(
+      'productName',
+      'productId'
+    ),
 
     linkText: async ({ productId, linkText }: SearchProduct, _: unknown, ctx: Context) => {
       const { clients: { messagesGraphQL }, vtex: { binding, tenant } } = ctx

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -1,0 +1,35 @@
+import {
+  formatTranslatableStringV2,
+  parseTranslatableStringV2,
+} from '@vtex/api'
+
+export const formatTranslatableProp = <R, P extends keyof R, I extends keyof R>(prop: P, idProp: I) =>
+  (root: R, _: unknown, ctx: Context) => addContextToTranslatableString(
+    {
+      content: root[prop] as unknown as string,
+      context: root[idProp] as unknown as string
+    },
+    ctx
+  )
+
+interface Message {
+  content: string,
+  context: string,
+  from?: string
+}
+
+export const addContextToTranslatableString = (message: Message, ctx: Context) => {
+  const { vtex: { tenant } } = ctx
+  const { locale } = tenant!
+
+  const {
+    content,
+    context: originalContext,
+    from: originalFrom
+  } = parseTranslatableStringV2(message.content)
+
+  const context = originalContext || message.context
+  const from = originalFrom || message.from || locale
+
+  return formatTranslatableStringV2({content, context, from})
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.25.0":
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.25.0.tgz#5d64fa74d34ffec67b3e7859bab837104dd21047"
-  integrity sha512-uMIr5FXnw//wiQokIYftf8nB+2vDc1bWFl2XYcChJdTv6So932BK8jBv+wQuc/eN/8BP4M/m0zcghjiejhw4pw==
+"@vtex/api@6.27.0":
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.27.0.tgz#c19634181915363bc9fa9e1150c5c15aa4b3f25e"
+  integrity sha512-yNkEbjSvKnC2VSAypYK5WaGW/tKmDgvO4kNaI8ZKU5anG3U82QjWWYlqsFZXh0ycvlP9l4+Og2BMHat4YKy+uA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4844,7 +4844,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
Currently, the `@traslatableV2` directive uses the source language `from` as the default's binding language. This works well in pages-graphql, however, it is not correct in this app since the catalog's source language is the same as the tenant's locale. 

This PR fixes this problem by correctly assigning the `from` to the tenant's default locale

#### How should this be manually tested?

[Workspace](https://gimenes--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
