### PR TITLE
Fix Cannot read property 'toString' of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes the error: Cannot read property 'toString' of null
 
 ## [0.3.3] - 2020-05-04
 ### Fixed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -275,7 +275,7 @@ export const queries = {
     const { query: filteredQuery, map: filteredMap } = filteredArgs
 
     const segmentData = ctx.vtex.segment
-    const salesChannel = (segmentData && segmentData.channel.toString()) || ''
+    const salesChannel = segmentData?.channel?.toString() || ''
     const unavailableString = hideUnavailableItems
       ? `&fq=isAvailablePerSalesChannel_${salesChannel}:1`
       : ''
@@ -512,7 +512,7 @@ export const queries = {
     )
     return getSearchMetaData(_, compatibilityArgs, ctx)
   },
-  /* All search engines need to implement the topSearches, searchSuggestions, and productSuggestions queries. 
+  /* All search engines need to implement the topSearches, searchSuggestions, and productSuggestions queries.
   VTEX search doesn't support these queries, so it always returns empty results as a placeholder. */
   topSearches: () => {
     return {

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -22,6 +22,10 @@ export const addContextToTranslatableString = (message: Message, ctx: Context) =
   const { vtex: { tenant } } = ctx
   const { locale } = tenant!
 
+  if (!message.content) {
+    return !message.content
+  }
+
   const {
     content,
     context: originalContext,


### PR DESCRIPTION
#### What problem is this solving?
According to this [query](https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dio_vtex_logs%20production%3Dtrue%20level%3Derror%20data.message!%3DPersistedQueryNotFound%20app%3Dvtex.search-resolver%40*%20%20%22data.message%22%3D%22Cannot%20read%20property%20%27toString%27%20of%20null%22&earliest=1588614060&latest=1588617660&sid=1588617702.927975_D730961E-090B-4E7E-A081-1F7623D93A11&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=) we have a `Cannot read property 'toString' of null` error. This PR fixes this problem

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
