### PR TITLE
Use new catalog-api-proxy endpoint for authenticated seaches (B2B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Call the new catalog-api-proxy endpoint for authenticaded searches (B2B).
 
 ## [0.6.0] - 2020-05-07
 

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,9 @@
       "name": "vtex.catalog-api-proxy:catalog-proxy"
     },
     {
+      "name": "vtex.catalog-api-proxy:authenticated-catalog-proxy"
+    },
+    {
       "name": "vbase-read-write"
     },
     {

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -44,10 +44,12 @@ interface SearchPageTypeResponse {
  */
 export class Search extends AppClient {
   private searchEncodeURI: (x: string) => string
+  private basePath: string
 
   public constructor(ctx: IOContext, opts?: InstanceOptions) {
     super('vtex.catalog-api-proxy@0.x', ctx, opts)
 
+    this.basePath = ctx.sessionToken ? '/proxy/authenticated/catalog' : '/proxy/catalog'
     this.searchEncodeURI = searchEncodeURI(ctx.account)
   }
 
@@ -198,7 +200,7 @@ export class Search extends AppClient {
     }
     config.inflightKey = inflightKey
 
-    return this.http.get<T>(`/proxy/catalog${url}`, config)
+    return this.http.get<T>(`${this.basePath}${url}`, config)
   }
 
   public getField = (id: number) =>
@@ -218,7 +220,7 @@ export class Search extends AppClient {
     }
     config.inflightKey = inflightKey
 
-    return this.http.getRaw<T>(`/proxy/catalog${url}`, config)
+    return this.http.getRaw<T>(`${this.basePath}${url}`, config)
   }
 
   private productSearchUrl = ({


### PR DESCRIPTION
#### What problem is this solving?
Use new catalog-api-proxy endpoint for authenticated seaches (B2B)

#### How should this be manually tested?

You need to link this https://github.com/vtex-apps/catalog-api-proxy/pull/24
It is working here: https://brunoh--motorolaus.myvtex.com/smartphones-razr/p

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Depends on https://github.com/vtex-apps/catalog-api-proxy/pull/24

<!-- Put any relevant information that doesn't fit in the other sections here. -->
