### PR TITLE
add log if item has non iterable sellers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add error log if search item has non iterable sellers.
 
 ## [0.6.1] - 2020-05-12
 ### Changed

--- a/node/resolvers/search/productSearch.ts
+++ b/node/resolvers/search/productSearch.ts
@@ -23,7 +23,27 @@ export const resolvers = {
       const quantity = resources.split('/')[1]
       return parseInt(quantity, 10)
     },
-    products: path(['productsRaw', 'data']),
+    products: ({ productsRaw }: ProductSearchParent, _: any, ctx: Context) => {
+      let hasBroken = false
+      for (const product of productsRaw.data) {
+        for (const item of product.items) {
+          if (item.sellers == null) {
+            const config: any = (productsRaw as any).config
+            ctx.vtex.logger.error({
+              message: 'Item missing sellers!',
+              searchUrl: config.url.replace(/\/proxy\/authenticated\/catalog|\/proxy\/catalog/, ''),
+              params: JSON.stringify(config.params)
+            })
+            hasBroken = true
+            break
+          }
+        }
+        if (hasBroken) {
+          break
+        }
+      }
+      return productsRaw.data
+    },
     breadcrumb: async (
       { translatedArgs, productsRaw: { data: products } }: ProductSearchParent,
       _: any,


### PR DESCRIPTION
#### What problem is this solving?

Just add log if item has null/undefined sellers so we can send this data to catalog team so they can fix this issue

#### How should this be manually tested?

https://fidelis--alssports.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
