### PR TITLE
remove cacheId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- `cacheId` from `compatibilityLayer`.
+
 ## [1.1.5] - 2020-05-14
 ### Changed
 - Update `biggySearch` client timeout.

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -24,7 +24,6 @@ export const convertBiggyProduct = (
 
   return {
     categories,
-    cacheId: product.link,
     productId: product.product || product.id,
     productName: product.name,
     productReference: product.reference || product.product || product.id,

--- a/node/package.json
+++ b/node/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.28.1",
+    "@vtex/api": "6.30.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,13 +777,14 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.28.1":
-  version "6.28.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.28.1.tgz#36ae0535bde187f0bf84c69d41bf30f3c38f5ea6"
-  integrity sha512-9lpRwHPPXsyrbwkgbFgMp5/ENvaqS5TVJ7VtOXtRo5HjjEKrRCRO2vhPnocCDYj0O1Msk41Awj30HMZ5MpblFw==
+"@vtex/api@6.30.0":
+  version "6.30.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.0.tgz#9287828804a9b00fa16ab025d530203c4a9464cc"
+  integrity sha512-1VkhwebJYCY7sBdUH3KD2+PTxpX+BiXgVrisXRC07kbaxghzRdJ8oJcjhiSjvEHovjHCBtIHQbTuaM48dRNg5g==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
+    "@vtex/node-error-report" "^0.0.2"
     "@wry/equality" "^0.1.9"
     agentkeepalive "^4.0.2"
     apollo-server-errors "^2.2.1"
@@ -821,6 +822,13 @@
     tar-fs "^2.0.0"
     uuid "^3.3.3"
     xss "^1.0.6"
+
+"@vtex/node-error-report@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.2.tgz#edf15095d6bb543d28b46f86bc109e6214149dfe"
+  integrity sha512-Q6V8E1IR/U0H6uTB1G+gH4ugL4Kw1l/WsK7W46LQBsxv4ISlZcO7dXPlWrL4RzRcVam5yzGAwNkv2wJdW61tAA==
+  dependencies:
+    is-stream "^2.0.0"
 
 "@vtex/tsconfig@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
When we set the cacheId in a ProductSummary, for example, the cached product is replaced by the product from the Biggy APi. It is causing problems in PDP because our product doesn't have all the info needed.
Since these products are coming from our API, we are not taking any advantage from this field, that's why I'm removing it!

[workspace](https://hiago--eriksbikeshop.myvtex.com/)