### PR TITLE
bump graphql version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Bump graphql version.
+
 ## [0.6.2] - 2020-05-13
 ### Changed
 - Add error log if search item has non iterable sellers.

--- a/node/package.json
+++ b/node/package.json
@@ -31,7 +31,7 @@
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.0-beta.4/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.1/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.30.0",
+    "@vtex/api": "6.30.1",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/package.json
+++ b/node/package.json
@@ -31,7 +31,7 @@
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.25.2-beta.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.0-beta.4/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.28.1",
+    "@vtex/api": "6.30.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.30.0":
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.0.tgz#9287828804a9b00fa16ab025d530203c4a9464cc"
-  integrity sha512-1VkhwebJYCY7sBdUH3KD2+PTxpX+BiXgVrisXRC07kbaxghzRdJ8oJcjhiSjvEHovjHCBtIHQbTuaM48dRNg5g==
+"@vtex/api@6.30.1":
+  version "6.30.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.1.tgz#e71ebed6cff6bfdec928535133ffe6d0522797ae"
+  integrity sha512-HfE5Jxii3daU8s3B0FS/5fKeoObkqZkdGBSz8iwWvhYN+nCrvJWm7J0KT5MyGNphp0E3ShxoHQhF46RUG8yXVA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4847,7 +4847,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5417,9 +5417,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.0-beta.4/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.1/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.0-beta.4/public#7b0f265943e6b99ccdf1cadad0b0715aa87462ee"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.1/public#8a5768cf10c831d22fa3e7b9445a0e843f064887"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,13 +777,14 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.28.1":
-  version "6.28.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.28.1.tgz#36ae0535bde187f0bf84c69d41bf30f3c38f5ea6"
-  integrity sha512-9lpRwHPPXsyrbwkgbFgMp5/ENvaqS5TVJ7VtOXtRo5HjjEKrRCRO2vhPnocCDYj0O1Msk41Awj30HMZ5MpblFw==
+"@vtex/api@6.30.0":
+  version "6.30.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.30.0.tgz#9287828804a9b00fa16ab025d530203c4a9464cc"
+  integrity sha512-1VkhwebJYCY7sBdUH3KD2+PTxpX+BiXgVrisXRC07kbaxghzRdJ8oJcjhiSjvEHovjHCBtIHQbTuaM48dRNg5g==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
+    "@vtex/node-error-report" "^0.0.2"
     "@wry/equality" "^0.1.9"
     agentkeepalive "^4.0.2"
     apollo-server-errors "^2.2.1"
@@ -821,6 +822,13 @@
     tar-fs "^2.0.0"
     uuid "^3.3.3"
     xss "^1.0.6"
+
+"@vtex/node-error-report@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.2.tgz#edf15095d6bb543d28b46f86bc109e6214149dfe"
+  integrity sha512-Q6V8E1IR/U0H6uTB1G+gH4ugL4Kw1l/WsK7W46LQBsxv4ISlZcO7dXPlWrL4RzRcVam5yzGAwNkv2wJdW61tAA==
+  dependencies:
+    is-stream "^2.0.0"
 
 "@vtex/tsconfig@^0.2.0":
   version "0.2.0"
@@ -4839,7 +4847,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5409,9 +5417,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.25.2-beta.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.0-beta.4/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.25.2-beta.0/public#5426ea5d6dedc54d790646c92696a944d454a603"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.0-beta.4/public#7b0f265943e6b99ccdf1cadad0b0715aa87462ee"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

I'm justing bumping the `search-graphql` version. It is related to this one: https://github.com/vtex-apps/search-graphql/pull/82

#### How should this be manually tested?

[Workspace](https://master--storecomponents.myvtex.com/apparel---accessories/clothing/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
