### PR TITLE
replace space to hyphen in attribute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Rpelace spaces by hyphens in the `buildAttributePath` function.
+
 ## [1.1.6] - 2020-05-28
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -214,18 +214,14 @@ export const buildBreadcrumb = (selectedFacets: SelectedFacet[]) => {
 }
 
 export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {
-  return selectedFacets.reduce(
-    (attributePath, facet) => {
-      if (facet.key === 'priceRange') {
-        facet.key = 'price'
-        facet.value = facet.value.replace(` TO `, ':')
-      }
+  return selectedFacets.reduce((attributePath, facet) => {
+    if (facet.key === 'priceRange') {
+      facet.key = 'price'
+      facet.value = facet.value.replace(` TO `, ':')
+    }
 
-      return facet.key !== 'ft'
-        ? `${attributePath}${facet.key}/${facet.value}/`
-        : attributePath
-    },
-
-    ''
-  )
+    return facet.key !== 'ft'
+      ? `${attributePath}${facet.key}/${facet.value.replace(/ |%20/, '-')}/`
+      : attributePath
+  }, '')
 }


### PR DESCRIPTION
#### What problem is this solving?

Some URLs can show facet values with spaces instead of hyphens. This PR replace all spaces by hyphens before sending the request to the Biggy API.

#### How should this be manually tested?

[Workspace](https://hiago--txboot.myvtex.com/texasboots/Ladies%20Accessories/Mens%20Accessories?map=c,specificationFilter_1197,specificationFilter_1197&order=OrderByPriceASC)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
