### PR TITLE
fix null context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when message had null context for a bad search on catalog.
 
 ## [0.7.0] - 2020-06-03
 ### Changed

--- a/node/resolvers/search/searchBreadcrumb.ts
+++ b/node/resolvers/search/searchBreadcrumb.ts
@@ -80,6 +80,11 @@ const getBrandInfo = async (
   return search.pageType(queryUnit).catch(() => null)
 }
 
+interface TranslatableData {
+  id?: string
+  name: string
+}
+
 export const resolvers = {
   SearchBreadcrumb: {
     name: async (obj: BreadcrumbParams, _: any, ctx: Context) => {
@@ -96,9 +101,9 @@ export const resolvers = {
         }
       }
       if (isCategoryMap(mapUnit)) {
-        const categoryData = metadataMap[breadcrumbMapKey(queryUnit, mapUnit)] ?? (await getCategoryInfo(obj, isVtex, ctx))
+        const categoryData = (metadataMap[breadcrumbMapKey(queryUnit, mapUnit)] ?? (await getCategoryInfo(obj, isVtex, ctx))) as TranslatableData
         if (categoryData) {
-          return formatTranslatableProp<any, any, any>('name', 'id')(categoryData, _, ctx)
+          return formatTranslatableProp<TranslatableData, 'name', 'id'>('name', 'id')(categoryData, _, ctx)
         }
       }
       if (isSellerMap(mapUnit)) {
@@ -108,9 +113,9 @@ export const resolvers = {
         }
       }
       if (isBrandMap(mapUnit)) {
-        const brandData = metadataMap[breadcrumbMapKey(queryUnit, mapUnit)] ?? (await getBrandInfo(obj, isVtex, ctx))
+        const brandData = (metadataMap[breadcrumbMapKey(queryUnit, mapUnit)] ?? (await getBrandInfo(obj, isVtex, ctx))) as TranslatableData
         if (brandData) {
-          return formatTranslatableProp<any, any, any>('name', 'id')(brandData, _, ctx)
+          return formatTranslatableProp<TranslatableData, 'name', 'id'>('name', 'id')(brandData, _, ctx)
         }
       }
       if (isSpecificationFilter(mapUnit)) {

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -26,7 +26,7 @@ export interface Message extends BaseMessage {
   context?: string
 }
 
-export const addContextToTranslatableString = (message: MessageWithContext, ctx: Context) => {
+export const addContextToTranslatableString = (message: Message, ctx: Context) => {
   const { vtex: { tenant } } = ctx
   const { locale } = tenant!
 
@@ -40,7 +40,7 @@ export const addContextToTranslatableString = (message: MessageWithContext, ctx:
     from: originalFrom
   } = parseTranslatableStringV2(message.content)
 
-  const context = (originalContext || message.context).toString()
+  const context = (originalContext || message.context)?.toString()
   const from = originalFrom || message.from || locale
 
   return formatTranslatableStringV2({ content, context, from })
@@ -54,7 +54,7 @@ export const translateToCurrentLanguage = (message: MessageWithContext, ctx: Con
 
   return state.messagesBindingLanguage!.load({
     content: message.content,
-    context: message.context.toString(),
+    context: message.context?.toString(),
     from: message.from ?? tenant!.locale,
   })
 }


### PR DESCRIPTION
#### What problem is this solving?

On some circumstances, with certain `query` values, the category/brand pagetype would return with id null, making the context.toString() be problematic.

Fix this and improve typings.

#### How should this be manually tested?

https://fidelis--motorolaus.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
