### PR TITLE
remove - from breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Remove `-`from breadcrumb.
+
 ## [1.3.1] - 2020-06-03
 
 ### Changed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -231,7 +231,7 @@ export const buildBreadcrumb = (selectedFacets: SelectedFacet[]) => {
           pivotMap.push(selectedFacet.key)
 
           return {
-            name: decodeURIComponent(selectedFacet.value),
+            name: decodeURIComponent(selectedFacet.value.replace(/-+/g, ' ')),
             href: `/${pivotValue.join('/')}?map=${pivotMap.join(',')}`,
           }
         })


### PR DESCRIPTION
#### What problem is this solving?

Remove dashes from breadcrumb.
This is just a quick fix, I'm about to use the breadcrumb from `facets` instead of `productSearch`

#### How should this be manually tested?

[Workspace](https://hiago--minisomx.myvtex.com/Salud-Y-Belleza)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
