### PR TITLE
Feature/split correction suggestions banners add redirect and facet breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Redirect query.
+- Breadcrumb to `facets`.
+
+### Changed
+- Remove `suggestions`, `correction` and `banners` from `productSearchV3` and create a query for each one.
+
 ## [1.4.1] - 2020-06-17
 
 ### Fixed

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -213,25 +213,6 @@ export class BiggySearchClient extends ExternalClient {
     }
   }
 
-  public async redirect(args: SearchResultArgs): Promise<any> {
-    const { fullText } = args
-
-    const url = `${this.store}/api/split/redirect_search/${buildPathFromArgs(
-      args
-    )}`
-
-    const result = await this.http.getRaw(url, {
-      params: {
-        query: fullText,
-      },
-      metric: 'search-redirect',
-    })
-
-    return {
-      url: result.data.redirect,
-    }
-  }
-
   public async searchSuggestions(args: { fullText: string }): Promise<any> {
     const { fullText } = args
 

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -158,4 +158,92 @@ export class BiggySearchClient extends ExternalClient {
 
     return result.data
   }
+
+  public async banners(args: SearchResultArgs): Promise<any> {
+    const { fullText } = args
+
+    const url = `${this.store}/api/split/banner_search/${buildPathFromArgs(
+      args
+    )}`
+
+    const result = await this.http.getRaw(url, {
+      params: {
+        query: fullText,
+      },
+      metric: 'search-result',
+    })
+
+    return {
+      banners: result.data.banners,
+    }
+  }
+
+  public async autocompleteSearchSuggestions(args: {
+    fullText: string
+  }): Promise<any> {
+    const { fullText } = args
+
+    const result = await this.http.get<any>(
+      `${this.store}/api/suggestion_searches`,
+      {
+        params: {
+          term: fullText,
+        },
+        metric: 'search-autcomplete-suggestions',
+      }
+    )
+
+    return result
+  }
+
+  public async correction(args: { fullText: string }): Promise<any> {
+    const { fullText } = args
+
+    const url = `${this.store}/api/split/correction_search/`
+
+    const result = await this.http.getRaw(url, {
+      params: {
+        query: fullText,
+      },
+      metric: 'search-correction',
+    })
+
+    return {
+      correction: result.data.correction,
+    }
+  }
+
+  public async redirect(args: SearchResultArgs): Promise<any> {
+    const { fullText } = args
+
+    const url = `${this.store}/api/split/redirect_search/${buildPathFromArgs(
+      args
+    )}`
+
+    const result = await this.http.getRaw(url, {
+      params: {
+        query: fullText,
+      },
+      metric: 'search-redirect',
+    })
+
+    return {
+      url: result.data.redirect,
+    }
+  }
+
+  public async searchSuggestions(args: { fullText: string }): Promise<any> {
+    const { fullText } = args
+
+    const url = `${this.store}/api/split/suggestion_search/`
+
+    const result = await this.http.getRaw(url, {
+      params: {
+        query: fullText,
+      },
+      metric: 'search-suggestions',
+    })
+
+    return result.data.suggestion
+  }
 }

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -271,6 +271,29 @@ export const buildBreadcrumb = (
   return breadcrumb
 }
 
+export const deprecatedBuildBreadcrumb = (selectedFacets: SelectedFacet[]) => {
+  const pivotValue: string[] = []
+  const pivotMap: string[] = []
+
+  return selectedFacets
+    ? selectedFacets
+        .filter(
+          selectedFacet =>
+            selectedFacet.key !== 'priceRange' &&
+            selectedFacet.key !== 'productClusterIds'
+        )
+        .map(selectedFacet => {
+          pivotValue.push(selectedFacet.value)
+          pivotMap.push(selectedFacet.key)
+
+          return {
+            name: decodeURIComponent(selectedFacet.value.replace(/-+/g, ' ')),
+            href: `/${pivotValue.join('/')}?map=${pivotMap.join(',')}`,
+          }
+        })
+    : []
+}
+
 export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {
   return selectedFacets
     ? selectedFacets.reduce((attributePath, facet) => {

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -11,11 +11,6 @@ interface ExtraData {
   value: string
 }
 
-interface BreadcrumbItem {
-  name: string
-  href: string
-}
-
 export const convertBiggyProduct = (
   product: any,
   tradePolicy?: string,
@@ -243,7 +238,7 @@ export const buildBreadcrumb = (
   const pivotValue: string[] = []
   const pivotMap: string[] = []
 
-  const breadcrumb: BreadcrumbItem[] = []
+  const breadcrumb: Breadcrumb[] = []
 
   if (fullText) {
     pivotValue.push(fullText)

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.3/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.4/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.4/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.2/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.3/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.1/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.1/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.1/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.2/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -404,6 +404,7 @@ export const queries = {
       recordsFiltered: result.total,
       fuzzy: result.fuzzy,
       operator: result.operator,
+      redirect: result.redirect,
     }
   },
 
@@ -510,21 +511,9 @@ export const queries = {
 
     return biggySearch.correction(args)
   },
-  redirect: (
-    _: any,
-    args: { fullText: string; selectedFacets: SelectedFacet[] },
-    ctx: Context
-  ) => {
-    const { biggySearch } = ctx.clients
-
-    return biggySearch.redirect({
-      attributePath: buildAttributePath(args.selectedFacets),
-      fullText: args.fullText,
-    })
-  },
   searchSuggestions: (_: any, args: { fullText: string }, ctx: Context) => {
     const { biggySearch } = ctx.clients
 
     return biggySearch.searchSuggestions(args)
-  }
+  },
 }

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -26,6 +26,7 @@ import {
   buildAttributePath,
   convertOrderBy,
   buildBreadcrumb,
+  deprecatedBuildBreadcrumb,
 } from '../../commons/compatibility-layer'
 import { productsCatalog, productsBiggy } from '../../commons/products'
 
@@ -402,6 +403,7 @@ export const queries = {
     return {
       products: convertedProducts,
       recordsFiltered: result.total,
+      breadcrumb: deprecatedBuildBreadcrumb(selectedFacets),
       correction: result.correction,
       fuzzy: result.fuzzy,
       operator: result.operator,

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -402,11 +402,8 @@ export const queries = {
     return {
       products: convertedProducts,
       recordsFiltered: result.total,
-      suggestion: result.suggestion,
-      correction: result.correction,
       fuzzy: result.fuzzy,
       operator: result.operator,
-      banners: result.banners,
     }
   },
 
@@ -471,14 +468,14 @@ export const queries = {
 
     return await biggySearch.topSearches()
   },
-  searchSuggestions: () => async (
+  autocompleteSearchSuggestions: (
     _: any,
-    args: SuggestionSearchesArgs,
+    args: { fullText: string },
     ctx: Context
   ) => {
     const { biggySearch } = ctx.clients
 
-    return await biggySearch.suggestionSearches(args)
+    return biggySearch.autocompleteSearchSuggestions(args)
   },
   productSuggestions: async (
     _: any,
@@ -496,4 +493,38 @@ export const queries = {
 
     return result
   },
+  banners: (
+    _: any,
+    args: { fullText: string; selectedFacets: SelectedFacet[] },
+    ctx: Context
+  ) => {
+    const { biggySearch } = ctx.clients
+
+    return biggySearch.banners({
+      attributePath: buildAttributePath(args.selectedFacets),
+      fullText: args.fullText,
+    })
+  },
+  correction: (_: any, args: { fullText: string }, ctx: Context) => {
+    const { biggySearch } = ctx.clients
+
+    return biggySearch.correction(args)
+  },
+  redirect: (
+    _: any,
+    args: { fullText: string; selectedFacets: SelectedFacet[] },
+    ctx: Context
+  ) => {
+    const { biggySearch } = ctx.clients
+
+    return biggySearch.redirect({
+      attributePath: buildAttributePath(args.selectedFacets),
+      fullText: args.fullText,
+    })
+  },
+  searchSuggestions: (_: any, args: { fullText: string }, ctx: Context) => {
+    const { biggySearch } = ctx.clients
+
+    return biggySearch.searchSuggestions(args)
+  }
 }

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -265,6 +265,7 @@ export const queries = {
         query: args.query,
         selectedFacets: args.selectedFacets,
       },
+      breadcrumb: buildBreadcrumb(result.attributes || [], args.fullText),
     }
   },
 
@@ -401,7 +402,6 @@ export const queries = {
     return {
       products: convertedProducts,
       recordsFiltered: result.total,
-      breadcrumb: buildBreadcrumb(selectedFacets),
       suggestion: result.suggestion,
       correction: result.correction,
       fuzzy: result.fuzzy,

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -402,6 +402,7 @@ export const queries = {
     return {
       products: convertedProducts,
       recordsFiltered: result.total,
+      correction: result.correction,
       fuzzy: result.fuzzy,
       operator: result.operator,
       redirect: result.redirect,

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -80,3 +80,26 @@ interface ProductSearchInput {
   orderBy: string
   productOriginVtex: boolean
 }
+
+interface ElasticAttribute {
+  visible: boolean
+  active: boolean
+  key: string
+  label: string
+  type: string
+  values: ElasticAttributeValue[]
+  minValue?: number
+  maxValue?: number
+}
+
+interface ElasticAttributeValue {
+  count: number
+  active: boolean
+  key: string
+  label: string
+}
+
+interface Breadcrumb {
+  href: string
+  name: string
+}

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -33,16 +33,17 @@ enum IndexingType {
 
 interface SearchResultArgs {
   attributePath: string
-  query: string
-  page: number
-  count: number
-  sort: string
-  operator: string
-  fuzzy: string
+  query?: string
+  page?: number
+  count?: number
+  sort?: string
+  operator?: string
+  fuzzy?: string
   leap?: boolean
   tradePolicy?: number
   segment?: SegmentData
   indexingType?: IndexingType
+  fullText: string
 }
 
 interface SuggestionProductsArgs {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5424,9 +5424,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.2/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.3/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.2/public#4b2857743e6090cbe6398a37ab03145781f55e54"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.3/public#33ca9a365d0588af87836cf3829aa5bc838633a7"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5424,9 +5424,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.3/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.4/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.3/public#33ca9a365d0588af87836cf3829aa5bc838633a7"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.4/public#398ec7fe1e887c1ec10cb1ec18c28478da8d4c11"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4847,7 +4847,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5424,9 +5424,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.1/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.2/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.1/public#97043cdebceefb8119642787672e65aa1c815588"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.2/public#4b2857743e6090cbe6398a37ab03145781f55e54"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5424,9 +5424,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.4/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.4/public#398ec7fe1e887c1ec10cb1ec18c28478da8d4c11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public#b4396a33ed2e02a531350660ded4a8da601adbdb"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5424,9 +5424,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.1/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.1/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.27.1/public#8a5768cf10c831d22fa3e7b9445a0e843f064887"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0-beta.1/public#97043cdebceefb8119642787672e65aa1c815588"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

With some tests, we concluded that if we separate the banner, correction, and suggestion from the `productSearch` we would increase the search performance. This PR split these fields into three new queries: `correction`,  `searchSuggestions`, and `banners`.

This PR adds another new query: the `redirect`. It will be used to redirect the user to another page based on the search query;

Besides that, I also added a new field to `facets`: the `breadcrumb`. `vtex.search-resolver@1.x` will have more performance if the breadcrumb is coming from `facets` instead of `productSearch`.

#### How should this be manually tested?

[Workspace](https://hiago--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

⚠️ Please, do not merge it before
- https://github.com/vtex-apps/search-graphql/pull/84