### PR TITLE
Add location filter and parse searchState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `location` attributes.
+- `searchState` parsing.
+
 ## [1.5.1] - 2020-06-17
 
 ### Removed

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -1,5 +1,6 @@
 import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
 import { IndexingType } from '../commons/compatibility-layer'
+import { parseState } from '../utils/searchState'
 import path from 'path'
 
 const buildPathFromArgs = (args: SearchResultArgs) => {
@@ -86,7 +87,16 @@ export class BiggySearchClient extends ExternalClient {
   }
 
   public async searchMetadata(args: SearchResultArgs): Promise<any> {
-    const { query, page, count, sort, operator, fuzzy, leap } = args
+    const {
+      query,
+      page,
+      count,
+      sort,
+      operator,
+      fuzzy,
+      leap,
+      searchState,
+    } = args
 
     const url = `${this.store}/api/split/metadata_search/${buildPathFromArgs(
       args
@@ -101,6 +111,7 @@ export class BiggySearchClient extends ExternalClient {
         operator,
         fuzzy,
         bgy_leap: leap ? true : undefined,
+        ...parseState(searchState),
       },
       metric: 'search-result',
     })
@@ -114,7 +125,16 @@ export class BiggySearchClient extends ExternalClient {
   }
 
   public async facets(args: SearchResultArgs): Promise<any> {
-    const { query, page, count, sort, operator, fuzzy, leap } = args
+    const {
+      query,
+      page,
+      count,
+      sort,
+      operator,
+      fuzzy,
+      leap,
+      searchState,
+    } = args
 
     const url = `${this.store}/api/split/attribute_search/${buildPathFromArgs(
       args
@@ -129,6 +149,7 @@ export class BiggySearchClient extends ExternalClient {
         operator,
         fuzzy,
         bgy_leap: leap ? true : undefined,
+        ...parseState(searchState),
       },
       metric: 'search-result',
     })
@@ -137,7 +158,16 @@ export class BiggySearchClient extends ExternalClient {
   }
 
   public async productSearch(args: SearchResultArgs): Promise<any> {
-    const { query, page, count, sort, operator, fuzzy, leap } = args
+    const {
+      query,
+      page,
+      count,
+      sort,
+      operator,
+      fuzzy,
+      leap,
+      searchState,
+    } = args
 
     const url = `${this.store}/api/split/product_search/${buildPathFromArgs(
       args
@@ -152,6 +182,7 @@ export class BiggySearchClient extends ExternalClient {
         operator,
         fuzzy,
         bgy_leap: leap ? true : undefined,
+        ...parseState(searchState),
       },
       metric: 'search-result',
     })

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -1,5 +1,4 @@
 import VtexSeller from './models/VtexSeller'
-import unescape from 'unescape'
 
 export enum IndexingType {
   API = 'API',
@@ -145,61 +144,6 @@ const convertSKU = (
     ],
   }
 }
-
-export const biggyAttributesToVtexFilters = (attributes: any) =>
-  attributes.map((attribute: any) => {
-    const isNumber = attribute.type === 'number'
-
-    return {
-      name: attribute.label,
-      type: isNumber
-        ? attribute.key === 'price'
-          ? 'PRICERANGE'
-          : 'NUMBER'
-        : attribute.type.toUpperCase(),
-      hidden: !attribute.visible,
-      values:
-        isNumber && attribute.key === 'price'
-          ? [
-              {
-                quantity: attribute.values.reduce(
-                  (acum: number, value: any) => acum + value.count,
-                  0
-                ),
-                name: unescape(attribute.label),
-                key: attribute.key,
-                value: attribute.key,
-                range: {
-                  from: attribute.minValue,
-                  to: attribute.maxValue,
-                },
-              },
-            ]
-          : isNumber
-          ? attribute.values.map((value: any) => {
-              return {
-                quantity: value.count,
-                name: unescape(`${value.from} - ${value.to}`),
-                key: attribute.key,
-                value: `${value.from}:${value.to}`,
-                selected: value.active,
-                range: {
-                  from: value.from !== '*' ? value.from : attribute.minValue,
-                  to: value.to !== '*' ? value.to : attribute.maxValue,
-                },
-              }
-            })
-          : attribute.values.map((value: any) => {
-              return {
-                quantity: value.count,
-                name: unescape(value.label),
-                key: attribute.key,
-                value: value.key,
-                selected: value.active,
-              }
-            }),
-    }
-  })
 
 /**
  * Convert from VTEX OrderBy into Biggy's sort.

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -22,12 +22,12 @@ import {
 import { toCompatibilityArgs } from './newURLs'
 import { PATH_SEPARATOR, MAP_VALUES_SEP } from './constants'
 import {
-  biggyAttributesToVtexFilters,
   buildAttributePath,
   convertOrderBy,
   buildBreadcrumb,
 } from '../../commons/compatibility-layer'
 import { productsCatalog, productsBiggy } from '../../commons/products'
+import { attributesToFilters } from '../../utils/attributes'
 
 interface ProductIndentifier {
   field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'
@@ -240,7 +240,7 @@ export const queries = {
       args
     )) as FacetsInput
 
-    let { fullText } = args
+    let { fullText, searchState } = args
 
     if (fullText) {
       fullText = await translateToStoreDefaultLanguage(ctx, args.fullText!)
@@ -250,17 +250,16 @@ export const queries = {
     const { segment } = ctx.vtex
 
     const biggyArgs = {
+      searchState,
+      query: fullText,
       attributePath: buildAttributePath(args.selectedFacets),
-      query: args.fullText,
       tradePolicy: segment && segment.channel,
     }
 
     const result = await biggySearch.facets(biggyArgs)
 
     return {
-      facets: result.attributes
-        ? biggyAttributesToVtexFilters(result.attributes)
-        : [],
+      facets: attributesToFilters(result),
       queryArgs: {
         query: args.query,
         selectedFacets: args.selectedFacets,
@@ -376,7 +375,15 @@ export const queries = {
 
     const { biggySearch } = ctx.clients
     const { segment } = ctx.vtex
-    const { from, to, selectedFacets, fullText, fuzzy, operator } = args
+    const {
+      from,
+      to,
+      selectedFacets,
+      fullText,
+      fuzzy,
+      operator,
+      searchState,
+    } = args
 
     const count = to - from + 1
     const page = Math.round((to + 1) / count)
@@ -386,6 +393,7 @@ export const queries = {
       count,
       fuzzy,
       operator,
+      searchState,
       attributePath: buildAttributePath(selectedFacets),
       query: fullText,
       tradePolicy: segment && segment.channel,
@@ -400,6 +408,7 @@ export const queries = {
     const convertedProducts = productResolver(result, ctx)
 
     return {
+      searchState,
       products: convertedProducts,
       recordsFiltered: result.total,
       correction: result.correction,

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -44,6 +44,7 @@ interface SearchResultArgs {
   segment?: SegmentData
   indexingType?: IndexingType
   fullText: string
+  searchState?: string
 }
 
 interface SuggestionProductsArgs {
@@ -68,6 +69,7 @@ interface FacetsInput {
   selectedFacets: SelectedFacet[]
   fullText: string
   query: string
+  searchState?: string
 }
 
 interface ProductSearchInput {
@@ -80,6 +82,7 @@ interface ProductSearchInput {
   operator: string
   orderBy: string
   productOriginVtex: boolean
+  searchState?: string
 }
 
 interface ElasticAttribute {

--- a/node/utils/attributes.test.ts
+++ b/node/utils/attributes.test.ts
@@ -1,0 +1,246 @@
+import { attributesToFilters } from './attributes'
+
+describe('attributesToFilters', () => {
+  it('should convert a text attribute correctly', () => {
+    expect(
+      attributesToFilters({
+        total: 108,
+        attributes: [
+          {
+            visible: true,
+            values: [
+              {
+                count: 108,
+                active: false,
+                key: 'lions-pride',
+                label: 'Lions Pride',
+              },
+            ],
+            key: 'brand',
+            label: 'Brand',
+            type: 'text' as 'text',
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        hidden: false,
+        name: 'Brand',
+        type: 'TEXT',
+        values: [
+          {
+            key: 'brand',
+            name: 'Lions Pride',
+            quantity: 108,
+            selected: false,
+            value: 'lions-pride',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should convert price attribute correctly', () => {
+    expect(
+      attributesToFilters({
+        total: 367,
+        attributes: [
+          {
+            visible: true,
+            values: [
+              {
+                count: 180,
+                active: false,
+                from: '*',
+                to: '30',
+              },
+              {
+                count: 90,
+                active: false,
+                from: '30',
+                to: '50',
+              },
+              {
+                count: 97,
+                active: false,
+                from: '50',
+                to: '*',
+              },
+            ],
+            active: false,
+            key: 'price',
+            label: 'Price',
+            type: 'number' as 'number',
+            minValue: 10,
+            maxValue: 100,
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        hidden: false,
+        name: 'Price',
+        type: 'PRICERANGE',
+        values: [
+          {
+            key: 'price',
+            name: 'Price',
+            quantity: 367,
+            value: 'price',
+            range: {
+              from: 10,
+              to: 100,
+            },
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should convert number attributes correctly', () => {
+    expect(
+      attributesToFilters({
+        total: 13,
+        attributes: [
+          {
+            visible: true,
+            values: [
+              {
+                count: 13,
+                active: false,
+                from: '0',
+                to: '*',
+              },
+            ],
+            active: false,
+            key: 'polegadas',
+            label: 'Polegadas',
+            type: 'number' as 'number',
+            minValue: 0,
+            maxValue: 0,
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        hidden: false,
+        name: 'Polegadas',
+        type: 'TEXT',
+        values: [
+          {
+            key: 'polegadas',
+            name: '0 - *',
+            quantity: 13,
+            selected: false,
+            value: '0:*',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should convert not selected location attributes correctly', () => {
+    expect(
+      attributesToFilters({
+        total: 124,
+        attributes: [
+          {
+            visible: true,
+            values: [
+              {
+                count: 71,
+                active: false,
+                from: '0',
+                to: '5505580',
+              },
+              {
+                count: 53,
+                active: false,
+                from: '0',
+                to: '4477620',
+              },
+            ],
+            active: false,
+            key: 'location',
+            label: 'Location',
+            type: 'location' as 'location',
+            minValue: 2421698.143072009,
+            maxValue: 6533501.777013255,
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        hidden: false,
+        name: 'Location',
+        type: 'TEXT',
+        values: [
+          {
+            key: 'location',
+            name: '0 - 5505580',
+            quantity: 71,
+            selected: false,
+            value: 'l:0:5505580',
+          },
+          {
+            key: 'location',
+            name: '0 - 4477620',
+            quantity: 53,
+            selected: false,
+            value: 'l:0:4477620',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('should convert selected location attributes correctly', () => {
+    expect(
+      attributesToFilters({
+        total: 124,
+        attributes: [
+          {
+            visible: true,
+            values: [
+              {
+                count: 71,
+                active: false,
+                from: '0',
+                to: '5505580',
+              },
+              {
+                count: 53,
+                active: false,
+                from: '0',
+                to: '4477620',
+              },
+            ],
+            active: true,
+            activeFrom: '0',
+            activeTo: '3605120',
+            key: 'location',
+            label: 'Location',
+            type: 'location' as 'location',
+            minValue: 2421698.143072009,
+            maxValue: 6533501.777013255,
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        hidden: false,
+        name: 'Location',
+        type: 'TEXT',
+        values: [
+          {
+            key: 'location',
+            name: '0 - 3605120',
+            quantity: 124,
+            selected: true,
+            value: 'l:0:3605120',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -1,0 +1,181 @@
+import { either, isEmpty, isNil } from 'ramda'
+import unescape from 'unescape'
+
+type Attribute = (NumericalAttribute | TextAttribute) & {
+  key: string
+  label: string
+  type: 'text' | 'number' | 'location'
+  visible: boolean
+}
+
+interface NumericalAttribute {
+  type: 'number' | 'location'
+  maxValue: number
+  minValue: number
+  active: boolean
+  activeFrom?: string
+  activeTo?: string
+  values: {
+    count: number
+    from: string
+    to: string
+    active: boolean
+  }[]
+}
+
+interface TextAttribute {
+  type: 'text'
+  values: {
+    key: string
+    count: number
+    active: boolean
+    label: string
+  }[]
+}
+
+type FilterType = 'PRICERANGE' | 'TEXT'
+interface Filter {
+  type: FilterType
+  name: string
+  hidden: boolean
+  values: FilterValue[]
+}
+
+interface FilterValue {
+  quantity: number
+  name: string
+  key: string
+  value: string
+  selected?: boolean
+  range?: {
+    from: number
+    to: number
+  }
+}
+
+/**
+ * Convert from Biggy's attributes into Specification Filters.
+ *
+ * @export
+ * @param {Attribute[]} [attributes] Attributes from Biggy's API.
+ * @returns {Filter[]}
+ */
+export const attributesToFilters = ({
+  total,
+  attributes,
+}: {
+  total: number
+  attributes?: Attribute[]
+}): Filter[] => {
+  if (either(isNil, isEmpty)(attributes)) {
+    return []
+  }
+
+  return attributes!.map(attribute => {
+    const { type, values } = convertValues(attribute, total)
+
+    return {
+      values,
+      type,
+      name: attribute.label,
+      hidden: !attribute.visible,
+    }
+  })
+}
+
+/**
+ * Convert values, and create FilterType, that can be either `PRICERANGE` or
+ * `TEXT`, only price uses the `PRICERANGE` type, other number attributes that
+ * come from Biggy's API are transformed into TEXT filters.
+ *
+ * Location attributes are also transformed in TEXT filters, but when a location
+ * is selected, only a single bucket is returned (the API returns multiple buckets,
+ * but does not return the selected one, and there's no need to select multiple
+ * location buckets).
+ *
+ * If an attribute is not of type `'text' | 'number' | 'location'`, an error will
+ * be thrown.
+ *
+ * @param {Attribute} attribute
+ * @returns {{ type: FilterType; values: FilterValue[] }}
+ */
+const convertValues = (
+  attribute: Attribute,
+  total: number
+): { type: FilterType; values: FilterValue[] } => {
+  // When creating a filter for price attribute, it should be the only one to use
+  // the type `'PRICERANGE'`.
+  if (attribute.type === 'number' && attribute.key === 'price') {
+    return {
+      type: 'PRICERANGE',
+      values: [
+        {
+          quantity: attribute.values.reduce(
+            (acum: number, value: any) => acum + value.count,
+            0
+          ),
+          name: unescape(attribute.label),
+          key: attribute.key,
+          value: attribute.key,
+          range: {
+            from: attribute.minValue,
+            to: attribute.maxValue,
+          },
+        },
+      ],
+    }
+  }
+
+  // For other `number` and `location` attributes we use TEXT based filters (checkboxes),
+  // with buckets (e.g.: 0 - 30, 30 - 90, etc).
+  if (attribute.type === 'number' || attribute.type === 'location') {
+    const valuePrefix = attribute.type === 'location' ? 'l:' : ''
+
+    // When a bucket is active, we should only show it, and none of the othter options.
+    if (attribute.active) {
+      return {
+        type: 'TEXT',
+        values: [
+          {
+            quantity: total,
+            name: unescape(`${attribute.activeFrom} - ${attribute.activeTo}`),
+            value: `${valuePrefix}${attribute.activeFrom}:${attribute.activeTo}`,
+            key: attribute.key,
+            selected: attribute.active,
+          },
+        ],
+      }
+    }
+
+    return {
+      type: 'TEXT',
+      values: attribute.values.map(value => {
+        return {
+          quantity: value.count,
+          name: unescape(`${value.from} - ${value.to}`),
+          key: attribute.key,
+          value: `${valuePrefix}${value.from}:${value.to}`,
+          selected: value.active,
+        }
+      }),
+    }
+  }
+
+  // Basic `text` attributes.
+  if (attribute.type === 'text') {
+    return {
+      type: 'TEXT',
+      values: attribute.values.map(value => {
+        return {
+          quantity: value.count,
+          name: unescape(value.label),
+          key: attribute.key,
+          value: value.key,
+          selected: value.active,
+        }
+      }),
+    }
+  }
+
+  throw new Error(`Not recognized attribute type: ${attribute.type}`)
+}

--- a/node/utils/searchState.test.ts
+++ b/node/utils/searchState.test.ts
@@ -1,0 +1,19 @@
+import { parseState } from './searchState'
+
+describe('parseState', () => {
+  it('should correctly parse empty state', () => {
+    expect(parseState('')).toEqual({})
+    expect(parseState(undefined)).toEqual({})
+  })
+
+  it('should return empty on invalid state', () => {
+    expect(parseState('adsasd')).toEqual({})
+    expect(parseState('4')).toEqual({})
+  })
+
+  it('should correctly parse state', () => {
+    expect(parseState(JSON.stringify({ property: 'value' }))).toEqual({
+      property: 'value',
+    })
+  })
+})

--- a/node/utils/searchState.ts
+++ b/node/utils/searchState.ts
@@ -1,0 +1,31 @@
+import { either, isEmpty, isNil } from 'ramda'
+
+/**
+ * Parse `searchState` string into a `object`.
+ * We treat `searchState` as a stringified javascript object.
+ * Parsing errors are returned as an empty object
+ *
+ * ```
+ *       { location: "l:-1:1", utm_source: "xxx" }
+ * ```
+ * @private
+ * @param {string} state
+ * @returns {{ [key: string]: string }}
+ * @memberof BiggySearchClient
+ */
+export const parseState = (state?: string): { [key: string]: string } => {
+  if (either(isNil, isEmpty)(state)) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(state!)
+    if (typeof parsed === 'object') {
+      return parsed
+    }
+  } catch (err) {
+    /* ignore parsing errors */
+  }
+
+  return {}
+}


### PR DESCRIPTION
#### What problem is this solving?

Accept and send to front-end components attributes of type `location`, this type of attribute needs to know the "query location" (passed in via queryString), in this case, we chose to pass via the generic `searchState` input variable.

I cleaned up a bit our attribute to specification filter conversion function and added a testing suite.

#### How should this be manually tested?

[Workspace](https://christian--biggy.myvtex.com/1/toyota?_q=toyota&fuzzy=0&map=trade-policy,ft&operator=and&searchState={%22location%22:%22l:-23.533773:-46.625290%22})

This workspace uses a modified version of `search-result` with this correction: https://github.com/vtex-apps/search-result/pull/362 

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/34144667/84697434-7e3f9100-af24-11ea-9ab2-eb8de8d78ce7.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
