### PR TITLE
Removed stub taxPercentage, and calculate when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `taxPercentage` calculation.
+
 ## [1.4.0] - 2020-06-15
 
 ### Added

--- a/node/commons/models/VtexSeller.ts
+++ b/node/commons/models/VtexSeller.ts
@@ -14,6 +14,7 @@ interface CommertialOffer {
   Price: number
   ListPrice: number
   PriceWithoutDiscount: number
+  Tax: number
 }
 
 class VtexSeller {
@@ -48,6 +49,7 @@ class VtexSeller {
       Price: price,
       ListPrice: oldPrice,
       PriceWithoutDiscount: price,
+      Tax: 0,
     }
   }
 }

--- a/node/resolvers/search/offer.ts
+++ b/node/resolvers/search/offer.ts
@@ -103,6 +103,8 @@ export const resolvers = {
       })?.Value;
       return spotPrice || sellingPrice
     },
-    taxPercentage: () => 0 // NOTE: We do not have offer.Tax info
+    taxPercentage: (offer: CommertialOffer) => {
+      return offer.Tax / offer.Price
+    }
   },
 }


### PR DESCRIPTION
#### What problem is this solving?

Removed stub taxPercentage, and calculate when possible (when using productOrigin prop for example).

#### How should this be manually tested?

[Workspace](https://christian--storecomponents.myvtex.com/shirt?_q=shirt&map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
x | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

