### PR TITLE
Revert "add deprecated breadcrumb"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Deprecated breadcrumb.
+
 ## [1.5.0] - 2020-06-17
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -271,29 +271,6 @@ export const buildBreadcrumb = (
   return breadcrumb
 }
 
-export const deprecatedBuildBreadcrumb = (selectedFacets: SelectedFacet[]) => {
-  const pivotValue: string[] = []
-  const pivotMap: string[] = []
-
-  return selectedFacets
-    ? selectedFacets
-        .filter(
-          selectedFacet =>
-            selectedFacet.key !== 'priceRange' &&
-            selectedFacet.key !== 'productClusterIds'
-        )
-        .map(selectedFacet => {
-          pivotValue.push(selectedFacet.value)
-          pivotMap.push(selectedFacet.key)
-
-          return {
-            name: decodeURIComponent(selectedFacet.value.replace(/-+/g, ' ')),
-            href: `/${pivotValue.join('/')}?map=${pivotMap.join(',')}`,
-          }
-        })
-    : []
-}
-
 export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {
   return selectedFacets
     ? selectedFacets.reduce((attributePath, facet) => {

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -26,7 +26,6 @@ import {
   buildAttributePath,
   convertOrderBy,
   buildBreadcrumb,
-  deprecatedBuildBreadcrumb,
 } from '../../commons/compatibility-layer'
 import { productsCatalog, productsBiggy } from '../../commons/products'
 
@@ -403,7 +402,6 @@ export const queries = {
     return {
       products: convertedProducts,
       recordsFiltered: result.total,
-      breadcrumb: deprecatedBuildBreadcrumb(selectedFacets),
       correction: result.correction,
       fuzzy: result.fuzzy,
       operator: result.operator,


### PR DESCRIPTION
Acabei precisando manter a versao deprecated do breadcrumb (vindo do ´productSearch´) enquanto o store-resources nao subia. Caso contrário as lojas ficariam sem breadcrumb.
Agora que o store-resource está atualizado já podemos remover o breadcrumb do `productSearch`
