### PR TITLE
use decodeURIComponent instead of decodeURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Use `decodeURIComponent` instead of `decodeURI` in metadata titletag and breadcrumb name.
+
 ## [0.8.0] - 2020-06-17
 
 ### Added

--- a/node/resolvers/search/modules/metadata.ts
+++ b/node/resolvers/search/modules/metadata.ts
@@ -129,7 +129,7 @@ const getPrimaryMetadata = (
     const cleanQuery = args.query || ''
     const term = head(cleanQuery.split('/')) || ''
     return {
-      titleTag: decodeURI(term),
+      titleTag: decodeURIComponent(term),
       metaTagDescription: null,
     }
   }

--- a/node/resolvers/search/searchBreadcrumb.ts
+++ b/node/resolvers/search/searchBreadcrumb.ts
@@ -121,7 +121,7 @@ export const resolvers = {
       if (isSpecificationFilter(mapUnit)) {
         return getSpecificationFilterName(queryUnit)
       }
-      return defaultName && decodeURI(defaultName)
+      return defaultName && decodeURIComponent(defaultName)
     },
     href: (params: BreadcrumbParams) => {
       const {


### PR DESCRIPTION
#### What problem is this solving?

Breadcrumb and titleTag don't decode the "/" (`%2F`)

#### How should this be manually tested?

[Workspace](https://searchslashbug--storecomponents.myvtex.com/top$2fs?map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
