### PR TITLE
Add extradata when productOriginVtex is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `extraData` when `productOriginVtex` is `true`.
+
 ## [1.6.0] - 2020-06-18
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -5,7 +5,7 @@ export enum IndexingType {
   XML = 'XML',
 }
 
-interface ExtraData {
+export interface ExtraData {
   key: string
   value: string
 }

--- a/node/commons/products.ts
+++ b/node/commons/products.ts
@@ -44,13 +44,6 @@ export const productsCatalog = async (searchResult: any, ctx: any) => {
       // This will help to sort the products
       product.biggyIndex = idx
 
-      biggyProduct.extraData = [
-        {
-          key: 'specificationTest',
-          value: 'specification do hiago',
-        },
-      ]
-
       if (biggyProduct.extraData) {
         biggyProduct.extraData.forEach(({ key, value }: ExtraData) => {
           if (indexOf(key, product.allSpecifications) < 0) {


### PR DESCRIPTION
#### What problem is this solving?

Add extradata when productOriginVtex is true. Currently, it is only working when it is false.

#### How should this be manually tested?

[Workspace](https://extradata--eriksbikeshop.myvtex.com/kids%20bikes?map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

