### PR TITLE
slugify facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Slugify facet keys before check if it is selected.
+
 ## [0.8.0] - 2020-06-17
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.31.1",
+    "@vtex/api": "6.33.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/resolvers/search/facets.ts
+++ b/node/resolvers/search/facets.ts
@@ -2,6 +2,7 @@ import { prop, toPairs } from 'ramda'
 
 import { zipQueryAndMap } from './utils'
 import { formatTranslatableProp, addContextToTranslatableString } from '../../utils/i18n'
+import { searchSlugify } from '../../utils/slug'
 
 interface EitherFacet extends SearchFacet {
   Children?: EitherFacet[]
@@ -37,7 +38,7 @@ const addSelected = (
     const currentFacetSlug = decodeURIComponent(facet.Value).toLowerCase()
     const isSelected =
       joinedQueryAndMap.find(
-        ([slug, slugMap]) => slug === currentFacetSlug && facet.Map === slugMap
+        ([slug, slugMap]) => searchSlugify(slug) === searchSlugify(currentFacetSlug) && facet.Map === slugMap
       ) !== undefined
 
     return {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.31.1":
-  version "6.31.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.31.1.tgz#dcb7bddb0b77d6a1ad936da0a6bbc42d577b7883"
-  integrity sha512-KogyA3ZL4behY/8HG7SormxbcOnETJAre6sWkUvSbl1SYLoeL/znvMigzp5812lGDxqjwcIxW6AdFP2Qla+8zw==
+"@vtex/api@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.33.0.tgz#8aca963a8b4a33d06321f8de3f5b224d4eec76ce"
+  integrity sha512-eguTB4WgSJJ+Hi90Uvy8jiu/OtyB6PV4IpixDH6197knFmmaif6L7lf34n8zkJ2sbJLFsYHDbk3WgCU2qNVexA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4847,7 +4847,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
Some facet keys have special characters such as `ñ`. But there is no consistency in the way this character is sent to the resolver. Sometimes it is `ñ`, and sometimes it is `n`.

The problem with this is that `search-resolver` need to compare what is sent from frontend with what is in the catalog API to know if the facet is selected or not.

This PR slugify the facet keys before comparing them.

#### How should this be manually tested?

[Workspace](https://hiago--hushpuppieskidscl.myvtex.com/nina/calzado/botas)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
