### PR TITLE
add misssing unescape import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add missing `unescape` import in `compatibility-layer`.
+
 ## [1.6.3] - 2020-06-25
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -1,3 +1,5 @@
+import unescape from 'unescape'
+
 import VtexSeller from './models/VtexSeller'
 
 export enum IndexingType {

--- a/node/package.json
+++ b/node/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.32.0",
+    "@vtex/api": "6.33.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.32.0":
-  version "6.32.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.32.0.tgz#358241705423c53e13c7201522fe8f9bd4ea732b"
-  integrity sha512-9DJI35bMeK3r6tkT9IAxd1y1sV55quJg3iYYBv3Tbpb7EcVeADudMV5IXqt9PjuWv2OntZNOAHy3NbZzRyjXzg==
+"@vtex/api@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.33.0.tgz#8aca963a8b4a33d06321f8de3f5b224d4eec76ce"
+  integrity sha512-eguTB4WgSJJ+Hi90Uvy8jiu/OtyB6PV4IpixDH6197knFmmaif6L7lf34n8zkJ2sbJLFsYHDbk3WgCU2qNVexA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?

We are not unescaping the breadcrumb.

![image](https://user-images.githubusercontent.com/40380674/86160005-8b8e7b00-bae1-11ea-821a-3d28dc62c4db.png)

This is because we are not importing the `unescape` lib in `compatibility-layer`

#### How should this be manually tested?

[Workspace](https://hiago--bitofbritain.myvtex.com/140/men-s?fuzzy=0&map=productClusterIds,department-&operator=and)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/40380674/86160216-d0b2ad00-bae1-11ea-8d8e-cae4ab14d1e6.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

