### PR TITLE
sort breadcrumb based on selectedFacets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Sort breadcrumb values based on `selectedFacets`.
+
 ## [1.6.3] - 2020-06-25
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -177,7 +177,8 @@ export const convertOrderBy = (orderBy?: string): string => {
 
 export const buildBreadcrumb = (
   attributes: ElasticAttribute[],
-  fullText: string
+  fullText: string,
+  selectedFacets: SelectedFacet[]
 ) => {
   const pivotValue: string[] = []
   const pivotMap: string[] = []
@@ -206,11 +207,20 @@ export const buildBreadcrumb = (
       pivotMap.push(attribute.key)
 
       breadcrumb.push({
+        key: value.key,
         name: unescape(value.label),
         href: `/${pivotValue.join('/')}?map=${pivotMap.join(',')}`,
       })
     })
   })
+
+  const selectedFacetsValues = selectedFacets.map(facet => facet.value)
+
+  breadcrumb.sort((a, b) =>
+    selectedFacetsValues.indexOf(a.key!) < selectedFacetsValues.indexOf(b.key!)
+      ? -1
+      : 1
+  )
 
   return breadcrumb
 }

--- a/node/package.json
+++ b/node/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.32.0",
+    "@vtex/api": "6.33.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -264,7 +264,11 @@ export const queries = {
         query: args.query,
         selectedFacets: args.selectedFacets,
       },
-      breadcrumb: buildBreadcrumb(result.attributes || [], args.fullText),
+      breadcrumb: buildBreadcrumb(
+        result.attributes || [],
+        args.fullText,
+        args.selectedFacets || []
+      ),
     }
   },
 

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -104,6 +104,7 @@ interface ElasticAttributeValue {
 }
 
 interface Breadcrumb {
+  key?: string
   href: string
   name: string
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.32.0":
-  version "6.32.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.32.0.tgz#358241705423c53e13c7201522fe8f9bd4ea732b"
-  integrity sha512-9DJI35bMeK3r6tkT9IAxd1y1sV55quJg3iYYBv3Tbpb7EcVeADudMV5IXqt9PjuWv2OntZNOAHy3NbZzRyjXzg==
+"@vtex/api@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.33.0.tgz#8aca963a8b4a33d06321f8de3f5b224d4eec76ce"
+  integrity sha512-eguTB4WgSJJ+Hi90Uvy8jiu/OtyB6PV4IpixDH6197knFmmaif6L7lf34n8zkJ2sbJLFsYHDbk3WgCU2qNVexA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?

Some clients are complaining about the order of breadcrumb values. In `search-resolver@0.x` the order is based on the `selectedFacets`.

This PR changes the `search-resolver@v1.x` breadcrumb to follow the same order in `v0.x` breadcrumb.

#### How should this be manually tested?

[Workspace](https://hiago--redoxx.myvtex.com/bags/duffel?map=c,specificationFilter_818&page=1)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

