### PR TITLE
fix specification names appearing in breadcrumb coming with catalog e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Decode specification names coming from catalog to remove special catalog characters.
 
 ## [0.8.0] - 2020-06-17
 

--- a/node/package.json
+++ b/node/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.31.1",
+    "@vtex/api": "6.33.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/resolvers/search/modules/metadata.ts
+++ b/node/resolvers/search/modules/metadata.ts
@@ -16,7 +16,7 @@ import {
 } from 'ramda'
 import { Functions } from '@gocommerce/utils'
 
-import { zipQueryAndMap, findCategoryInTree, getBrandFromSlug } from '../utils'
+import { zipQueryAndMap, findCategoryInTree, getBrandFromSlug, searchDecodeURI } from '../utils'
 import { toTitleCase } from '../../../utils/string'
 import { formatTranslatableProp, translateManyToCurrentLanguage, Message, shouldTranslateToUserLocale } from '../../../utils/i18n'
 
@@ -102,7 +102,7 @@ const getBrandMetadata = async (
 }
 
 export const getSpecificationFilterName = (name: string) => {
-  return toTitleCase(decodeURI(name))
+  return toTitleCase(searchDecodeURI(decodeURI(name)))
 }
 
 const getPrimaryMetadata = (

--- a/node/resolvers/search/productSearch.test.ts
+++ b/node/resolvers/search/productSearch.test.ts
@@ -258,7 +258,7 @@ describe('tests for breadcrumb resolver', () => {
   })
 })
 
-describe.only('tests related to the productSearch query', () => {
+describe('tests related to the productSearch query', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     resetContext()

--- a/node/resolvers/search/utils.ts
+++ b/node/resolvers/search/utils.ts
@@ -143,6 +143,30 @@ export const searchEncodeURI = (account: string) => (str: string) => {
   return str
 }
 
+export const searchDecodeURI = (str: string) => {
+  return str.replace(/(\@perc\@|\@slash\@|\@quo\@|\@squo\@|\@dot\@|\@lpar\@|\@rpar\@)/g, (c: string) => {
+    switch (c) {
+      case '@perc@':
+        return '%'
+      case '@quo@':
+        return "\""
+      case '@squo@':
+        return "\'"
+      case '@dot@':
+        return "."
+      case '@lpar@':
+        return "("
+      case '@rpar@':
+        return ")"
+      case '@slash@':
+        return "/"
+      default: {
+        return c
+      }
+    }
+  })
+}
+
 export const getMapAndPriceRangeFromSelectedFacets = (
   selectedFacets: SelectedFacets[]
 ) => {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.31.1":
-  version "6.31.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.31.1.tgz#dcb7bddb0b77d6a1ad936da0a6bbc42d577b7883"
-  integrity sha512-KogyA3ZL4behY/8HG7SormxbcOnETJAre6sWkUvSbl1SYLoeL/znvMigzp5812lGDxqjwcIxW6AdFP2Qla+8zw==
+"@vtex/api@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.33.0.tgz#8aca963a8b4a33d06321f8de3f5b224d4eec76ce"
+  integrity sha512-eguTB4WgSJJ+Hi90Uvy8jiu/OtyB6PV4IpixDH6197knFmmaif6L7lf34n8zkJ2sbJLFsYHDbk3WgCU2qNVexA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4847,7 +4847,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
…ncoded chars

#### What problem is this solving?

Specifications may come encoded when coming from the browser, so we have to decode them before showing to the user.

5@slash@6 => 5/6

#### How should this be manually tested?

https://fidelis--storekimbo.myvtex.com/caffe/roasting_2@slash@6

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
