### PR TITLE
Make skuSpecification's field & value translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Translation to `SKUSpecificationField` and `SKUSpecificationValue`.
 
 ## [0.8.0] - 2020-06-17
-
 ### Added
 - Add `suggestions`, `correction`, `banners`, and `redirect`.
 

--- a/node/package.json
+++ b/node/package.json
@@ -31,7 +31,7 @@
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.1-beta.0/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.31.1",
+    "@vtex/api": "6.33.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/package.json
+++ b/node/package.json
@@ -31,7 +31,7 @@
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.1-beta.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.1/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -27,6 +27,7 @@ import { resolvers as productSearchResolvers } from './productSearch'
 import { resolvers as recommendationResolvers } from './recommendation'
 import { resolvers as breadcrumbResolvers } from './searchBreadcrumb'
 import { resolvers as skuResolvers } from './sku'
+import { resolvers as skuSpecificationResolver } from './skuSpecification'
 import { resolvers as skuSpecificationFieldResolver } from './skuSpecificationField'
 import { resolvers as skuSpecificationValueResolver } from './skuSpecificationValue'
 import { resolvers as productPriceRangeResolvers } from './productPriceRange'
@@ -140,6 +141,7 @@ export const fieldResolvers = {
   ...productResolvers,
   ...recommendationResolvers,
   ...skuResolvers,
+  ...skuSpecificationResolver,
   ...skuSpecificationFieldResolver,
   ...skuSpecificationValueResolver,
   ...breadcrumbResolvers,

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -27,6 +27,8 @@ import { resolvers as productSearchResolvers } from './productSearch'
 import { resolvers as recommendationResolvers } from './recommendation'
 import { resolvers as breadcrumbResolvers } from './searchBreadcrumb'
 import { resolvers as skuResolvers } from './sku'
+import { resolvers as skuSpecificationFieldResolver } from './skuSpecificationField'
+import { resolvers as skuSpecificationValueResolver } from './skuSpecificationValue'
 import { resolvers as productPriceRangeResolvers } from './productPriceRange'
 import {
   SearchCrossSellingTypes,
@@ -138,6 +140,8 @@ export const fieldResolvers = {
   ...productResolvers,
   ...recommendationResolvers,
   ...skuResolvers,
+  ...skuSpecificationFieldResolver,
+  ...skuSpecificationValueResolver,
   ...breadcrumbResolvers,
   ...productSearchResolvers,
   ...assemblyOptionResolvers,

--- a/node/resolvers/search/skuSpecification.ts
+++ b/node/resolvers/search/skuSpecification.ts
@@ -1,0 +1,11 @@
+export const resolvers = {
+  SkuSpecification: {
+    values: (skuSpecification: SkuSpecification) => {
+      const fieldId = skuSpecification.field.id
+      return skuSpecification.values.map(value => ({
+        ...value,
+        fieldId,
+      }))
+    },
+  },
+}

--- a/node/resolvers/search/skuSpecificationField.ts
+++ b/node/resolvers/search/skuSpecificationField.ts
@@ -1,0 +1,15 @@
+import { addContextToTranslatableString } from '../../utils/i18n'
+
+export const resolvers = {
+  SKUSpecificationField: {
+    name: ( field: SKUSpecificationField, _: any, ctx: Context) => {
+      return addContextToTranslatableString(
+        {
+          content: field.name,
+          context: field.id
+        },
+        ctx
+      )
+    }
+  }
+}

--- a/node/resolvers/search/skuSpecificationValue.ts
+++ b/node/resolvers/search/skuSpecificationValue.ts
@@ -1,0 +1,15 @@
+import { addContextToTranslatableString } from '../../utils/i18n'
+
+export const resolvers = {
+  SKUSpecificationValue: {
+    name: ( value: SKUSpecificationValue, _: any, ctx: Context) => {
+      return addContextToTranslatableString(
+        {
+          content: value.name,
+          context: value.id
+        },
+        ctx
+      )
+    }
+  }
+}

--- a/node/resolvers/search/skuSpecificationValue.ts
+++ b/node/resolvers/search/skuSpecificationValue.ts
@@ -6,7 +6,7 @@ export const resolvers = {
       return addContextToTranslatableString(
         {
           content: value.name,
-          context: value.id
+          context: value.fieldId
         },
         ctx
       )

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -130,6 +130,11 @@ interface SearchItem {
   }[]
 }
 
+interface SkuSpecification {
+  field: SKUSpecificationField,
+  values: SKUSpecificationValue[]
+}
+
 interface SKUSpecificationField {
   name: string,
   id: string
@@ -137,7 +142,8 @@ interface SKUSpecificationField {
 
 interface SKUSpecificationValue {
   name: string,
-  id: string
+  id: string,
+  fieldId: string
 }
 
 interface SearchImage {

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -130,6 +130,16 @@ interface SearchItem {
   }[]
 }
 
+interface SKUSpecificationField {
+  name: string,
+  id: string
+}
+
+interface SKUSpecificationValue {
+  name: string,
+  id: string
+}
+
 interface SearchImage {
   imageId: string
   imageLabel: string | null

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.31.1":
-  version "6.31.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.31.1.tgz#dcb7bddb0b77d6a1ad936da0a6bbc42d577b7883"
-  integrity sha512-KogyA3ZL4behY/8HG7SormxbcOnETJAre6sWkUvSbl1SYLoeL/znvMigzp5812lGDxqjwcIxW6AdFP2Qla+8zw==
+"@vtex/api@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.33.0.tgz#8aca963a8b4a33d06321f8de3f5b224d4eec76ce"
+  integrity sha512-eguTB4WgSJJ+Hi90Uvy8jiu/OtyB6PV4IpixDH6197knFmmaif6L7lf34n8zkJ2sbJLFsYHDbk3WgCU2qNVexA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5417,9 +5417,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.1-beta.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public#b4396a33ed2e02a531350660ded4a8da601adbdb"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.1-beta.0/public#7e3b4d10a84fb6e8f39822654904754cc1c3e5cc"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Makes SKUSpecificationField and SKUSpecificationValue translatable. Without this, the SKU selector is breaking on languages different from the main one.

Depends on https://github.com/vtex-apps/search-graphql/pull/86 We will need to update `package.json` with the correct version of `vtex.search-graphql`

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/classic-shoes/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
