### PR TITLE
add selectedProperties field to the product object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `selectedProperties` to the product object.
+
 ## [1.7.0] - 2020-07-09
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -28,8 +28,16 @@ export const convertBiggyProduct = (
     convertSKU(product, indexingType, tradePolicy)
   )
 
+  const selectedProperties = [
+    {
+      key: product.split.labelKey,
+      value: product.split.labelValue,
+    },
+  ]
+
   const convertedProduct: any = {
     categories,
+    selectedProperties,
     productId: product.id,
     cacheId: `sp-${product.id}`,
     productName: product.name,

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0-beta.1/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0-beta.1/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5155,9 +5155,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0-beta.1/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0-beta.1/public#dc16a8b359ae06f765a653cb654072fe701c5b62"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0/public#bc9a2320b7b6c36fd6c8d2558c25768302281a7e"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5155,9 +5155,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0-beta.1/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.28.0/public#b4396a33ed2e02a531350660ded4a8da601adbdb"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.29.0-beta.1/public#dc16a8b359ae06f765a653cb654072fe701c5b62"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### ⚠️ Depends On
- https://github.com/vtex-apps/search-graphql/pull/87

#### What problem is this solving?

The intelligent search has a feature called split. Basically, instead of showing one product with three possible colors, we show three products, each one with one color.

Before split:
![image](https://user-images.githubusercontent.com/40380674/86956776-06821200-c130-11ea-8534-8824f1c2bd1e.png)
After split:
![image](https://user-images.githubusercontent.com/40380674/86956818-1863b500-c130-11ea-98b5-639ebb4aeaf3.png)


This PR adds a new field called `selectedProperties`. This field has the properties that were selected after the split.

#### How should this be manually tested?

[Workspace](https://hiago--footnotes.myvtex.com/luna%20snake%20flat%20slingback?_q=Luna%20snake%20flat%20slingback&map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->