### PR TITLE
stop doing get for field ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stop doing a get request for every product on properties and specification groups resolvers, use skuSpecifications filed from catalog to get field id.
 
 ## [0.8.4] - 2020-07-09
 ### Fixed

--- a/node/__mocks__/product.ts
+++ b/node/__mocks__/product.ts
@@ -22,6 +22,25 @@ export const getProduct = (customFields = {}) => {
     allSpecifications: ['Numero do calçado'],
     allSpecificationsGroups: ['Tamanho'],
     description: "If you go classic, you can't go wrong.",
+    skuSpecifications: [
+      {
+        field: {
+          id: 10,
+          name: "Numero do calçado",
+          isActive: true,
+          position: 1,
+          type: "Combo",
+        },
+        values: [{
+          id: "190",
+          name: "35",
+        },
+        {
+          id: "191",
+          name: "37",
+        }]
+      }
+    ],
     items: [
       {
         itemId: '35',

--- a/node/resolvers/search/product.test.ts
+++ b/node/resolvers/search/product.test.ts
@@ -202,6 +202,15 @@ describe('tests related to product resolver', () => {
   })
 
   describe('specificationGroups resolver', () => {
+    test('specification groups should not crash if object has no skuSpecifications or property', async () => {
+      const product = getProduct({
+        skuSpecifications: undefined,
+        allSpecifications: undefined,
+        allSpecificationsGroups: undefined
+      })
+      const result = await resolvers.Product.properties(product as any, {}, mockContext as any)
+      expect(result).toMatchObject([])
+    })
     test('specifications groups should have expected format but not translated if same locale as tenant', async () => {
       const product = getProduct()
       const result = await resolvers.Product.specificationGroups(product as any, {}, mockContext as any)
@@ -217,50 +226,80 @@ describe('tests related to product resolver', () => {
     test('specifications groups should have expected format and translated values', async () => {
       mockContext.vtex.locale = 'fr-FR'
       const product = getProduct()
-      mockContext.clients.search.filtersInCategoryFromId.mockImplementationOnce(() => ([{
-        Name: 'Numero do calçado',
-        FieldId: 'specification-Id',
-      }]))
       const result = await resolvers.Product.specificationGroups(product as any, {}, mockContext as any)
 
       expect(result[0]).toMatchObject({
         name: 'Tamanho (((16))) <<<pt-BR>>>',
-        specifications: [{ name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>', values: ["35 (((specification-Id))) <<<pt-BR>>>"] }]
+        specifications: [{ name: 'Numero do calçado (((10))) <<<pt-BR>>>', values: ["35 (((10))) <<<pt-BR>>>"] }]
       })
       expect(result[1]).toMatchObject({
         name: 'allSpecifications (((16))) <<<pt-BR>>>',
-        specifications: [{ name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>', values: ["35 (((specification-Id))) <<<pt-BR>>>"] }]
+        specifications: [{ name: 'Numero do calçado (((10))) <<<pt-BR>>>', values: ["35 (((10))) <<<pt-BR>>>"] }]
       })
     })
   })
 
   describe('properties resolver', () => {
+    test('propertiies resolver should not crash if object has no skuSpecifications or property', async () => {
+      const product = getProduct({
+        skuSpecifications: undefined,
+        allSpecifications: undefined
+      })
+      const result = await resolvers.Product.properties(product as any, {}, mockContext as any)
+      expect(result).toMatchObject([])
+    })
     test('properties should have expected format but not translated if same locale as tenant', async () => {
       const product = getProduct()
       const result = await resolvers.Product.properties(product as any, {}, mockContext as any)
       expect(result).toMatchObject([{ name: 'Numero do calçado', values: ['35'] }])
     })
-    test('specifications groups should have expected format and translated values', async () => {
+    test('properties should have expected format and translated values', async () => {
       mockContext.vtex.locale = 'fr-FR'
       const product = getProduct({
         allSpecifications: ['Numero do calçado', 'testeName'],
-        'testeName': ['teste value']
+        'testeName': ['teste value'],
+        skuSpecifications: [
+          {
+            field: {
+              id: 10,
+              name: "Numero do calçado",
+              isActive: true,
+              position: 1,
+              type: "Combo",
+            },
+            values: [{
+              id: "190",
+              name: "35",
+            },
+            {
+              id: "191",
+              name: "37",
+            }]
+          },
+          {
+            field: {
+              id: 11,
+              name: "testeName",
+              isActive: true,
+              position: 2,
+              type: "Combo",
+            },
+            values: [{
+              id: "200",
+              name: "teste value",
+            },
+            {
+              id: "201",
+              name: "teste value 2",
+            }]
+          }
+        ],
       })
 
-      mockContext.clients.search.filtersInCategoryFromId.mockImplementationOnce(() => ([
-        {
-          Name: 'Numero do calçado',
-          FieldId: 'specification-Id',
-        },
-        {
-          Name: 'testeName',
-          FieldId: 'teste-id'
-        }
-      ]))
       const result = await resolvers.Product.properties(product as any, {}, mockContext as any)
       expect(result).toMatchObject([
-        { name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>', values: ['35 (((specification-Id))) <<<pt-BR>>>'] },
-        { name: 'testeName (((teste-id))) <<<pt-BR>>>', values: ['teste value (((teste-id))) <<<pt-BR>>>'] }
+        { name: 'Numero do calçado (((10))) <<<pt-BR>>>', values: ['35 (((10))) <<<pt-BR>>>'] },
+        { name: 'testeName (((11))) <<<pt-BR>>>', values: ['teste value (((11))) <<<pt-BR>>>'] }
       ])
     })
   })


### PR DESCRIPTION
#### What problem is this solving?

We were doing a get request on catalog for each product to get the field ids for that product. But this is not necessary, they already come in the `skuSpecifications` value.

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
