### PR TITLE
fix null exception in split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Deal with `null` exception in `product.split`.
+
 ## [1.8.0] - 2020-07-09
 ### Added
 - `selectedProperties` to the product object.

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -28,7 +28,7 @@ export const convertBiggyProduct = (
     convertSKU(product, indexingType, tradePolicy)
   )
 
-  const selectedProperties = [
+  const selectedProperties = product.split && [
     {
       key: product.split.labelKey,
       value: product.split.labelValue,


### PR DESCRIPTION
#### What problem is this solving?

The last search-resolver version (1.8.0) has a bug where stores with no split throw null exceptions.
This PR fixes this problem.

#### How should this be manually tested?

[Workspace](https://hiago--alssports.myvtex.com/mouthguards?map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->