### PR TITLE
Bugfix/specification group undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Not treating a possible undefined object coming from product.specificationGroups
+
 ## [1.9.0] - 2020-07-15
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -32,7 +32,7 @@ export const convertBiggyProduct = (
 
   const allSpecifications = product.productSpecifications.concat(getSKUSpecifications(product))
 
-  const specificationGroups = JSON.parse(product.specificationGroups)
+  const specificationGroups = product.specificationGroups ? JSON.parse(product.specificationGroups) : {}
 
   const allSpecificationsGroups = [ ...Object.keys(specificationGroups) ]
 


### PR DESCRIPTION
#### What problem is this solving?

Fixing a case where not updated catalogs could return undefined for the specificationGroup and there was no check to make it become an empty object instead of trying to JSON.parse(undefined)

#### How should this be manually tested?

https://tornai--b2bstore.myvtex.com/Computers/

#### Checklist/Reminders

- [x] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
