### PR TITLE
allow custom order options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Allow custom order options.
+
 ## [1.10.1] - 2020-07-31
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -303,8 +303,10 @@ export const convertOrderBy = (orderBy?: string): string => {
       return 'release:desc'
     case 'OrderByBestDiscountDESC':
       return 'discount:desc'
-    default:
+    case 'OrderByScoreDESC':
       return ''
+    default:
+      return orderBy || ''
   }
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Allow custom order options.
Currently, `search-resolver` returns `''`  when it is a not mapped order option.

#### How should this be manually tested?

[Workspace](https://customorderby--storecomponents.myvtex.com/top?_q=top&map=ft&order=OrderByNameDESC)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
