### PR TITLE
Convert filter to number

### DIFF
--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -25,7 +25,7 @@ export class BiggySearchClient extends ExternalClient {
   }
 
   public async topSearches(): Promise<any> {
-    const result = await this.http.get<any>(`${this.store}/api/top_searches`, {
+    const result = await this.http.get(`${this.store}/api/top_searches`, {
       metric: 'top-searches',
     })
 
@@ -35,7 +35,7 @@ export class BiggySearchClient extends ExternalClient {
   public async suggestionSearches(args: SuggestionSearchesArgs): Promise<any> {
     const { term } = args
 
-    const result = await this.http.get<any>(
+    const result = await this.http.get(
       `${this.store}/api/suggestion_searches`,
       {
         params: {
@@ -72,7 +72,7 @@ export class BiggySearchClient extends ExternalClient {
       })
     }
 
-    const result = await this.http.post<any>(
+    const result = await this.http.post(
       `${this.store}/api/suggestion_products`,
       {
         term,
@@ -214,7 +214,7 @@ export class BiggySearchClient extends ExternalClient {
   }): Promise<any> {
     const { fullText } = args
 
-    const result = await this.http.get<any>(
+    const result = await this.http.get(
       `${this.store}/api/suggestion_searches`,
       {
         params: {

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -255,8 +255,10 @@ export const queries = {
       fullText = await translateToStoreDefaultLanguage(ctx, args.fullText!)
     }
 
-    const { biggySearch, search } = ctx.clients
-    const { segment } = ctx.vtex
+    const {
+      clients: { biggySearch, search },
+      vtex: { segment, account },
+    } = ctx
 
     const biggyArgs = {
       searchState,
@@ -287,7 +289,7 @@ export const queries = {
     }
 
     return {
-      facets: attributesToFilters(result),
+      facets: attributesToFilters({ ...result, account }),
       queryArgs: {
         query: args.query,
         selectedFacets: args.selectedFacets,


### PR DESCRIPTION
#### What problem is this solving?
`localizaseminovos` has a milleage filter that should be displayed with a range, but today we only send price facets with ranges. So we created this workaround specifically for the `localizaseminovos` while we do not support having more facets of type number with range. **this should be removed as soon as possible**

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--localizaseminovos.myvtex.com/hatch?map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![localiza](https://user-images.githubusercontent.com/20840671/88297435-43c0d500-ccd6-11ea-9cf8-d81a769f7d39.gif)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
