### PR TITLE
PER-56: Squash 0.x changes into 1.x branch and fixed SKU variations being undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,113 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Use Elastic instead of SOLR.
 
+## [0.11.0] - 2020-07-31
+
+### Changed
+- Bump `search-graphql` version to `v0.31.0`.
+
+## [0.10.0] - 2020-07-21
+
+### Added
+- `originalName` to `SpecificationGroup`.
+- `originalName` to `SpecificationGroupProperty`.
+- `originalName` to `SKUSpecificationField`.
+- `originalName` to `SKUSpecificationValue`.
+
+## [0.9.0] - 2020-07-09
+
+### Changed
+- Update `vtex.search-graphql` version.
+
+## [0.8.4] - 2020-07-09
+### Fixed
+- Translate variations fields inside the SKU items with id as well.
+
+## [0.8.3] - 2020-07-08
+### Fixed
+- Decode specification names coming from catalog to remove special catalog characters.
+
+## [0.8.2] - 2020-07-07
+### Added
+- Translation to `SKUSpecificationField` and `SKUSpecificationValue`.
+
+## [0.8.1] - 2020-07-07
+
+### Fixed
+- Slugify facet keys before check if it is selected.
+
+## [0.8.0] - 2020-06-17
+### Added
+- Add `suggestions`, `correction`, `banners`, and `redirect`.
+
+## [0.7.3] - 2020-06-10
+### Added
+- Translation of specifications in product.
+
+## [0.7.2] - 2020-06-08
+### Fixed
+- Categories and subcategories not being translated.
+
+## [0.7.1] - 2020-06-03
+### Fixed
+- Error when message had null context for a bad search on catalog.
+
+## [0.7.0] - 2020-06-03
+### Changed
+- Many changes to support multiple bindings stores with different locales.
+
+## [0.6.3] - 2020-06-02
+
+### Added
+- Bump graphql version.
+
+## [0.6.2] - 2020-05-13
+### Changed
+- Add error log if search item has non iterable sellers.
+
+## [0.6.1] - 2020-05-12
+### Changed
+- Call the new catalog-api-proxy endpoint for authenticaded searches (B2B).
+
+## [0.6.0] - 2020-05-07
+
+## [0.5.0] - 2020-05-07
+### Added
+- `taxPercentage` resolver on `Offer`.
+
+## [0.4.0] - 2020-05-05
+### Changed
+- Remove new urls logic
+
+## [0.3.7] - 2020-05-05
+### Fixed
+- Adds context to brand translatable fields
+- Adds context translation to category translatable fields
+
+## [0.3.6] - 2020-05-05
+### Fixed
+- Adds context translation to sku translatable fields
+
+## [0.3.5] - 2020-05-04
+### Fixed
+- Fixes `rawMessage.match is not a function`
+
+## [0.3.4] - 2020-05-04
+### Fixed
+- Fixes the error: Cannot read property 'toString' of null
+
+## [0.3.3] - 2020-05-04
+### Fixed
+- Uses locale from tenant instead of binding in strings translations
+
+## [0.3.2] - 2020-04-29
+### Changed
+- Stop writing search stats to VBase.
+
+## [0.3.1] - 2020-04-22
+### Fixed
+- `titleTag` returning `null` when the `productName` was `null`.
+
 ## [0.3.0] - 2020-04-20
 ### Added
 - migrate search-graphql code to search-resolver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Relevant commits from the `0.x` branch.
+
+### Fixed
+
+- SKU variations being `undefined`.
+
 ## [1.13.1] - 2020-08-05
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,7 @@
     "vtex.messages": "1.x",
     "vtex.catalog-api-proxy": "0.x",
     "vtex.search-graphql": "0.x",
+    "vtex.rewriter": "1.x",
     "vtex.sae-analytics": "2.x"
   },
   "policies": [
@@ -21,6 +22,12 @@
     },
     {
       "name": "vtex.catalog-api-proxy:catalog-proxy"
+    },
+    {
+      "name": "vtex.catalog-api-proxy:authenticated-catalog-proxy"
+    },
+    {
+      "name": "vtex.rewriter:resolve-graphql"
     },
     {
       "name": "vbase-read-write"

--- a/node/__mocks__/helpers.ts
+++ b/node/__mocks__/helpers.ts
@@ -14,9 +14,11 @@ const searchClientMock = {
   ),
   category: jest.fn(),
   categories: jest.fn(),
-  crossSelling: jest.fn(),    
+  crossSelling: jest.fn(),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  productById: jest.fn((_id: string, _cacheable: boolean = true) => promisify(null))
+  productById: jest.fn((_id: string, _cacheable: boolean = true) => promisify(null)),
+  productsRaw: jest.fn(() => ({ data: [] })),
+  filtersInCategoryFromId: jest.fn(),
 }
 
 const messagesGraphQLClientMock = {
@@ -34,16 +36,43 @@ const segmentClientMock = {
     }),
 }
 
-export const mockContext = {
+export const getBindingLocale = () => mockContext.vtex.binding.locale
+
+const rewriterClientMock: any = {
+  getRoute: jest.fn((id: string, type: string, bindingId: string) => promisify(`${id}-${type}-${bindingId}-${getBindingLocale()}`))
+}
+
+const getLocale = () => mockContext.vtex.locale
+const getTenantLocale = () => mockContext.vtex.tenant.locale
+
+const initialCtxState = {
+  account: 'storecomponents',
+  platform: 'vtex',
+  locale: 'pt-BR',
+  tenant: { locale: 'pt-BR' },
+  binding: { id: 'abc', locale: 'pt-BR' }
+}
+
+const generateDeepCopy = (obj: any) => JSON.parse(JSON.stringify(obj))
+
+export const mockContext: any = {
   vtex: {
-    account: 'storecomponents',
-    platform: 'vtex',
-    locale: 'pt-BR',
-    tenant: { locale: 'pt-BR' },
+    ...generateDeepCopy(initialCtxState),
   },
   clients: {
     search: searchClientMock,
     segment: segmentClientMock,
     messagesGraphQL: messagesGraphQLClientMock,
+    rewriter: rewriterClientMock,
+  },
+  state: {
+    messagesBindingLanguage: {
+      loadMany: jest.fn((messages: any) => messages.map((message: any) => `${message.content}-${getLocale()}`))
+    },
+    messagesTenantLanguage: {
+      load: jest.fn((message: any) => `${message.content}-${getTenantLocale()}`)
+    }
   },
 }
+
+export const resetContext = () => {mockContext.vtex = { ...generateDeepCopy(initialCtxState) }}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -2,6 +2,7 @@ import { IOClients } from '@vtex/api'
 
 import { Search } from './search'
 import { Checkout } from './checkout'
+import { Rewriter } from './rewriter'
 import { BiggySearchClient } from './biggy-search'
 
 export class Clients extends IOClients {
@@ -10,6 +11,9 @@ export class Clients extends IOClients {
   }
   public get checkout() {
     return this.getOrSet('checkout', Checkout)
+  }
+  public get rewriter() {
+    return this.getOrSet('rewriter', Rewriter)
   }
   public get biggySearch() {
     return this.getOrSet('biggySearch', BiggySearchClient)

--- a/node/clients/rewriter.ts
+++ b/node/clients/rewriter.ts
@@ -1,0 +1,68 @@
+import { AppGraphQLClient, IOContext, InstanceOptions, GraphQLResponse, Serializable } from "@vtex/api"
+
+const getRouteQuery = `query GetRoute($id: String!, $type: String!) {
+  internal {
+    routes(locator: {id:$id, type:$type}) {
+      route
+      binding
+    }
+  }
+}
+`
+
+interface Route {
+  route: string
+  binding: string
+}
+
+interface GetRoutesResponse {
+  internal: {
+    routes: Route[]
+  }
+}
+
+class CustomGraphQLError extends Error {
+  public graphQLErrors: any
+
+  constructor(message: string, graphQLErrors: any[]) {
+    super(message)
+    this.graphQLErrors = graphQLErrors
+  }
+}
+export function throwOnGraphQLErrors<T extends Serializable>(message: string) {
+  return function maybeGraphQLResponse(response: GraphQLResponse<T>) {
+    if (response && response.errors && response.errors.length > 0) {
+      throw new CustomGraphQLError(message, response.errors)
+    }
+
+    return response
+  }
+}
+
+export class Rewriter extends AppGraphQLClient {
+  public constructor(context: IOContext, options?: InstanceOptions) {
+    super('vtex.rewriter@1.x', context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+      }
+    })
+  }
+
+  public getRoute = async (id: string, type: string, bindingId: string) => {
+    const data = await this.graphql.query<GetRoutesResponse, { id: string, type: string }>({
+      query: getRouteQuery,
+      variables: { id, type },
+    },
+      {
+        metric: 'search-get-route'
+      }
+    )
+      .then(throwOnGraphQLErrors('Error getting route data from vtex.rewriter'))
+      .then(data => {
+        return data.data!.internal.routes
+      })
+
+    return data.find(route => route.binding === bindingId)?.route
+  }
+}

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -101,7 +101,6 @@ export const convertBiggyProduct = (
   return convertedProduct
 }
 
-
 const getVariations = (sku: BiggySearchSKU): string[] => {
   return sku.attributes.map((attribute) => attribute.key)
 }
@@ -262,13 +261,9 @@ const convertSKU = (
   }
 
   variations.forEach((variation) => {
-    const attributes = product.textAttributes.filter((attribute) => attribute.labelKey == variation)
-    if (attributes != null && attributes.length > 0) {
-      item[variation] = []
-
-      attributes.forEach((attribute) => {
-        item[variation].push(attribute.labelValue)
-      })
+    const attribute = sku.attributes.find((attribute) => attribute.key == variation)
+    if (attribute != null) {
+      item[variation] = [attribute.value]
     }
   })
 

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -59,7 +59,7 @@ export const convertBiggyProduct = (
     description: product.description,
     items: skus,
     allSpecifications,
-    categoryId: "",
+    categoryId: product.categoryIds?.[0],
     productTitle: "",
     metaTagDescription: "",
     clusterHighlights: {},

--- a/node/commons/products.ts
+++ b/node/commons/products.ts
@@ -9,8 +9,8 @@ export const productsBiggy = async (searchResult: any, ctx: any) => {
   searchResult.products.forEach((product: any) => {
     try {
       products.push(convertBiggyProduct(product, segment && segment.channel))
-    } catch (e) {
-      // TODO: add logging
+    } catch (err) {
+      console.error(err)
     }
   })
 

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -19,7 +19,8 @@ declare global {
   type Context = ServiceContext<Clients, State, CustomContext>
 
   interface State extends RecorderState {
-    messages?: MessagesLoaderV2
+    messagesTenantLanguage?: MessagesLoaderV2
+    messagesBindingLanguage?: MessagesLoaderV2
   }
 
   interface StaleRevalidateData<T>{

--- a/node/resolvers/search/brand.ts
+++ b/node/resolvers/search/brand.ts
@@ -1,11 +1,24 @@
 import { prop } from 'ramda'
 
+import { formatTranslatableProp } from '../../utils/i18n'
 import { searchSlugify } from '../../utils/slug'
 
 export const resolvers = {
   Brand: {
+    name: formatTranslatableProp<Brand, 'name', 'id'>(
+      'name',
+      'id'
+    ),
 
-    titleTag: prop('title'),
+    titleTag: formatTranslatableProp<Brand, 'title', 'id'>(
+      'title',
+      'id'
+    ),
+
+    metaTagDescription: formatTranslatableProp<Brand, 'metaTagDescription', 'id'>(
+      'metaTagDescription',
+      'id'
+    ),
 
     active: prop('isActive'),
 

--- a/node/resolvers/search/category.ts
+++ b/node/resolvers/search/category.ts
@@ -1,6 +1,7 @@
 import { compose, last, prop, split } from 'ramda'
 
 import { getCategoryInfo } from './utils'
+import { formatTranslatableProp, shouldTranslateToBinding } from '../../utils/i18n'
 
 const lastSegment = compose<string, string[], string>(
   last,
@@ -19,17 +20,40 @@ type SafeCategory = CategoryByIdResponse | CategoryTreeResponse
 
 export const resolvers = {
   Category: {
+    name: formatTranslatableProp<SafeCategory, 'name', 'id'>(
+      'name',
+      'id'
+    ),
+
     cacheId: prop('id'),
 
-    href: async ({ url }: SafeCategory) => {
+    href: async ({ url, id }: SafeCategory, _: unknown, ctx: Context) => {
+      if (shouldTranslateToBinding(ctx)) {
+        const rewriterUrl = await ctx.clients.rewriter.getRoute(id.toString(), 'anyCategoryEntity', ctx.vtex.binding!.id!)
+        if (rewriterUrl) {
+          url = rewriterUrl
+        }
+      }
       return cleanUrl(url)
     },
 
-    metaTagDescription: prop('MetaTagDescription'),
+    metaTagDescription: formatTranslatableProp<SafeCategory, 'MetaTagDescription', 'id'>(
+      'MetaTagDescription',
+      'id'
+    ),
 
-    titleTag: prop('Title'),
+    titleTag: formatTranslatableProp<SafeCategory, 'Title', 'id'>(
+      'Title',
+      'id'
+    ),
 
-    slug: async ({ url }: SafeCategory) => {
+    slug: async ({ url, id }: SafeCategory, _: unknown, ctx: Context) => {
+      if (shouldTranslateToBinding(ctx)) {
+        const rewriterUrl = await ctx.clients.rewriter.getRoute(id.toString(), 'anyCategoryEntity', ctx.vtex.binding!.id!)
+        if (rewriterUrl) {
+          url = rewriterUrl
+        }
+      }
       return url ? lastSegment(url) : null
     },
 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -23,7 +23,11 @@ import {
   getMapAndPriceRangeFromSelectedFacets,
 } from './utils'
 import { toCompatibilityArgs } from './newURLs'
-import { PATH_SEPARATOR, MAP_VALUES_SEP } from './constants'
+import {
+  PATH_SEPARATOR,
+  MAP_VALUES_SEP,
+} from './constants'
+import { shouldTranslateToTenantLocale } from '../../utils/i18n'
 import {
   buildAttributePath,
   convertOrderBy,
@@ -125,7 +129,7 @@ const getCompatibilityArgsFromSelectedFacets = async (
 
 const translateToStoreDefaultLanguage = async (
   ctx: Context,
-  term: string
+  term: string,
 ): Promise<string> => {
   const {
     clients,
@@ -134,21 +138,22 @@ const translateToStoreDefaultLanguage = async (
   } = ctx
   const { locale: to } = tenant!
 
-  if (!from || from === to) {
+  if (!shouldTranslateToTenantLocale(ctx)) {
+    // Do not translate if string already in correct language
     return term
   }
 
-  if (!state.messages) {
-    state.messages = createMessagesLoader(clients, to)
+  if (!state.messagesTenantLanguage) {
+    state.messagesTenantLanguage = createMessagesLoader(clients, to)
   }
 
-  return state.messages!.load({
-    from,
+  return state.messagesTenantLanguage!.load({
+    from: from!,
     content: term,
   })
 }
 
-const noop = () => {}
+const noop = () => { }
 
 // Does prefetching and warms up cache for up to the 10 first elements of a search, so if user clicks on product page
 const searchFirstElements = (
@@ -217,6 +222,21 @@ const isLegacySearchFormat = ({
 const isValidProductIdentifier = (identifier: ProductIndentifier | undefined) =>
   !!identifier && !isNil(identifier.value) && !isEmpty(identifier.value)
 
+const getTranslatedSearchTerm = async (query: SearchArgs['query'], map: SearchArgs['map'], ctx: Context) => {
+  if (!query || !map || !shouldTranslateToTenantLocale(ctx)) {
+    return query
+  }
+  const ftSearchIndex = map.split(',').findIndex(m => m === 'ft')
+  if (ftSearchIndex === -1) {
+    return query
+  }
+  const queryArray = query.split('/')
+  const queryUnit = queryArray[ftSearchIndex]
+  const translated = await translateToStoreDefaultLanguage(ctx, queryUnit)
+  const queryTranslated = [...queryArray.slice(0, ftSearchIndex), translated, ...queryArray.slice(ftSearchIndex + 1)]
+  return queryTranslated.join('/')
+}
+
 export const queries = {
   autocomplete: async (
     _: any,
@@ -230,6 +250,7 @@ export const queries = {
     if (!args.searchTerm) {
       throw new UserInputError('No search term provided')
     }
+
     const translatedTerm = await translateToStoreDefaultLanguage(
       ctx,
       args.searchTerm
@@ -497,7 +518,7 @@ export const queries = {
       args.map = map
     }
 
-    const query = await translateToStoreDefaultLanguage(ctx, args.query || '')
+    const query = await getTranslatedSearchTerm(args.query || '', args.map || '', ctx)
     const translatedArgs = {
       ...args,
       query,

--- a/node/resolvers/search/modules/metadata.ts
+++ b/node/resolvers/search/modules/metadata.ts
@@ -8,7 +8,6 @@ import {
   map,
   filter,
   findLastIndex,
-  path,
   split,
   toLower,
   reverse,
@@ -17,8 +16,9 @@ import {
 } from 'ramda'
 import { Functions } from '@gocommerce/utils'
 
-import { zipQueryAndMap, findCategoryInTree, getBrandFromSlug } from '../utils'
+import { zipQueryAndMap, findCategoryInTree, getBrandFromSlug, searchDecodeURI } from '../utils'
 import { toTitleCase } from '../../../utils/string'
+import { formatTranslatableProp, translateManyToCurrentLanguage, Message, shouldTranslateToUserLocale } from '../../../utils/i18n'
 
 type TupleString = [string, string]
 
@@ -48,6 +48,7 @@ const getAndParsePagetype = async (path: string, ctx: Context) => {
   return {
     titleTag: pagetype.title || pagetype.name,
     metaTagDescription: pagetype.metaTagDescription,
+    id: pagetype.id,
   }
 }
 
@@ -68,10 +69,11 @@ const getCategoryMetadata = async (
       findCategoryInTree(
         await search.categories(cleanQuery.split('/').length),
         cleanQuery.split('/')
-      ) || {}
+      )
     return {
-      metaTagDescription: path(['MetaTagDescription'], category),
-      titleTag: path(['Title'], category) || path(['Name'], category),
+      id: null,
+      metaTagDescription: category?.MetaTagDescription,
+      titleTag: category?.Title ?? category?.name,
     }
   }
 
@@ -89,17 +91,18 @@ const getBrandMetadata = async (
   const cleanQuery = head(split('/', query || '')) || ''
 
   if (Functions.isGoCommerceAcc(account)) {
-    const brand = (await getBrandFromSlug(toLower(cleanQuery), search)) || {}
+    const brand = await getBrandFromSlug(toLower(cleanQuery), search)
     return {
-      metaTagDescription: path(['metaTagDescription'], brand),
-      titleTag: path(['title'], brand) || path(['name'], brand),
+      id: null,
+      metaTagDescription: brand?.metaTagDescription,
+      titleTag: brand?.title ?? brand?.name,
     }
   }
   return getAndParsePagetype(cleanQuery, ctx)
 }
 
 export const getSpecificationFilterName = (name: string) => {
-  return toTitleCase(decodeURI(name))
+  return toTitleCase(searchDecodeURI(decodeURI(name)))
 }
 
 const getPrimaryMetadata = (
@@ -153,7 +156,7 @@ const getNameForRemainingMaps = async (
         }
       }
       if (map === 'b' && !isGC) {
-        const brand = await search.pageType(decodeURI(query)).catch(() => null)
+        const brand = await search.pageType(decodeURI(query), 'map=b').catch(() => null)
         if (brand) {
           return brand.name
         }
@@ -174,12 +177,23 @@ export const emptyTitleTag = {
 
 type StringNull = string | null | undefined
 
+const removeNulls = <T>(array: (T | null | undefined)[]): T[] => array.filter(Boolean) as T[]
+
 const isNotNil = complement(isNil)
 const joinNames = compose<StringNull[], string[], string[], string>(
   join(' - '),
   reverse,
   filter(isNotNil) as any
 )
+
+const translateTitles = (metadata: SearchMetadata, otherNames: (string | null)[], ctx: Context) => {
+  const messages: Message[] = []
+  if (metadata.titleTag) {
+    messages.push({ content: metadata.titleTag, context: metadata.id ?? undefined })
+  }
+  messages.push(...removeNulls(otherNames).map(name => ({ content: name })))
+  return translateManyToCurrentLanguage(messages, ctx)
+}
 
 /**
  * Get metadata of category/brand APIs
@@ -212,8 +226,12 @@ export const getSearchMetaData = async (
     getNameForRemainingMaps(validTuples, ctx),
   ])
 
+  const titleTagNames =
+    shouldTranslateToUserLocale(ctx) ?
+      (await translateTitles(metadata, otherNames, ctx))
+      : [metadata.titleTag, ...otherNames]
   return {
-    titleTag: joinNames([metadata.titleTag, ...otherNames]),
-    metaTagDescription: metadata.metaTagDescription,
+    titleTag: joinNames(titleTagNames),
+    metaTagDescription: formatTranslatableProp<SearchMetadata, 'metaTagDescription', 'id'>('metaTagDescription', 'id')(metadata, {}, ctx),
   }
 }

--- a/node/resolvers/search/productSearch.ts
+++ b/node/resolvers/search/productSearch.ts
@@ -1,7 +1,8 @@
 import { path } from 'ramda'
 import { IOResponse } from '@vtex/api'
 import { Functions } from '@gocommerce/utils'
-import { zipQueryAndMap } from './utils'
+import { zipQueryAndMap, breadcrumbMapKey } from './utils'
+import { shouldTranslateToBinding } from '../../utils/i18n'
 
 interface ProductSearchParent {
   productsRaw: IOResponse<SearchProduct[]>
@@ -10,6 +11,76 @@ interface ProductSearchParent {
     titleTag: string | null
     metaTagDescription: string | null
   }
+}
+
+interface Metadata {
+  id: string
+  name: string
+}
+
+const getTypeForCategory = (index: number) => {
+  if (index === 0) {
+    return 'department'
+  }
+  if (index === 1) {
+    return 'category'
+  }
+  return 'subcategory'
+}
+
+const getRouteForQueryUnit = async (queryUnit: string, mapUnit: string, categoriesSearched: string[], index: number, ctx: Context) => {
+  const bindingId = ctx.vtex.binding!.id!
+  const key = `${queryUnit}-${mapUnit}`
+  if (mapUnit === 'b') {
+    const brandPageType = await ctx.clients.search.pageType(queryUnit, 'map=b')
+
+    if (index === 0) {
+      // if it is a brand page, we should check if there is a route on rewriter for this brand
+      const brandFromRewriter = await ctx.clients.rewriter.getRoute(brandPageType.id, 'brand', bindingId)
+      if (brandFromRewriter) {
+        return { path: brandFromRewriter, key, name: brandPageType.name, id: brandPageType.id }
+      }
+    }
+    return { path: queryUnit, key, name: brandPageType.name, id: brandPageType.id }
+  }
+  if (mapUnit === 'c') {
+    const categoryPosition = categoriesSearched.findIndex(cat => cat === queryUnit)
+    const category = await ctx.clients.search.pageType(categoriesSearched.slice(0, categoryPosition + 1).join('/'))
+    const route = await ctx.clients.rewriter.getRoute(category.id, getTypeForCategory(categoryPosition), bindingId)
+    return { path: route ?? queryUnit, key, name: category.name, id: category.id }
+  }
+  return { path: queryUnit, key, name: null, id: null }
+}
+
+const breadcrumbDataWithBinding = async (queryAndMap: [string, string][], categoriesSearched: string[], mapArray: string[], ctx: Context) => {
+  const queryTranslationsAndKeys = await Promise.all(queryAndMap.map(([queryUnit, mapUnit], index) => {
+    return getRouteForQueryUnit(queryUnit, mapUnit, categoriesSearched, index, ctx)
+  }))
+  const queryTranslations = queryTranslationsAndKeys.reduce((acc, curr) => {
+    acc[curr.key] = curr.path
+    return acc
+  }, {} as Record<string, string>)
+
+  const metadataMap = queryTranslationsAndKeys.filter(({ name }) => Boolean(name)).reduce((acc, curr) => {
+    acc[curr.key] = { name: curr.name!, id: curr.id! }
+    return acc
+  }, {} as Record<string, Metadata>)
+
+  const indexFirstCategory = mapArray.findIndex(m => m === 'c')
+  const hrefs = queryAndMap.reduce((acc, curr) => {
+    const [queryUnit, mapUnit] = curr
+    const slug = mapUnit === 'c' || mapUnit === 'b' ? queryTranslations[breadcrumbMapKey(queryUnit, mapUnit)] : queryUnit
+    let prefix = acc.length > 0 ? acc[acc.length - 1] : ''
+    if (mapUnit === 'c') {
+      prefix = indexFirstCategory > 0 ? acc[indexFirstCategory - 1] : ''
+    }
+    const noSlashSlug = slug.startsWith('/') ? slug.slice(1) : slug
+    const url = `${prefix}/${noSlashSlug}`
+    acc.push(url)
+    return acc
+  }, [] as string[])
+
+  return { hrefs, metadataMap }
 }
 
 export const resolvers = {
@@ -23,12 +94,33 @@ export const resolvers = {
       const quantity = resources.split('/')[1]
       return parseInt(quantity, 10)
     },
-    products: path(['productsRaw', 'data']),
+    products: ({ productsRaw }: ProductSearchParent, _: any, ctx: Context) => {
+      let hasBroken = false
+      for (const product of productsRaw.data) {
+        for (const item of product.items) {
+          if (item.sellers == null) {
+            const config: any = (productsRaw as any).config
+            ctx.vtex.logger.error({
+              message: 'Item missing sellers!',
+              searchUrl: config.url.replace(/\/proxy\/authenticated\/catalog|\/proxy\/catalog/, ''),
+              params: JSON.stringify(config.params)
+            })
+            hasBroken = true
+            break
+          }
+        }
+        if (hasBroken) {
+          break
+        }
+      }
+      return productsRaw.data
+    },
     breadcrumb: async (
       { translatedArgs, productsRaw: { data: products } }: ProductSearchParent,
       _: any,
-      { vtex: { account }, clients: { search } }: Context
+      ctx: Context
     ) => {
+      const { vtex: { account }, clients: { search } } = ctx
       const query = translatedArgs?.query || ''
       const map = translatedArgs?.map || ''
       const queryAndMap = zipQueryAndMap(
@@ -38,6 +130,7 @@ export const resolvers = {
       const categoriesSearched = queryAndMap
         .filter(([_, m]) => m === 'c')
         .map(([q]) => q)
+
       const categoriesCount = map.split(',').filter(m => m === 'c').length
       const categories =
         !!categoriesCount && Functions.isGoCommerceAcc(account)
@@ -46,6 +139,12 @@ export const resolvers = {
 
       const queryArray = query.split('/')
       const mapArray = map.split(',')
+
+      const { metadataMap, hrefs } =
+        shouldTranslateToBinding(ctx) ?
+          await breadcrumbDataWithBinding(queryAndMap, categoriesSearched, mapArray, ctx)
+          : { metadataMap: {}, hrefs: null }
+
       return queryAndMap.map(
         ([queryUnit, mapUnit]: [string, string], index: number) => ({
           queryUnit,
@@ -56,6 +155,8 @@ export const resolvers = {
           categories,
           categoriesSearched,
           products,
+          metadataMap,
+          hrefs
         })
       )
     },

--- a/node/resolvers/search/searchBreadcrumb.test.ts
+++ b/node/resolvers/search/searchBreadcrumb.test.ts
@@ -1,0 +1,417 @@
+import { resolvers } from './searchBreadcrumb'
+import { mockContext, resetContext } from '../../__mocks__/helpers'
+import { getProduct } from '../../__mocks__/product'
+
+describe('tests related to the name resolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetContext()
+  })
+
+  test('get name for category', async () => {
+    const payload = {
+      queryUnit: 'category',
+      mapUnit: 'c',
+      index: 0,
+      queryArray: ['category'],
+      mapArray: ['c'],
+      categories: [],
+      categoriesSearched: ['category'],
+      products: {},
+      metadataMap: {},
+      hrefs: null,
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('category (((1))) <<<pt-BR>>>')
+  })
+
+  test('get name for category from metadata map', async () => {
+    const payload = {
+      queryUnit: 'category',
+      mapUnit: 'c',
+      index: 0,
+      queryArray: ['category'],
+      mapArray: ['c'],
+      categories: [],
+      categoriesSearched: ['category'],
+      products: {},
+      metadataMap: {
+        ['category-c']: { name: 'category', id: 'id' }
+      },
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('category (((id))) <<<pt-BR>>>')
+  })
+
+  test('get name for brand', async () => {
+    const payload = {
+      queryUnit: 'brand',
+      mapUnit: 'b',
+      index: 0,
+      queryArray: ['brand'],
+      mapArray: ['b'],
+      categories: [],
+      categoriesSearched: ['brand'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('brand (((1))) <<<pt-BR>>>')
+  })
+
+  test('get name for brand from metadata map', async () => {
+    const payload = {
+      queryUnit: 'brand',
+      mapUnit: 'b',
+      index: 0,
+      queryArray: ['brand'],
+      mapArray: ['b'],
+      categories: [],
+      categoriesSearched: ['brand'],
+      products: {},
+      metadataMap: {
+        ['brand-b']: { name: 'brand', id: 'id' },
+      },
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('brand (((id))) <<<pt-BR>>>')
+  })
+
+  test('get name for subcategory', async () => {
+    const payload = {
+      queryUnit: 'category2',
+      mapUnit: 'c',
+      index: 1,
+      queryArray: ['category', 'category2'],
+      mapArray: ['c', 'c'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('category/category2 (((1))) <<<pt-BR>>>')
+  })
+
+  test('get name for subcategory from metadata map', async () => {
+    const payload = {
+      queryUnit: 'category2',
+      mapUnit: 'c',
+      index: 1,
+      queryArray: ['category', 'category2'],
+      mapArray: ['c', 'c'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      metadataMap: {
+        ['category-c']: { name: 'category', id: 'id' },
+        ['category2-c']: { name: 'category2', id: 'id2' },
+      },
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('category2 (((id2))) <<<pt-BR>>>')
+  })
+
+  test('get name for subcategory in query with many facets', async () => {
+    const payload = {
+      queryUnit: 'category2',
+      mapUnit: 'c',
+      index: 1,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('category/category2 (((1))) <<<pt-BR>>>')
+  })
+
+  test('get name for subcategory in query with many facets in metadata map', async () => {
+    const payload = {
+      queryUnit: 'category2',
+      mapUnit: 'c',
+      index: 1,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {
+        ['category-c']: { name: 'category', id: 'id' },
+        ['category2-c']: { name: 'category2', id: 'id2' },
+        ['brand-b']: { name: 'brand', id: 'id' }
+      },
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('category2 (((id2))) <<<pt-BR>>>')
+  })
+
+  test('get name for filter', async () => {
+    const payload = {
+      queryUnit: 'filter',
+      mapUnit: 'specificationFilter_100',
+      index: 3,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('Filter')
+  })
+
+  test('get name for brand as filter', async () => {
+    const payload = {
+      queryUnit: 'brand',
+      mapUnit: 'b',
+      index: 2,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('brand (((1))) <<<pt-BR>>>')
+  })
+
+  test('get name for productClusterIds as filter', async () => {
+    const product = getProduct({
+      productClusters: {
+        '140': 'Cool Cluster',
+      }
+    })
+
+    const payload = {
+      queryUnit: '140',
+      mapUnit: 'productClusterIds',
+      index: 0,
+      queryArray: ['140', 'filter'],
+      mapArray: ['productClusterIds', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: [],
+      products: [product],
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('Cool Cluster')
+  })
+
+  test('if productsClusterIds not found, fail gracefully', async () => {
+    const product = getProduct({
+      productClusters: {
+        '141': 'Cool Cluster',
+      }
+    })
+
+    const payload = {
+      queryUnit: '140',
+      mapUnit: 'productClusterIds',
+      index: 0,
+      queryArray: ['140', 'filter'],
+      mapArray: ['productClusterIds', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: [],
+      products: [product],
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe(payload.queryUnit)
+  })
+
+  test('get name for sellerIds as filter', async () => {
+    const product = getProduct({
+      productClusters: {
+        '140': 'Cool Cluster',
+      }
+    })
+
+    const payload = {
+      queryUnit: '1',
+      mapUnit: 'sellerIds',
+      index: 0,
+      queryArray: ['1', 'filter'],
+      mapArray: ['sellerIds', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: [],
+      products: [product],
+      metadataMap: {},
+    }
+    const result = await resolvers.SearchBreadcrumb.name(payload as any, {}, mockContext as any)
+    expect(result).toBe('VTEX')
+  })
+})
+
+describe('tests related to the href resolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetContext()
+  })
+
+  test('get href for department', () => {
+    const payload = {
+      queryUnit: 'category',
+      mapUnit: 'c',
+      index: 0,
+      queryArray: ['category'],
+      mapArray: ['c'],
+      categories: [],
+      categoriesSearched: ['category'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe('/category')
+  })
+
+  test('get href for category', () => {
+    const payload = {
+      queryUnit: 'category2',
+      mapUnit: 'c',
+      index: 1,
+      queryArray: ['category', 'category2'],
+      mapArray: ['c', 'c'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe('/category/category2')
+  })
+
+  test('get href for brand', () => {
+    const payload = {
+      queryUnit: 'brand',
+      mapUnit: 'b',
+      index: 0,
+      queryArray: ['brand'],
+      mapArray: ['b'],
+      categories: [],
+      categoriesSearched: [],
+      products: {},
+      metadataMap: {},
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe('/brand')
+  })
+
+  test('get href for category with brand', () => {
+    const payload = {
+      queryUnit: 'brand',
+      mapUnit: 'b',
+      index: 1,
+      queryArray: ['category', 'brand'],
+      mapArray: ['c', 'b'],
+      categories: [],
+      categoriesSearched: ['category'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe('/category/brand?map=c,b')
+  })
+
+  test('get href for category and other filters', () => {
+    const payload = {
+      queryUnit: 'filter',
+      mapUnit: 'specificationFilter_100',
+      index: 3,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe('/category/category2/brand/filter?map=c,c,b,specificationFilter_100')
+  })
+
+  test('index arg will be respected always', () => {
+    const payload = {
+      queryUnit: 'brand',
+      mapUnit: 'b',
+      index: 2,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe('/category/category2/brand?map=c,c,b')
+  })
+
+  test('use hrefs args if available - department', () => {
+    const payload = {
+      queryUnit: 'category',
+      mapUnit: 'c',
+      index: 0,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+      hrefs: ['/category', '/category/category2', 'category/category2/brand', 'category/category2/brand/filter']
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe(payload.hrefs[0])
+  })
+  test('use hrefs args if available - category', () => {
+    const payload = {
+      queryUnit: 'category2',
+      mapUnit: 'c',
+      index: 1,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+      hrefs: ['/category', '/category/category2', 'category/category2/brand', 'category/category2/brand/filter']
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe(payload.hrefs[1])
+  })
+
+  test('use hrefs args if available - full href', () => {
+    const payload = {
+      queryUnit: 'filter',
+      mapUnit: 'specificationFilter_100',
+      index: 3,
+      queryArray: ['category', 'category2', 'brand', 'filter'],
+      mapArray: ['c', 'c', 'b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+      hrefs: ['/category', '/category/category2', 'category/category2/brand', 'category/category2/brand/filter']
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe(payload.hrefs[3] + '?map=c,c,b,specificationFilter_100')
+  })
+
+  test('use hrefs args if available - brand', () => {
+    const payload = {
+      queryUnit: 'brand',
+      mapUnit: 'b',
+      index: 0,
+      queryArray: ['brand', 'filter'],
+      mapArray: ['b', 'specificationFilter_100'],
+      categories: [],
+      categoriesSearched: ['category', 'category2'],
+      products: {},
+      metadataMap: {},
+      hrefs: ['brand', 'brand/filter']
+    }
+    const result = resolvers.SearchBreadcrumb.href(payload as any)
+    expect(result).toBe(payload.hrefs[0])
+  })
+})

--- a/node/resolvers/search/searchBreadcrumb.ts
+++ b/node/resolvers/search/searchBreadcrumb.ts
@@ -1,8 +1,9 @@
 import { Functions } from '@gocommerce/utils'
 import { equals, includes, toLower } from 'ramda'
 
+import { formatTranslatableProp } from '../../utils/i18n'
 import { getSpecificationFilterName } from './modules/metadata'
-import { findCategoryInTree, getBrandFromSlug } from './utils'
+import { findCategoryInTree, getBrandFromSlug, breadcrumbMapKey } from './utils'
 
 interface BreadcrumbParams {
   queryUnit: string
@@ -13,6 +14,8 @@ interface BreadcrumbParams {
   categories: CategoryTreeResponse[]
   categoriesSearched: string[]
   products: SearchProduct[]
+  hrefs: string[] | null
+  metadataMap: Record<string, { id: string, name: string }>
 }
 
 const findClusterNameFromId = (
@@ -77,13 +80,18 @@ const getBrandInfo = async (
   return search.pageType(queryUnit).catch(() => null)
 }
 
+interface TranslatableData {
+  id?: string
+  name: string
+}
+
 export const resolvers = {
   SearchBreadcrumb: {
     name: async (obj: BreadcrumbParams, _: any, ctx: Context) => {
       const {
         vtex: { account },
       } = ctx
-      const { queryUnit, mapUnit, index, queryArray, products } = obj
+      const { queryUnit, mapUnit, index, queryArray, products, metadataMap } = obj
       const defaultName = queryArray[index]
       const isVtex = !Functions.isGoCommerceAcc(account)
       if (isProductClusterMap(mapUnit)) {
@@ -93,9 +101,9 @@ export const resolvers = {
         }
       }
       if (isCategoryMap(mapUnit)) {
-        const categoryData = await getCategoryInfo(obj, isVtex, ctx)
+        const categoryData = (metadataMap[breadcrumbMapKey(queryUnit, mapUnit)] ?? (await getCategoryInfo(obj, isVtex, ctx))) as TranslatableData
         if (categoryData) {
-          return categoryData.name
+          return formatTranslatableProp<TranslatableData, 'name', 'id'>('name', 'id')(categoryData, _, ctx)
         }
       }
       if (isSellerMap(mapUnit)) {
@@ -105,32 +113,46 @@ export const resolvers = {
         }
       }
       if (isBrandMap(mapUnit)) {
-        const brandData = await getBrandInfo(obj, isVtex, ctx)
-        return brandData ? brandData.name : defaultName
+        const brandData = (metadataMap[breadcrumbMapKey(queryUnit, mapUnit)] ?? (await getBrandInfo(obj, isVtex, ctx))) as TranslatableData
+        if (brandData) {
+          return formatTranslatableProp<TranslatableData, 'name', 'id'>('name', 'id')(brandData, _, ctx)
+        }
       }
       if (isSpecificationFilter(mapUnit)) {
         return getSpecificationFilterName(queryUnit)
       }
       return defaultName && decodeURI(defaultName)
     },
-    href: ({
-      index,
-      queryArray,
-      mapArray,
-      mapUnit,
-      queryUnit,
-    }: BreadcrumbParams) => {
-      if (index === 0 && (isCategoryMap(mapUnit) || isBrandMap(mapUnit))) {
-        return `/${queryUnit}`
+    href: (params: BreadcrumbParams) => {
+      const {
+        index,
+        queryArray,
+        mapArray,
+        mapUnit,
+        hrefs,
+      } = params
+
+      const noMapQueryString = mapArray.slice(0, index + 1).every(isCategoryMap) || (isBrandMap(mapUnit) && index === 0)
+      if (hrefs) {
+        // Will fall here only if store translated data for different binding on upper resolver
+        const href = hrefs[index]
+        if (noMapQueryString) {
+          return href
+        }
+        return `${href}?map=${sliceAndJoin(
+          mapArray,
+          index + 1,
+          ','
+        )}`
       }
-      if (mapArray.every(isCategoryMap)) {
-        return `/${sliceAndJoin(queryArray, index + 1, '/')}`
-      }
-      return `/${sliceAndJoin(queryArray, index + 1, '/')}?map=${sliceAndJoin(
+
+      const queryString = noMapQueryString ? '' : `?map=${sliceAndJoin(
         mapArray,
         index + 1,
         ','
       )}`
+
+      return `/${sliceAndJoin(queryArray, index + 1, '/')}${queryString}`
     },
   },
 }

--- a/node/resolvers/search/skuSpecificationField.ts
+++ b/node/resolvers/search/skuSpecificationField.ts
@@ -1,10 +1,18 @@
+import { addContextToTranslatableString } from '../../utils/i18n'
+
 export const resolvers = {
   SKUSpecificationField: {
     originalName: (value: SKUSpecificationField) => {
       return value.name
     },
-    name: (value: SKUSpecificationField) => {
-      return value.name
+    name: (field: SKUSpecificationField, _: any, ctx: Context) => {
+      return addContextToTranslatableString(
+        {
+          content: field.name,
+          context: field.id
+        },
+        ctx
+      )
     }
   }
 }

--- a/node/resolvers/search/skuSpecificationValue.ts
+++ b/node/resolvers/search/skuSpecificationValue.ts
@@ -1,10 +1,18 @@
+import { addContextToTranslatableString } from '../../utils/i18n'
+
 export const resolvers = {
   SKUSpecificationValue: {
     originalName: (value: SKUSpecificationValue) => {
       return value.name
     },
-    name: (value: SKUSpecificationValue) => {
-      return value.name
+    name: (value: SKUSpecificationValue, _: any, ctx: Context) => {
+      return addContextToTranslatableString(
+        {
+          content: value.name,
+          context: value.fieldId
+        },
+        ctx
+      )
     }
   }
 }

--- a/node/resolvers/search/utils.ts
+++ b/node/resolvers/search/utils.ts
@@ -143,6 +143,30 @@ export const searchEncodeURI = (account: string) => (str: string) => {
   return str
 }
 
+export const searchDecodeURI = (str: string) => {
+  return str.replace(/(\@perc\@|\@slash\@|\@quo\@|\@squo\@|\@dot\@|\@lpar\@|\@rpar\@)/g, (c: string) => {
+    switch (c) {
+      case '@perc@':
+        return '%'
+      case '@quo@':
+        return "\""
+      case '@squo@':
+        return "\'"
+      case '@dot@':
+        return "."
+      case '@lpar@':
+        return "("
+      case '@rpar@':
+        return ")"
+      case '@slash@':
+        return "/"
+      default: {
+        return c
+      }
+    }
+  })
+}
+
 export const getMapAndPriceRangeFromSelectedFacets = (
   selectedFacets: SelectedFacet[]
 ) => {
@@ -157,4 +181,8 @@ export const getMapAndPriceRangeFromSelectedFacets = (
   const map = selectedFacets.map(facet => facet.key).join(',')
 
   return [map, priceRange]
+}
+
+export const breadcrumbMapKey = (queryUnit: string, mapUnit: string) => {
+  return `${queryUnit}-${mapUnit}`
 }

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -101,6 +101,7 @@ interface SearchProduct {
   Specifications?: string[]
   allSpecifications?: string[]
   allSpecificationsGroups?: string[]
+  skuSpecifications?: SkuSpecification[]
 }
 
 interface SearchItem {
@@ -128,6 +129,10 @@ interface SearchItem {
     itemId: string
     amount: number
   }[]
+}
+
+interface SearchItemExtended extends SearchItem {
+  skuSpecifications?: SkuSpecification[]
 }
 
 interface SkuSpecification {

--- a/node/typings/Filter.ts
+++ b/node/typings/Filter.ts
@@ -1,0 +1,7 @@
+interface FilterListTreeCategoryById {
+  Name: string
+  CategoryId: number
+  FieldId: number
+  isActive: boolean
+  IsStockKeepingUnit: boolean
+}

--- a/node/typings/SearchMetadata.ts
+++ b/node/typings/SearchMetadata.ts
@@ -7,4 +7,5 @@ interface SearchMetadataArgs {
 interface SearchMetadata {
   titleTag?: string | null
   metaTagDescription?: string | null
+  id?: string | null
 }

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -1,0 +1,81 @@
+import {
+  formatTranslatableStringV2,
+  parseTranslatableStringV2,
+  createMessagesLoader,
+} from '@vtex/api'
+
+export const formatTranslatableProp = <R, P extends keyof R, I extends keyof R>(prop: P, idProp: I) =>
+  (root: R, _: unknown, ctx: Context) => addContextToTranslatableString(
+    {
+      content: root[prop] as unknown as string,
+      context: root[idProp] as unknown as string
+    },
+    ctx
+  )
+
+interface BaseMessage {
+  content: string
+  from?: string
+}
+
+interface MessageWithContext extends BaseMessage {
+  context: string | number
+}
+
+export interface Message extends BaseMessage {
+  context?: string
+}
+
+export const addContextToTranslatableString = (message: Message, ctx: Context) => {
+  const { vtex: { tenant } } = ctx
+  const { locale } = tenant!
+
+  if (!message.content) {
+    return message.content
+  }
+
+  const {
+    content,
+    context: originalContext,
+    from: originalFrom
+  } = parseTranslatableStringV2(message.content)
+
+  const context = (originalContext || message.context)?.toString()
+  const from = originalFrom || message.from || locale
+
+  return formatTranslatableStringV2({ content, context, from })
+}
+
+export const translateToCurrentLanguage = (message: MessageWithContext, ctx: Context) => {
+  const { state, clients, vtex: { binding, tenant, locale } } = ctx
+  if (!state.messagesBindingLanguage) {
+    state.messagesBindingLanguage = createMessagesLoader(clients, locale ?? binding!.locale)
+  }
+
+  return state.messagesBindingLanguage!.load({
+    content: message.content,
+    context: message.context?.toString(),
+    from: message.from ?? tenant!.locale,
+  })
+}
+
+export const translateManyToCurrentLanguage = (messages: Message[], ctx: Context) => {
+  const { state, clients, vtex: { binding, tenant, locale } } = ctx
+  if (!state.messagesBindingLanguage) {
+    state.messagesBindingLanguage = createMessagesLoader(clients, locale ?? binding!.locale)
+  }
+
+  return state.messagesBindingLanguage!.loadMany(messages.map(message => ({
+    content: message.content,
+    context: message.context,
+    from: message.from ?? tenant!.locale,
+  })))
+}
+
+export const shouldTranslateToUserLocale = ({ vtex: { tenant, locale } }: Context) => tenant?.locale !== locale
+
+export const shouldTranslateToBinding = ({ vtex: { binding, tenant } }: Context) =>
+  Boolean(tenant?.locale && binding?.locale && tenant.locale !== binding.locale)
+
+  export const shouldTranslateToTenantLocale = ({ vtex: { locale, tenant } }: Context) =>
+  Boolean(tenant?.locale && locale && tenant.locale !== locale)

--- a/node/utils/slug.ts
+++ b/node/utils/slug.ts
@@ -26,3 +26,10 @@ export function searchSlugify(str: string) {
   const replaced = noCommas.replace(/[*+~.()'"!:@&\[\]`/ %$#?{}|><=_^]/g, '-')
   return toLower(removeAccents(replaced))
 }
+
+export const slugifyStoreIndexer = (str: string) =>
+  str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[*+~.()'"!:@&\[\]`,/ %$#?{}|><=_^]/g, '-')

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Port relevant changes from the 0.x branch into the 1.x branch.
Some relevant changes were made to the way the resolver handles translations, our resolver
was still using old code.

This was done by rebasing and then squashing every commit from the master branch that was not
on the 1.x branch (versions 0.3.x -> 0.11.x).

#### How should this be manually tested?

[Workspace](https://christian--storecomponents.myvtex.com/home---decor/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This reverts the last revert 👀 

This PR is identical to https://github.com/vtex-apps/search-resolver/pull/74, except the new handling of variations.