### PR TITLE
PER-56: Fix compatibility `variations` and `speficiations` not being set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Compatibility `variations` and `speficiations` not being set in some situations.
+
 ## [1.13.2] - 2020-08-06
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -83,15 +83,11 @@ export const convertBiggyProduct = (
     })
   }
 
-  product.productSpecifications.forEach((specification) => {
+  allSpecifications.forEach((specification) => {
     const attributes = product.textAttributes.filter((attribute) => attribute.labelKey == specification)
-    if (attributes != null && attributes.length > 0) {
-      convertedProduct[specification] = []
-
-      attributes.forEach((attribute) => {
-        convertedProduct[specification].push(attribute.labelValue)
-      })
-    }
+    convertedProduct[specification] = attributes.map((attribute) => {
+      attribute.labelValue
+    })
   })
 
   allSpecificationsGroups.forEach((specificationGroup) => {
@@ -262,9 +258,7 @@ const convertSKU = (
 
   variations.forEach((variation) => {
     const attribute = sku.attributes.find((attribute) => attribute.key == variation)
-    if (attribute != null) {
-      item[variation] = [attribute.value]
-    }
+    item[variation] = attribute != null ? [attribute.value] : []
   })
 
   return item


### PR DESCRIPTION
#### What problem is this solving?

`allSpecifications` was created using attributes from both product and sku attributes,
but only `productSpecifications` was set in the root of the product. When translating
all values inside `allSpecifications` were expected to be set in the product root.

#### How should this be manually tested?

[Workspace](https://christian--applesaddlery.myvtex.com/shoes?_q=shoes&map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
