### PR TITLE
translate other metadata names with their ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Translate metadata names with their IDs in context.
 
 ## [0.11.0] - 2020-07-31
 

--- a/node/__mocks__/helpers.ts
+++ b/node/__mocks__/helpers.ts
@@ -67,7 +67,7 @@ export const mockContext: any = {
   },
   state: {
     messagesBindingLanguage: {
-      loadMany: jest.fn((messages: any) => messages.map((message: any) => `${message.content}-${getLocale()}`))
+      loadMany: jest.fn((messages: any) => messages.map((message: any) => `${message.content}-${getLocale()}${message.context ? `-${message.context}` : ''}`))
     },
     messagesTenantLanguage: {
       load: jest.fn((message: any) => `${message.content}-${getTenantLocale()}`)

--- a/node/resolvers/search/productSearch.test.ts
+++ b/node/resolvers/search/productSearch.test.ts
@@ -145,6 +145,23 @@ describe('tests related to the searchMetadata query', () => {
     expect(mockContext.clients.search.pageType).toBeCalledTimes(1)
     expect(mockContext.state.messagesBindingLanguage.loadMany).toBeCalledTimes(1)
   })
+
+  test('get search metadata from pageType for category with brand & specification filter with locale difference', async () => {
+    const args = {
+      query: 'Department/Category/Brand/Large',
+      map: 'c,c,b,specificationFilter_15',
+    }
+
+    mockContext.vtex.locale = 'es-ES'
+    mockContext.vtex.tenant.locale = 'fr-FR'
+
+    const result = await queries.searchMetadata({}, args, mockContext as any)
+    expect(result.titleTag).toBe('Large-es-ES - brand-es-ES - department/category-title-es-ES')
+    expect(result.metaTagDescription).toBe(
+      'department/category-metaTagDescription (((1))) <<<fr-FR>>>'
+    )
+    expect(mockContext.clients.search.pageType).toBeCalledTimes(2)
+  })
 })
 
 describe('tests for breadcrumb resolver', () => {

--- a/node/resolvers/search/productSearch.test.ts
+++ b/node/resolvers/search/productSearch.test.ts
@@ -138,7 +138,7 @@ describe('tests related to the searchMetadata query', () => {
     mockContext.vtex.tenant.locale = 'fr-FR'
 
     const result = await queries.searchMetadata({}, args, mockContext as any)
-    expect(result.titleTag).toBe('department/category-title-es-ES')
+    expect(result.titleTag).toBe('department/category-title-es-ES-1')
     expect(result.metaTagDescription).toBe(
       'department/category-metaTagDescription (((1))) <<<fr-FR>>>'
     )
@@ -156,7 +156,7 @@ describe('tests related to the searchMetadata query', () => {
     mockContext.vtex.tenant.locale = 'fr-FR'
 
     const result = await queries.searchMetadata({}, args, mockContext as any)
-    expect(result.titleTag).toBe('Large-es-ES - brand-es-ES - department/category-title-es-ES')
+    expect(result.titleTag).toBe('Large-es-ES-15 - brand-es-ES-1 - department/category-title-es-ES-1')
     expect(result.metaTagDescription).toBe(
       'department/category-metaTagDescription (((1))) <<<fr-FR>>>'
     )

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

The other names for the metadata title were not being translated with their id as context, which would result in wrong translations. This fixes it.

#### How should this be manually tested?

https://fidelis--miriadeit.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
