### PR TITLE
PER-497: compatibility category tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Categories and categoriesIds to compatibility layer from all trees.
+
 ## [1.14.1] - 2020-08-06
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -25,20 +25,13 @@ export const convertBiggyProduct = async (
   priceTable?: string,
   indexingType?: IndexingType,
 ) => {
-  const categories: string[] = product.categories
-    ? product.categories.map((_: any, index: number) => {
-        const subArray = product.categories.slice(0, index)
-        return `/${subArray.join('/')}/`
-      })
-    : []
+  const categories: string[] = []
+  const categoriesIds: string[] = []
 
-
-  const categoriesIds: string[] = product.categoryIds
-  ? product.categoryIds.map((_: any, index: number) => {
-      const subArray = product.categoryIds.slice(0, index + 1)
-      return `/${subArray.join('/')}/`
-    }).reverse()
-  : []
+  product.categoryTrees.forEach((categoryTree) => {
+    categories.push(`/${categoryTree.categoryNames.join('/')}/`)
+    categoriesIds.push(`/${categoryTree.categoryIds.join('/')}/`)
+  })
 
   const skus: SearchItem[] = (product.skus || []).map(
     convertSKU(product, indexingType, tradePolicy)

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -127,6 +127,7 @@ interface BiggySearchProduct {
   specificationGroups: string
   textAttributes: BiggyTextAttribute[]
   split: BiggySplit
+  categoryTrees: BiggyCategoryTree[]
 }
 
 interface BiggySplit {
@@ -191,4 +192,9 @@ interface BiggyTextAttribute {
   labelValue: string
   key: string
   value: string
+}
+
+interface BiggyCategoryTree {
+  categoryNames: string[]
+  categoryIds: string[]
 }


### PR DESCRIPTION
#### What problem is this solving?

We only had information of one category tree in elasticsearch, now we have all the category trees, so this PR makes it so we pass all of them forward to the respective fields.

#### How should this be manually tested?

It's linked on https://tornai--atitudecosmeticos.myvtex.com/ , but there's not really easy way to test it as these fields are not being passed forward, it seems. We're just making sure the return of the compatibility layer is exactly the same as the fq API. I console.logged some things to show how it is now, and here's the link to the fq API: https://atitudecosmeticos.myvtex.com/api/catalog_system/pub/products/search/?fq=productId:2113    

BEFORE PR:
![Screen Shot 2020-08-13 at 12 08 51](https://user-images.githubusercontent.com/28491720/90152660-6fc3f900-dd5e-11ea-8630-2f68454032f9.png)


AFTER PR:
![Screen Shot 2020-08-13 at 12 05 17](https://user-images.githubusercontent.com/28491720/90152457-35f2f280-dd5e-11ea-9c22-532323464edb.png)



#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes
Most of the work was actually done on the DB side, adding the fields and passing them to the possible facets of the product.
