### PR TITLE
add regionId to the simulationPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add `regionId` to the `simulationPayload`.
+
 ## [1.15.0] - 2020-08-13
 
 ### Added
-
 - Categories and categoriesIds to compatibility layer from all trees.
 
 ## [1.14.1] - 2020-08-06

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -23,6 +23,7 @@ export const convertBiggyProduct = async (
   simulationBehavior: 'skip' | 'default' | null,
   tradePolicy?: string,
   priceTable?: string,
+  regionId?: string,
   indexingType?: IndexingType,
 ) => {
   const categories: string[] = []
@@ -86,7 +87,8 @@ export const convertBiggyProduct = async (
   if (simulationBehavior === 'default') {
     const simulationPayload: SimulationPayload = {
       priceTables: priceTable ? [priceTable] : undefined,
-      items: getSimulationPayloads(convertedProduct)
+      items: getSimulationPayloads(convertedProduct),
+      shippingData: { logisticsInfo: [{ regionId }] }
     }
 
     const simulation = await checkout.simulation(simulationPayload)

--- a/node/commons/products.ts
+++ b/node/commons/products.ts
@@ -9,7 +9,7 @@ export const productsBiggy = async (searchResult: any, ctx: any, simulationBehav
 
   searchResult.products.forEach((product: any) => {
     try {
-      products.push(convertBiggyProduct(product, checkout, simulationBehavior, segment?.channel, segment?.priceTables))
+      products.push(convertBiggyProduct(product, checkout, simulationBehavior, segment?.channel, segment?.priceTables, segment?.regionId))
     } catch (err) {
       console.error(err)
     }

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -243,4 +243,9 @@ interface SimulationPayload {
   isCheckedIn?: boolean
   priceTables?: string[]
   marketingData?: Record<string, string>
+  shippingData?: ShippingData
+}
+
+interface ShippingData {
+  logisticsInfo?: { regionId?: string }[]
 }


### PR DESCRIPTION
#### What problem is this solving?

We are not sending the `regionId` to the simulation API.

#### How should this be manually tested?

[https://hiago--exitocol.myvtex.com/tomate](url)

You can change your location to the difference in the products price.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
