### PR TITLE
Fix simulation call with multiple sellers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Add multiple calls to simulation for each seller for each product on compatibility layer.
+- Add calls to simulation for product sellers on compatibility layer.
 
 ## [1.15.1] - 2020-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add multiple calls to simulation for each seller for each product on compatibility layer.
+
 ## [1.15.1] - 2020-08-14
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -149,7 +149,7 @@ const fillSearchItemWithSimulation = (searchItem: SearchItem, orderFormItems: Or
 
       seller.commertialOffer.Price = orderFormItem.price / 100
       seller.commertialOffer.PriceValidUntil = orderFormItem.priceValidUntil
-      seller.commertialOffer.ListPrice = orderFormItem.listPrice / 10
+      seller.commertialOffer.ListPrice = orderFormItem.listPrice / 100
     })
   }
 

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -85,15 +85,25 @@ export const convertBiggyProduct = async (
   }
 
   if (simulationBehavior === 'default') {
-    const simulationPayload: SimulationPayload = {
-      priceTables: priceTable ? [priceTable] : undefined,
-      items: getSimulationPayloads(convertedProduct),
-      shippingData: { logisticsInfo: [{ regionId }] }
-    }
+    const payloadItems = getSimulationPayloads(convertedProduct)
 
-    const simulation = await checkout.simulation(simulationPayload)
+    const simulationPayloads: SimulationPayload[] = payloadItems.map((item) => {
+       return {
+        priceTables: priceTable ? [priceTable] : undefined,
+        items: [item],
+        shippingData: { logisticsInfo: [{ regionId }] }
+      }
+    })
 
-    const groupedBySkuId = groupBy(prop("id"), simulation.items)
+    const simulationPromises = simulationPayloads.map((payload) => {
+      return checkout.simulation(payload)
+    })
+
+    const simulations = await Promise.all(simulationPromises)
+
+    const simulationItems = simulations.map((simulation) => simulation.items).reduce((acc, val) => acc.concat(val), []).filter(distinct)
+
+    const groupedBySkuId = groupBy(prop("id"), simulationItems)
 
     const orderItemsBySellerById: OrderFormItemBySellerById = mergeAll(Object.entries(groupedBySkuId).map(([id, items]) => {
       const groupedBySeller = indexBy((prop("seller")), items)
@@ -132,9 +142,14 @@ const fillSearchItemWithSimulation = (searchItem: SearchItem, orderFormItems: Or
     searchItem.sellers.forEach((seller) => {
       const orderFormItem = orderFormItems[seller.sellerId]
 
+      if (orderFormItem == null) {
+        console.warn(`Product ${searchItem.itemId} is unavailable for seller ${seller.sellerId}`)
+        return
+      }
+
       seller.commertialOffer.Price = orderFormItem.price / 100
       seller.commertialOffer.PriceValidUntil = orderFormItem.priceValidUntil
-      seller.commertialOffer.ListPrice = orderFormItem.listPrice / 100
+      seller.commertialOffer.ListPrice = orderFormItem.listPrice / 10
     })
   }
 


### PR DESCRIPTION
#### What problem is this solving?

Simulation doesn't let us call in one payload multiple items with the same ID for diferent sellers. This change fixes it to make parallel calls and added a check to see whether

#### How should this be manually tested?

https://christian--kevinyee.myvtex.com/Disney

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
