### PR TITLE
Add support for 'salesChannel' argument in 'productsByIdentifier' query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `salesChannel` argument in `productsByIdentifier` query.
 
 ## [0.11.1] - 2020-08-12
 ### Fixed

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -46,6 +46,14 @@ export class Search extends AppClient {
   private searchEncodeURI: (x: string) => string
   private basePath: string
 
+  private addSalesChannel = (url: string, salesChannel?: string | number) => {
+    if (!salesChannel) {
+      return url
+    }
+
+    return url.concat(`&sc=${salesChannel}`)
+  }
+
   public constructor(ctx: IOContext, opts?: InstanceOptions) {
     super('vtex.catalog-api-proxy@0.x', ctx, opts)
 
@@ -78,11 +86,11 @@ export class Search extends AppClient {
       }
     )
 
-  public productsByEan = (ids: string[]) =>
+  public productsByEan = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${ids
+      this.addSalesChannel(`/pub/products/search?${ids
         .map(id => `fq=alternateIds_Ean:${id}`)
-        .join('&')}`,
+        .join('&')}`, salesChannel),
       { metric: 'search-productByEan' }
     )
 
@@ -95,9 +103,11 @@ export class Search extends AppClient {
     })
   }
 
-  public productsById = (ids: string[]) =>
+  public productsById = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${ids.map(id => `fq=productId:${id}`).join('&')}`,
+      this.addSalesChannel(`/pub/products/search?${ids
+        .map(id => `fq=productId:${id}`)
+        .join('&')}`, salesChannel),
       { metric: 'search-productById' }
     )
 
@@ -109,19 +119,19 @@ export class Search extends AppClient {
       }
     )
 
-  public productsByReference = (ids: string[]) =>
+  public productsByReference = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${ids
+      this.addSalesChannel(`/pub/products/search?${ids
         .map(id => `fq=alternateIds_RefId:${id}`)
-        .join('&')}`,
+        .join('&')}`, salesChannel),
       { metric: 'search-productByReference' }
     )
 
-  public productBySku = (skuIds: string[]) =>
+  public productBySku = (skuIds: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${skuIds
+      this.addSalesChannel(`/pub/products/search?${skuIds
         .map(skuId => `fq=skuId:${skuId}`)
-        .join('&')}`,
+        .join('&')}`, salesChannel),
       { metric: 'search-productBySku' }
     )
 

--- a/node/package.json
+++ b/node/package.json
@@ -31,7 +31,7 @@
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.31.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",
@@ -44,7 +44,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.36.0",
+    "@vtex/api": "6.36.2",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -72,6 +72,7 @@ interface ProductRecommendationArg {
 interface ProductsByIdentifierArgs {
   field: 'id' | 'ean' | 'reference' | 'sku'
   values: [string]
+  salesChannel?: string
 }
 
 const inputToSearchCrossSelling = {
@@ -399,20 +400,20 @@ export const queries = {
     } = ctx
 
     let products = [] as SearchProduct[]
-    const { field, values } = args
+    const { field, values, salesChannel } = args
 
     switch (field) {
       case 'id':
-        products = await search.productsById(values)
+        products = await search.productsById(values, salesChannel)
         break
       case 'ean':
-        products = await search.productsByEan(values)
+        products = await search.productsByEan(values, salesChannel)
         break
       case 'reference':
-        products = await search.productsByReference(values)
+        products = await search.productsByReference(values, salesChannel)
         break
       case 'sku':
-        products = await search.productBySku(values)
+        products = await search.productBySku(values, salesChannel)
         break
     }
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5148,9 +5148,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0-beta.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0-beta.0/public#3d0b978fb7e1552b551f046df9aa1659e55a37da"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0/public#b6c0b3d6baaecfaf8fbc9cc9da59c745a5b23cb3"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,14 +777,14 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.36.0":
-  version "6.36.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.36.0.tgz#debc0462cae4196a6580ded8ed88359dcb6ce31d"
-  integrity sha512-kEIHIOA6oXCGq65TpQG6ZBA2r3qQ9SAgoMpjo87dZvbybvxTPI7mz8URKy4jKuArf1mkhzLu9EqsJ+xwljFySg==
+"@vtex/api@6.36.2":
+  version "6.36.2"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.36.2.tgz#98295c5f3e8ae492a55d996f7074e5fe09067e1e"
+  integrity sha512-J72dBwQG0hLJTGnFUwCJgW5v9iRubrQZ13aA2fwHohLeEcBOG/OAdd/eF3tuQY7lh8giCv4w0l0+oWvNor9vTg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
-    "@vtex/node-error-report" "^0.0.2"
+    "@vtex/node-error-report" "^0.0.3"
     "@wry/equality" "^0.1.9"
     agentkeepalive "^4.0.2"
     apollo-server-errors "^2.2.1"
@@ -822,10 +822,10 @@
     uuid "^3.3.3"
     xss "^1.0.6"
 
-"@vtex/node-error-report@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.2.tgz#edf15095d6bb543d28b46f86bc109e6214149dfe"
-  integrity sha512-Q6V8E1IR/U0H6uTB1G+gH4ugL4Kw1l/WsK7W46LQBsxv4ISlZcO7dXPlWrL4RzRcVam5yzGAwNkv2wJdW61tAA==
+"@vtex/node-error-report@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.3.tgz#365a2652aeebbd6b51ddc5d64c3c0bc1a326dc71"
+  integrity sha512-HhBworWQfSs6PU3yroloc7H2/pWboDIzgdiJ6SYc3mJVRU5/bXtwM9HGPkAGZvAb/0cMwFC963SYYKvOfeSjbA==
   dependencies:
     is-stream "^2.0.0"
 
@@ -5148,9 +5148,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.31.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0-beta.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.31.0/public#af2733e2895e3df1e7a8685aaeb0c0609475f216"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0-beta.0/public#3d0b978fb7e1552b551f046df9aa1659e55a37da"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Enables users to query for products in a certain Sales Channel.

#### How should this be manually tested?

Go to this [Workspace](https://victormiranda--storecomponents.myvtex.com/_v/private/vtex.search-graphql@0.32.0-beta.0/graphiql/v1), and perform the query:

```graphql
{
  productsByIdentifier(field: id, values: ["2", "2001"], salesChannel: "4") {
    brand
    productName
  }
}
```

You should get one product as a result. This product is **only** available in this Sales Channel. 

<img width="548" alt="Screen Shot 2020-08-27 at 12 32 54" src="https://user-images.githubusercontent.com/27777263/91463188-758f0380-e861-11ea-874a-ba576a17a987.png">

Try querying for it with `salesChannel: "1"`, and you should receive a `not found` error.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Should be merged after https://github.com/vtex-apps/search-graphql/pull/90.
