### PR TITLE
decode fulltext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Double encoded `fulltext`.
+
 ## [1.15.5] - 2020-08-28
 
 ### Fixed

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -175,7 +175,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query: decodeURIComponent(query || ''),
+        query: decodeURIComponent(query ?? ''),
         page,
         count,
         sort,

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -104,7 +104,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query: decodeURIComponent(query || ''),
+        query: decodeURIComponent(query ?? ''),
         page,
         count,
         sort,

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -142,7 +142,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query: decodeURIComponent(query || ''),
+        query: decodeURIComponent(query ?? ''),
         page,
         count,
         sort,

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -39,7 +39,7 @@ export class BiggySearchClient extends ExternalClient {
       `${this.store}/api/suggestion_searches`,
       {
         params: {
-          term,
+          term: decodeURIComponent(term),
         },
         metric: 'suggestion-searches',
       }
@@ -75,7 +75,7 @@ export class BiggySearchClient extends ExternalClient {
     const result = await this.http.post(
       `${this.store}/api/suggestion_products`,
       {
-        term,
+        term: decodeURIComponent(term),
         attributes,
       },
       {
@@ -104,7 +104,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query,
+        query: decodeURIComponent(query || ''),
         page,
         count,
         sort,
@@ -142,7 +142,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query,
+        query: decodeURIComponent(query || ''),
         page,
         count,
         sort,
@@ -175,7 +175,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query,
+        query: decodeURIComponent(query || ''),
         page,
         count,
         sort,
@@ -199,7 +199,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query: fullText,
+        query: decodeURIComponent(fullText),
       },
       metric: 'search-result',
     })
@@ -218,7 +218,7 @@ export class BiggySearchClient extends ExternalClient {
       `${this.store}/api/suggestion_searches`,
       {
         params: {
-          term: fullText,
+          term: decodeURIComponent(fullText),
         },
         metric: 'search-autcomplete-suggestions',
       }
@@ -234,7 +234,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query: fullText,
+        query: decodeURIComponent(fullText),
       },
       metric: 'search-correction',
     })
@@ -251,7 +251,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query: fullText,
+        query: decodeURIComponent(fullText),
       },
       metric: 'search-suggestions',
     })

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -317,7 +317,7 @@ export const queries = {
       },
       breadcrumb: buildBreadcrumb(
         result.attributes || [],
-        args.fullText,
+        decodeURIComponent(args.fullText),
         args.selectedFacets
       ),
     }


### PR DESCRIPTION
#### What problem is this solving?

Sometimes the fulltext has some encoded character and the lib we are using to make the REST calls are encoding it again.

#### How should this be manually tested?

[Workspace](https://hiago--dunloppneus.myvtex.com/lt285$2f75r16?_q=LT285$2F75R16&map=ft)

search for `LT285/75R16`

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

