### PR TITLE
Feature/whitelabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Filter by seller white label.
 
 ## [1.17.4] - 2020-10-05
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -51,7 +51,7 @@
     },
     {
       "attrs": {
-        "host": "exitocol.vtexcommercebeta.com.br",
+        "host": "{{account}}.vtexcommercebeta.com.br",
         "path": "/*"
       },
       "name": "outbound-access"

--- a/manifest.json
+++ b/manifest.json
@@ -48,6 +48,13 @@
         "host": "search.biggylabs.com.br",
         "path": "/*"
       }
+    },
+    {
+      "attrs": {
+        "host": "exitocol.vtexcommercebeta.com.br",
+        "path": "/*"
+      },
+      "name": "outbound-access"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/manifest.json
+++ b/manifest.json
@@ -48,13 +48,6 @@
         "host": "search.biggylabs.com.br",
         "path": "/*"
       }
-    },
-    {
-      "attrs": {
-        "host": "{{account}}.vtexcommercebeta.com.br",
-        "path": "/*"
-      },
-      "name": "outbound-access"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -14,6 +14,13 @@ const buildPathFromArgs = (args: SearchResultArgs) => {
   return path.join(attributePath.split('%20').join('-'), policyAttr)
 }
 
+const buildBSearchFilterCookie = (sellers?: RegionSeller[]) =>
+  !sellers || sellers.length === 0
+    ? ''
+    : sellers.reduce((cookie: string, seller: RegionSeller, idx: number) => {
+      return `${cookie}${idx > 0 ? '/' : ''}${seller.id}`
+    }, 'bsearch-filter=skuSeller#')
+
 export class BiggySearchClient extends ExternalClient {
   private store: string
 
@@ -134,6 +141,7 @@ export class BiggySearchClient extends ExternalClient {
       fuzzy,
       leap,
       searchState,
+      sellers,
     } = args
 
     const url = `${this.store}/api/split/attribute_search/${buildPathFromArgs(
@@ -152,6 +160,9 @@ export class BiggySearchClient extends ExternalClient {
         ...parseState(searchState),
       },
       metric: 'search-result',
+      headers: {
+        Cookie: buildBSearchFilterCookie(sellers),
+      },
     })
 
     return result.data
@@ -167,6 +178,7 @@ export class BiggySearchClient extends ExternalClient {
       fuzzy,
       leap,
       searchState,
+      sellers,
     } = args
 
     const url = `${this.store}/api/split/product_search/${buildPathFromArgs(
@@ -185,6 +197,9 @@ export class BiggySearchClient extends ExternalClient {
         ...parseState(searchState),
       },
       metric: 'search-result',
+      headers: {
+        Cookie: buildBSearchFilterCookie(sellers),
+      },
     })
 
     return result.data
@@ -220,7 +235,7 @@ export class BiggySearchClient extends ExternalClient {
         params: {
           term: decodeURIComponent(fullText),
         },
-        metric: 'search-autcomplete-suggestions',
+        metric: 'search-autocomplete-suggestions',
       }
     )
 

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -18,8 +18,8 @@ const buildBSearchFilterCookie = (sellers?: RegionSeller[]) =>
   !sellers || sellers.length === 0
     ? ''
     : sellers.reduce((cookie: string, seller: RegionSeller, idx: number) => {
-      return `${cookie}${idx > 0 ? '/' : ''}${seller.id}`
-    }, 'bsearch-filter=skuSeller#')
+        return `${cookie}${idx > 0 ? '/' : ''}${seller.id}`
+      }, 'bsearch-filter=private-seller#')
 
 export class BiggySearchClient extends ExternalClient {
   private store: string

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -62,6 +62,7 @@ export class BiggySearchClient extends ExternalClient {
       facetValue: attributeValue,
       tradePolicy,
       indexingType,
+      sellers
     } = args
     const attributes: { key: string; value: string }[] = []
 
@@ -87,6 +88,9 @@ export class BiggySearchClient extends ExternalClient {
       },
       {
         metric: 'suggestion-products',
+        headers: {
+          Cookie: buildBSearchFilterCookie(sellers),
+        },
       }
     )
 

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -1,24 +1,20 @@
 import {
   InstanceOptions,
   IOContext,
+  JanusClient,
   RequestConfig,
-  ExternalClient,
 } from '@vtex/api'
 
 import { statusToError } from '../utils'
 
-export class Checkout extends ExternalClient {
-  public constructor(context: IOContext, options?: InstanceOptions) {
-    super(
-      `https://${context.account}.vtexcommercebeta.com.br/`,
-      context,
-      {
-        ...options,
-        headers: {
-          ...(options && options.headers),
-        },
-      }
-    )
+export class Checkout extends JanusClient {
+  public constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(ctx, {
+      ...options,
+      headers: {
+        ...(options && options.headers),
+      },
+    })
   }
 
   private getChannelQueryString = () => {
@@ -37,8 +33,8 @@ export class Checkout extends ExternalClient {
       }
     )
 
-  public regions = (regionId: string, salesChannel?: number) =>
-    this.http.get(this.routes.regions(regionId, salesChannel))
+  public regions = (regionId: string, channel?: number) =>
+    this.http.get(this.routes.regions(regionId, channel))
 
   protected post = <T>(url: string, data?: any, config: RequestConfig = {}) => {
     return this.http.post<T>(url, data, config).catch(statusToError) as Promise<
@@ -51,7 +47,8 @@ export class Checkout extends ExternalClient {
     return {
       simulation: (queryString: string) =>
         `${base}/orderForms/simulation${queryString}`,
-      regions: (regionId: string, salesChannel?: number) => `${base}/regions/${regionId}${salesChannel ? `&sc=${salesChannel}` : ''}`,
+      regions: (regionId: string, channel?: number) =>
+        `${base}/regions/${regionId}${channel ? `?sc=${channel}` : ''}`,
     }
   }
 }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -37,8 +37,8 @@ export class Checkout extends ExternalClient {
       }
     )
 
-  public regions = (regionId: string) =>
-    this.http.get(this.routes.regions(regionId))
+  public regions = (regionId: string, salesChannel?: number) =>
+    this.http.get(this.routes.regions(regionId, salesChannel))
 
   protected post = <T>(url: string, data?: any, config: RequestConfig = {}) => {
     return this.http.post<T>(url, data, config).catch(statusToError) as Promise<
@@ -51,7 +51,7 @@ export class Checkout extends ExternalClient {
     return {
       simulation: (queryString: string) =>
         `${base}/orderForms/simulation${queryString}`,
-      regions: (regionId: string) => `${base}/regions/${regionId}`,
+      regions: (regionId: string, salesChannel?: number) => `${base}/regions/${regionId}${salesChannel ? `&sc=${salesChannel}` : ''}`,
     }
   }
 }

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -1,20 +1,24 @@
 import {
   InstanceOptions,
   IOContext,
-  JanusClient,
   RequestConfig,
+  ExternalClient,
 } from '@vtex/api'
 
 import { statusToError } from '../utils'
 
-export class Checkout extends JanusClient {
-  public constructor(ctx: IOContext, options?: InstanceOptions) {
-    super(ctx, {
-      ...options,
-      headers: {
-        ...(options && options.headers),
-      },
-    })
+export class Checkout extends ExternalClient {
+  public constructor(context: IOContext, options?: InstanceOptions) {
+    super(
+      `https://${context.account}.vtexcommercebeta.com.br/`,
+      context,
+      {
+        ...options,
+        headers: {
+          ...(options && options.headers),
+        },
+      }
+    )
   }
 
   private getChannelQueryString = () => {
@@ -33,6 +37,9 @@ export class Checkout extends JanusClient {
       }
     )
 
+  public regions = (regionId: string) =>
+    this.http.get(this.routes.regions(regionId))
+
   protected post = <T>(url: string, data?: any, config: RequestConfig = {}) => {
     return this.http.post<T>(url, data, config).catch(statusToError) as Promise<
       T
@@ -44,6 +51,7 @@ export class Checkout extends JanusClient {
     return {
       simulation: (queryString: string) =>
         `${base}/orderForms/simulation${queryString}`,
+      regions: (regionId: string) => `${base}/regions/${regionId}`,
     }
   }
 }

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -151,6 +151,7 @@ const fillSearchItemWithSimulation = (searchItem: SearchItem, orderFormItems: Or
         return
       }
 
+      seller.commertialOffer.AvailableQuantity = orderFormItem?.availability === 'withoutPriceFulfillment' ? 0 : seller.commertialOffer.AvailableQuantity
       seller.commertialOffer.Price = orderFormItem.sellingPrice ? orderFormItem.sellingPrice / 100 : orderFormItem.price / 100
       seller.commertialOffer.PriceValidUntil = orderFormItem.priceValidUntil
       seller.commertialOffer.ListPrice = orderFormItem.listPrice / 100

--- a/node/package.json
+++ b/node/package.json
@@ -30,7 +30,7 @@
     "querystring": "^0.2.0",
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "unescape": "^1.0.1",
     "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.33.0/public"
   },

--- a/node/resolvers/search/constants.ts
+++ b/node/resolvers/search/constants.ts
@@ -1,4 +1,5 @@
 export const SEARCH_URLS_BUCKET = 'newSearchURLs'
+export const SELLERS_BUCKET = 'sellersByRegionId'
 export const CATEGORY_TREE_ROOT_BUCKET = 'categoryTree'
 export const CATEGORY_TREE_CHILDREN_BUCKET = 'categoryTreeChildren'
 export const CATEGORY_TREE_ROOT_PATH = 'categoryTree.json'

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -254,6 +254,7 @@ const getSellers = async (
   vbase: VBase,
   checkout: Checkout,
   regionId?: string,
+  salesChannel?: number,
 ) => {
   if (!regionId) {
     return []
@@ -263,7 +264,7 @@ const getSellers = async (
     vbase,
     `${SELLERS_BUCKET}`,
     regionId,
-    async (params: { regionId: string; checkout: Checkout }) => params.checkout.regions(params.regionId),
+    async (params: { regionId: string; checkout: Checkout }) => params.checkout.regions(params.regionId, salesChannel),
     { regionId, checkout },
     {
       expirationInMinutes: 10,
@@ -317,7 +318,7 @@ export const queries = {
       vtex: { segment, account },
     } = ctx
 
-    const sellers = await getSellers(vbase, checkout, segment?.regionId,)
+    const sellers = await getSellers(vbase, checkout, segment?.regionId, segment?.channel)
 
     const biggyArgs = {
       searchState,
@@ -480,7 +481,7 @@ export const queries = {
       simulationBehavior,
     } = args
 
-    const sellers = await getSellers(vbase, checkout, segment?.regionId)
+    const sellers = await getSellers(vbase, checkout, segment?.regionId, segment?.channel)
 
     const count = to - from + 1
     const page = Math.round((to + 1) / count)
@@ -603,7 +604,7 @@ export const queries = {
       vtex: { segment },
     } = ctx
 
-    const sellers = await getSellers(vbase, checkout, segment?.regionId)
+    const sellers = await getSellers(vbase, checkout, segment?.regionId, segment?.channel)
 
     const tradePolicy = path<string | undefined>(['segment', 'channel'], args)
 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -316,6 +316,8 @@ export const queries = {
 
     const sellers = await getSellers(account, segment.regionId, vbase, checkout)
 
+    console.log(sellers)
+
     const biggyArgs = {
       searchState,
       query: fullText,

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -41,8 +41,8 @@ interface SearchResultArgs {
 }
 
 interface RegionSeller {
-  id: string;
-  name: string;
+  id: string
+  name: string
 }
 
 interface SuggestionProductsArgs {
@@ -67,6 +67,7 @@ interface SelectedFacet {
 }
 
 interface FacetsInput {
+  map: string
   selectedFacets: SelectedFacet[]
   fullText: string
   query: string

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -37,6 +37,12 @@ interface SearchResultArgs {
   indexingType?: IndexingType
   fullText: string
   searchState?: string
+  sellers?: RegionSeller[]
+}
+
+interface RegionSeller {
+  id: string;
+  name: string;
 }
 
 interface SuggestionProductsArgs {

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -54,6 +54,7 @@ interface SuggestionProductsArgs {
   indexingType?: IndexingType
   productOriginVtex: boolean
   simulationBehavior: 'skip' | 'default' | null
+  sellers?: RegionSeller[]
 }
 
 interface SuggestionSearchesArgs {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5037,10 +5037,10 @@ typescript@3.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
   integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 unescape@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Add seller white label filter.

1. It calls the `api/checkout/pub/region` api to get all available sellers by regionId
2. Then, it adds a cookie to filter the search by those sellers

OBS: I'm not using `JanusClient` because the region route is only available on the beta version. Once this route is available on the stable version I will use JanusClient again.

#### How should this be manually tested?

[Exito workspace](https://hiago--exitocol.myvtex.com/electrodomesticos/refrigeracion/neveras)

You can change your region by clicking on "Como quieres recibir tu pedido" > Envio a domicilio > type your email address > Select "Ciudad": `Chia` and "Direcion": `Comercial`.

Then, click on a category like "Eletrodomesticos".

Since exito was not reindexed, you will see an empty search.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
