### PR TITLE
[1.x] Add support for 'salesChannel' argument in 'productsByIdentifier' query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `salesChannel` argument in `productsByIdentifier` query.
 
 ## [1.15.7] - 2020-09-08
 ### Fixed

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -46,6 +46,14 @@ export class Search extends AppClient {
   private searchEncodeURI: (x: string) => string
   private basePath: string
 
+  private addSalesChannel = (url: string, salesChannel?: string | number) => {
+    if (!salesChannel) {
+      return url
+    }
+
+    return url.concat(`&sc=${salesChannel}`)
+  }
+
   public constructor(ctx: IOContext, opts?: InstanceOptions) {
     super('vtex.catalog-api-proxy@0.x', ctx, opts)
 
@@ -78,11 +86,11 @@ export class Search extends AppClient {
       }
     )
 
-  public productsByEan = (ids: string[]) =>
+  public productsByEan = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${ids
+      this.addSalesChannel(`/pub/products/search?${ids
         .map(id => `fq=alternateIds_Ean:${id}`)
-        .join('&')}`,
+        .join('&')}`, salesChannel),
       { metric: 'search-productByEan' }
     )
 
@@ -95,9 +103,11 @@ export class Search extends AppClient {
     })
   }
 
-  public productsById = (ids: string[]) =>
+  public productsById = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${ids.map(id => `fq=productId:${id}`).join('&')}`,
+      this.addSalesChannel(`/pub/products/search?${ids
+        .map(id => `fq=productId:${id}`)
+        .join('&')}`, salesChannel),
       { metric: 'search-productById' }
     )
 
@@ -109,19 +119,19 @@ export class Search extends AppClient {
       }
     )
 
-  public productsByReference = (ids: string[]) =>
+  public productsByReference = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${ids
+      this.addSalesChannel(`/pub/products/search?${ids
         .map(id => `fq=alternateIds_RefId:${id}`)
-        .join('&')}`,
+        .join('&')}`, salesChannel),
       { metric: 'search-productByReference' }
     )
 
-  public productBySku = (skuIds: string[]) =>
+  public productBySku = (skuIds: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?${skuIds
+      this.addSalesChannel(`/pub/products/search?${skuIds
         .map(skuId => `fq=skuId:${skuId}`)
-        .join('&')}`,
+        .join('&')}`, salesChannel),
       { metric: 'search-productBySku' }
     )
 

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.31.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -66,6 +66,7 @@ interface ProductRecommendationArg {
 interface ProductsByIdentifierArgs {
   field: 'id' | 'ean' | 'reference' | 'sku'
   values: string[]
+  salesChannel?: string
 }
 
 const inputToSearchCrossSelling = {
@@ -398,20 +399,20 @@ export const queries = {
     } = ctx
 
     let products = [] as SearchProduct[]
-    const { field, values } = args
+    const { field, values, salesChannel } = args
 
     switch (field) {
       case 'id':
-        products = await search.productsById(values)
+        products = await search.productsById(values, salesChannel)
         break
       case 'ean':
-        products = await search.productsByEan(values)
+        products = await search.productsByEan(values, salesChannel)
         break
       case 'reference':
-        products = await search.productsByReference(values)
+        products = await search.productsByReference(values, salesChannel)
         break
       case 'sku':
-        products = await search.productBySku(values)
+        products = await search.productBySku(values, salesChannel)
         break
     }
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5155,9 +5155,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.31.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.31.0/public#af2733e2895e3df1e7a8685aaeb0c0609475f216"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.32.0/public#b6c0b3d6baaecfaf8fbc9cc9da59c745a5b23cb3"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

Enables users to query for products in a certain Sales Channel.

#### How should this be manually tested?

Go to this [Workspace](https://victormiranda--eriksbikeshop.myvtex.com/).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

This is pretty much the same implementation from https://github.com/vtex-apps/search-resolver/pull/85, but now in the `v1.x` branch.