### PR TITLE
Avoid breaking query if imageUrl is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid breaking if `imageUrl` is null.
 
 ## [0.12.0] - 2020-09-08
 ### Added

--- a/node/resolvers/search/sku.ts
+++ b/node/resolvers/search/sku.ts
@@ -1,4 +1,4 @@
-import { find, head, map, replace, slice } from 'ramda'
+import { find, head, map } from 'ramda'
 import { formatTranslatableProp, addContextToTranslatableString } from '../../utils/i18n'
 
 export const resolvers = {
@@ -25,15 +25,17 @@ export const resolvers = {
     images: (
       { images = [] }: SearchItem,
       { quantity }: { quantity: number }
-    ) =>
-      map(
-        image => ({
+    ) => {
+      const someImages = quantity > 0 ? images.slice(0, quantity) : images
+
+      return someImages.map((image) => {
+        return {
           cacheId: image.imageId,
           ...image,
-          imageUrl: replace('http://', 'https://', image.imageUrl),
-        }),
-        quantity > 0 ? slice(0, quantity, images) : images
-      ),
+          imageUrl: image.imageUrl ? image.imageUrl.replace('http://', 'https://') : '',
+        }
+      })
+    },
 
     kitItems: (
       { kitItems }: SearchItem,


### PR DESCRIPTION
#### What problem is this solving?

Avoid this error from happening:
https://vtex.slack.com/archives/C9P4RMW6Q/p1599774737172200

![image](https://user-images.githubusercontent.com/284515/92814782-f7227d80-f399-11ea-8dec-1f1d187145a6.png)

#### How should this be manually tested?

https://brenovtex--redoxx.myvtex.com/micro-manager-91097/p?skuId=701738

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
