### PR TITLE
Fix/add pricerange other languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add other languages key for PRICERANGE consideration
+### Added
+- Support for other languages in the `PRICERANGE`.
 
 ## [1.20.1] - 2020-10-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add other languages key for PRICERANGE consideration
 
 ## [1.20.1] - 2020-10-08
 ### Added

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -114,7 +114,9 @@ const convertValues = (
 ): { type: FilterType; values: FilterValue[] } => {
   // When creating a filter for price attribute, it should be the only one to use
   // the type `'PRICERANGE'`.
-  if (attribute.type === 'number' && ['price', 'pre-', 'precio', 'preço'].some(p => p === attribute.key)) {
+  const knownPriceKeys = ['price', 'pre-', 'precio', 'preco', 'pret']
+
+  if (attribute.type === 'number' && knownPriceKeys.some(p => p === attribute.key)) {
     return {
       type: 'PRICERANGE',
       values: attribute.values.map((value: any) => {

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -114,7 +114,7 @@ const convertValues = (
 ): { type: FilterType; values: FilterValue[] } => {
   // When creating a filter for price attribute, it should be the only one to use
   // the type `'PRICERANGE'`.
-  if (attribute.type === 'number' && attribute.key === 'price') {
+  if (attribute.type === 'number' && ['price', 'pre-', 'precio', 'preço'].some(p => p === attribute.key)) {
     return {
       type: 'PRICERANGE',
       values: attribute.values.map((value: any) => {


### PR DESCRIPTION
#### What problem is this solving?

Add some other comparisons for PRICERANGE, it was considered only for `price` and was added for `precio` `pre-` `preço`

#### How should this be manually tested?

[fstudio](https://beta--fstudio.myvtex.com/Aparate-foto/d)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/65255533/93492264-3b4cdb00-f8d0-11ea-8519-e81ac18399b6.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
