### PR TITLE
add misspelled and operator to the productSuggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `operator` and `misspelled` to the `productSuggestions` query
+
 ## [1.26.0] - 2020-11-13
 
-## Added
+### Added
 
 - X-VTEX-IS-ID header to calls to search.biggylabs
 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -701,7 +701,13 @@ export const queries = {
       }
     )
 
-    return { ...result, products: convertedProducts }
+    const {
+      count,
+      operator,
+      correction: { misspelled },
+    } = result
+
+    return { count, operator, misspelled, products: convertedProducts }
   },
   banners: (
     _: any,


### PR DESCRIPTION
#### What problem is this solving?

Add `operator` and `misspelled` to the `productSuggestions` query

#### How should this be manually tested?

[Workspace](https://hiago--alssports.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

