### PR TITLE
Return values to specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Return values to specifications.
+
 ## [1.17.0] - 2020-09-16
 ### Added
 - Support for `excludedPaymentSystems` and `includedPaymentSystems` arguments in `Installments` type.

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -127,7 +127,7 @@ export const convertBiggyProduct = async (
     allSpecifications.forEach((specification) => {
       const attributes = product.textAttributes.filter((attribute) => attribute.labelKey == specification)
       convertedProduct[specification] = attributes.map((attribute) => {
-        attribute.labelValue
+        return attribute.labelValue
       })
     })
   }


### PR DESCRIPTION
#### What problem is this solving?

Specifications where returning empty because of a `return` statement that should exist but didnt.

#### How should this be manually tested?

Find a productSummary like in the screenshot below and you'll see the values are there.
https://tornai--alssports.myvtex.com/clothing/shirts/Mens?map=c,c,specificationFilter_7721

![Screen Shot 2020-09-28 at 14 10 55](https://user-images.githubusercontent.com/28491720/94464214-90240780-0194-11eb-8990-27aad12e23ac.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes
