### PR TITLE
Add changes to make enableFiltersFetchOptimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Facets` field resolver to add `quantity` and make it possible to limit facet values.
 
 ## [0.13.1] - 2020-09-16
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -31,7 +31,7 @@
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
     "typescript": "3.8.3",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.33.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.36.0/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/resolvers/search/facets.ts
+++ b/node/resolvers/search/facets.ts
@@ -149,9 +149,6 @@ export const resolvers = {
   Facet: {
     values: (facet: Facet, args: FacetValuesArgs) => {
       const { values } = facet
-      if (args.from === undefined) {
-        return values
-      }
       return values.slice(args.from ?? 0, args.to)
     },
     quantity: (facet: Facet) => {

--- a/node/resolvers/search/facets.ts
+++ b/node/resolvers/search/facets.ts
@@ -152,7 +152,7 @@ export const resolvers = {
       if (args.from === undefined) {
         return values
       }
-      return values.slice(args.from, args.to)
+      return values.slice(args.from ?? 0, args.to)
     },
     quantity: (facet: Facet) => {
       return facet.values.length || 0

--- a/node/resolvers/search/facets.ts
+++ b/node/resolvers/search/facets.ts
@@ -151,9 +151,8 @@ export const resolvers = {
       const { values } = facet
       if (args.from === undefined) {
         return values
-      } else {
-        return values.slice(args.from, args.to)
       }
+      return values.slice(args.from, args.to)
     },
     quantity: (facet: Facet) => {
       return facet.values.length || 0

--- a/node/resolvers/search/facets.ts
+++ b/node/resolvers/search/facets.ts
@@ -8,13 +8,6 @@ interface EitherFacet extends SearchFacet {
   Children?: EitherFacet[]
 }
 
-//This Type represents all kind of facets, from department, to categories, to brand and specifications
-interface GenericFacet extends SearchFacet {
-  NameWithTranslation?: string
-  Id?: string
-  Children?: GenericFacet
-}
-
 enum FilterType {
   TEXT = 'TEXT',
   NUMBER = 'NUMBER',
@@ -152,6 +145,19 @@ export const resolvers = {
     },
 
     name: formatTranslatableProp<SearchFacetCategory, 'Name', 'Id'>('Name', 'Id')
+  },
+  Facet: {
+    values: (facet: Facet, args: FacetValuesArgs) => {
+      const { values } = facet
+      if (args.from === undefined) {
+        return values
+      } else {
+        return values.slice(args.from, args.to)
+      }
+    },
+    quantity: (facet: Facet) => {
+      return facet.values.length || 0
+    }
   },
   Facets: {
     facets: async ({

--- a/node/typings/Filter.ts
+++ b/node/typings/Filter.ts
@@ -5,3 +5,20 @@ interface FilterListTreeCategoryById {
   isActive: boolean
   IsStockKeepingUnit: boolean
 }
+
+interface FacetValuesArgs {
+  from: number
+  to: number
+}
+
+//This Type represents all kind of facets, from department, to categories, to brand and specifications
+interface GenericFacet extends SearchFacet {
+  NameWithTranslation?: string
+  Id?: string
+  Children?: GenericFacet
+}
+
+interface Facet {
+  name: string,
+  values: GenericFacet[]
+}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds some changes necessary to make the store setting enableFiltersFetchOptimization work. This setting is responsible for truncating facets after the 10th one and making it possible to fetch the rest with a refetch.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Go to the workspace and then check on the graphql that in the FacetsV2 query the `from` value is 0 and `to` is 10 
![image](https://user-images.githubusercontent.com/8443580/94735403-14b38900-0341-11eb-8807-9bdffb44aa0d.png)
Then, on the `Color` filter, click on `show 4 more` and notice that the query was re-fetched, updating the results with every facet available!

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->

NEEDS 
https://github.com/vtex-apps/search-graphql/pull/94