### PR TITLE
[1.x] Use new feature of Search API to group SKUs in product recommendation shelves #107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use new feature of Search API to group SKUs in product recommendation shelves.
 
 ## [1.19.0] - 2020-10-06
 ### Added

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -187,7 +187,7 @@ export class Search extends AppClient {
     })
 
   public crossSelling = (id: string, type: SearchCrossSellingTypes) =>
-    this.get<SearchProduct[]>(`/pub/products/crossselling/${type}/${id}`, {
+    this.get<SearchProduct[]>(`/pub/products/crossselling/${type}/${id}?groupByProduct=true`, {
       metric: 'search-crossSelling',
     })
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5155,9 +5155,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.33.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.36.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.33.0/public#35bab67c525ded267cdef7dc3b045f05f83ab6fd"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.36.0/public#eecc3dee383eb1990fa2b8e0a2a30b99bba947c9"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

The Search API is returning the SKU as separate items in the product recommendation shelves. This new API feature groups them.

#### How should this be manually tested?

https://brenovtex--alssports.myvtex.com/patagn-bomber-jacket-retro-x-girls/p
https://vysk--nancymeyer.myvtex.com/simone-perele--wish-demi-cup-bra-bdm-12b330/p?utm_source=123
