### PR TITLE
Fix wrong category id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Noew getting last category from tree instead of first for product categoryId
+- Now getting last category from tree instead of first for product categoryId
 
 ## [1.20.1] - 2020-10-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Noew getting last category from tree instead of first for product categoryId
 
 ## [1.20.1] - 2020-10-08
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -67,7 +67,7 @@ export const convertBiggyProduct = async (
     description: product.description,
     items: skus,
     allSpecifications,
-    categoryId: product.categoryIds?.[0],
+    categoryId: product.categoryIds?.slice(-1)[0],
     productTitle: "",
     metaTagDescription: "",
     clusterHighlights: {},


### PR DESCRIPTION
#### What problem is this solving?

We were getting the first category from the tree instead of the last for the product categoryId

#### How should this be manually tested?

https://tornai--demostore.myvtex.com/admin/graphql-ide

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
