### PR TITLE
PER-1102: Add href and value.id to category facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `value.id` to category facets.
+- `href` to all facet values.
 
 ## [1.21.1] - 2020-10-09
 ### Changed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -359,18 +359,20 @@ export const queries = {
       )
     }
 
+    const breadcrumb = buildBreadcrumb(
+      result.attributes || [],
+      decodeURIComponent(args.fullText),
+      args.selectedFacets
+    )
+
     return {
-      facets: attributesToFilters({ ...result, account }),
+      facets: attributesToFilters({ ...result, account, breadcrumb }),
       queryArgs: {
         map: args.map,
         query: args.query,
         selectedFacets: args.selectedFacets,
       },
-      breadcrumb: buildBreadcrumb(
-        result.attributes || [],
-        decodeURIComponent(args.fullText),
-        args.selectedFacets
-      ),
+      breadcrumb,
     }
   },
 

--- a/node/utils/attributes.test.ts
+++ b/node/utils/attributes.test.ts
@@ -1,4 +1,4 @@
-import { attributesToFilters } from './attributes'
+import { attributesToFilters, buildHref } from './attributes'
 
 describe('attributesToFilters', () => {
   it('should convert a text attribute correctly', () => {
@@ -10,6 +10,7 @@ describe('attributesToFilters', () => {
             visible: true,
             values: [
               {
+                id: undefined,
                 count: 108,
                 active: false,
                 key: 'lions-pride',
@@ -21,6 +22,8 @@ describe('attributesToFilters', () => {
             type: 'text' as 'text',
           },
         ],
+        account: 'lions-pride',
+        breadcrumb: [],
       })
     ).toEqual([
       {
@@ -29,6 +32,8 @@ describe('attributesToFilters', () => {
         type: 'TEXT',
         values: [
           {
+            href: 'lions-pride?map=brand',
+            id: undefined,
             key: 'brand',
             name: 'Lions Pride',
             quantity: 108,
@@ -75,6 +80,8 @@ describe('attributesToFilters', () => {
             maxValue: 100,
           },
         ],
+        account: 'lions-pride',
+        breadcrumb: [],
       })
     ).toEqual([
       {
@@ -120,6 +127,8 @@ describe('attributesToFilters', () => {
             maxValue: 0,
           },
         ],
+        account: 'samsungbr',
+        breadcrumb: [],
       })
     ).toEqual([
       {
@@ -168,6 +177,8 @@ describe('attributesToFilters', () => {
             maxValue: 6533501.777013255,
           },
         ],
+        account: 'localizaseminovos',
+        breadcrumb: [],
       })
     ).toEqual([
       {
@@ -225,6 +236,8 @@ describe('attributesToFilters', () => {
             maxValue: 6533501.777013255,
           },
         ],
+        account: 'localizaseminovos',
+        breadcrumb: [],
       })
     ).toEqual([
       {
@@ -242,5 +255,18 @@ describe('attributesToFilters', () => {
         ],
       },
     ])
+  })
+})
+
+describe('buildHref', () => {
+  it('should create an href from nothing', () => {
+    expect(buildHref('', '', '')).toEqual('')
+    expect(buildHref('', 'hello', 'world')).toEqual('world?map=hello')
+  })
+
+  it('should create an href from existing base', () => {
+    expect(buildHref('hello?map=world', 'ola', 'mundo')).toEqual(
+      'hello/mundo?map=world,ola'
+    )
   })
 })

--- a/node/utils/attributes.test.ts
+++ b/node/utils/attributes.test.ts
@@ -85,21 +85,32 @@ describe('attributesToFilters', () => {
       })
     ).toEqual([
       {
-        hidden: false,
-        name: 'Price',
-        type: 'PRICERANGE',
         values: [
           {
+            quantity: 180,
+            name: '',
             key: 'price',
-            name: 'Price',
-            quantity: 367,
-            value: 'price',
-            range: {
-              from: 10,
-              to: 100,
-            },
+            selected: false,
+            range: { from: 10, to: 30 },
+          },
+          {
+            quantity: 90,
+            name: '',
+            key: 'price',
+            selected: false,
+            range: { from: 30, to: 50 },
+          },
+          {
+            quantity: 97,
+            name: '',
+            key: 'price',
+            selected: false,
+            range: { from: 50, to: 100 },
           },
         ],
+        type: 'PRICERANGE',
+        name: 'Price',
+        hidden: false,
       },
     ])
   })

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -1,4 +1,4 @@
-import { either, isEmpty, isNil, last } from 'ramda'
+import { either, isEmpty, isNil } from 'ramda'
 import unescape from 'unescape'
 
 type Attribute = (NumericalAttribute | TextAttribute) & {

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -83,7 +83,7 @@ export const attributesToFilters = ({
   }
 
   return attributes!.map(attribute => {
-    const baseHref = (last(breadcrumb) ?? { href: '', name: '' }).href
+    const baseHref = (breadcrumb[breadcrumb.length - 1] ?? { href: '', name: '' }).href
     const { type, values } = convertValues(attribute, total, account, baseHref)
 
     return {
@@ -246,13 +246,13 @@ export const buildHref = (
   key: string,
   value: string
 ): string => {
-  if (isEmpty(key) || isEmpty(value)) {
+  if (key === '' || value === '') {
     return baseHref
   }
 
   const [path = '', map = ''] = baseHref.split('?map=')
-  const pathValues = [...path.split('/'), value].filter(x => !isEmpty(x))
-  const mapValues = [...map.split(','), key].filter(x => !isEmpty(x))
+  const pathValues = [...path.split('/'), value].filter(x => x)
+  const mapValues = [...map.split(','), key].filter(x => x)
 
   return `${pathValues.join('/')}?map=${mapValues.join(',')}`
 }


### PR DESCRIPTION
#### What problem is this solving?

Adding `value.id` to category facets, and `href` to all facets.

This is a rebase #64 without the changes made to dependencies.

#### How should this be manually tested?

- Use this query on admin-graphql-ide:

```graphql
{
  facets(fullText: "specialized bike", selectedFacets: []) {
    facets {
      name
      values {
        id
        href
      }
    }
  }
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

- Without this PR:

![image](https://user-images.githubusercontent.com/34144667/95593634-510d7600-0a20-11eb-8459-7acaadb521fb.png)

- With this PR:

![image](https://user-images.githubusercontent.com/34144667/95593590-45ba4a80-0a20-11eb-9018-78a4015f29bc.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
