### PR TITLE
Uses groupId for specification group translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Uses groupId as the context for product specification groups
 
 ## [0.15.0] - 2020-10-08
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,13 @@
       "name": "vtex.catalog-api-proxy:authenticated-catalog-proxy"
     },
     {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "{{account}}.vtexcommercestable.com.br",
+        "path": "/api/catalog_system/*"
+      }
+    },
+    {
       "name": "vtex.rewriter:resolve-graphql"
     },
     {

--- a/node/__mocks__/helpers.ts
+++ b/node/__mocks__/helpers.ts
@@ -1,5 +1,9 @@
-const promisify = (obj: any) => {
+export const promisify = (obj: any) => {
   return new Promise(resolve => resolve(obj))
+}
+
+const catalogClientMock = {
+  skuStockKeepingUnitById: jest.fn(),
 }
 
 const searchClientMock = {
@@ -60,6 +64,7 @@ export const mockContext: any = {
     ...generateDeepCopy(initialCtxState),
   },
   clients: {
+    catalog: catalogClientMock,
     search: searchClientMock,
     segment: segmentClientMock,
     messagesGraphQL: messagesGraphQLClientMock,

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -1,0 +1,32 @@
+import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
+
+export interface SkuStockKeepingUnitByIdReponse {
+  'ProductSpecifications': {
+    "FieldGroupId": number,
+    "FieldGroupName": string
+  }[]
+}
+
+export class Catalog extends ExternalClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(
+      `http://${context.account}.vtexcommercestable.com.br/api/catalog_system`,
+      context,
+      {
+        ...(options ?? {}),
+        headers: {
+          ...(options?.headers ?? {}),
+          'Content-Type': 'application/json',
+          'VtexIdclientAutCookie': context.authToken,
+          'X-Vtex-Use-Https': 'true',
+        },
+      }
+    )
+  }
+
+  public skuStockKeepingUnitById (id: string | number) {
+    return this.http.get<SkuStockKeepingUnitByIdReponse>(`/pvt/sku/stockkeepingunitbyid/${id}`, {
+      metric: 'sku-stock-kepping-unit-by-id',
+    })
+  }
+}

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -3,6 +3,7 @@ import { IOClients } from '@vtex/api'
 import { Search } from './search'
 import { Checkout } from './checkout'
 import { Rewriter } from './rewriter'
+import { Catalog } from './catalog'
 
 export class Clients extends IOClients {
   public get search() {
@@ -13,5 +14,8 @@ export class Clients extends IOClients {
   }
   public get rewriter() {
     return this.getOrSet('rewriter', Rewriter)
+  }
+  public get catalog() {
+    return this.getOrSet('catalog', Catalog)
   }
 }

--- a/node/resolvers/search/product.test.ts
+++ b/node/resolvers/search/product.test.ts
@@ -1,5 +1,5 @@
 import { resolvers } from './product'
-import { mockContext, getBindingLocale, resetContext } from '../../__mocks__/helpers'
+import { mockContext, getBindingLocale, resetContext, promisify } from '../../__mocks__/helpers'
 import { getProduct } from '../../__mocks__/product'
 
 describe('tests related to product resolver', () => {
@@ -215,6 +215,19 @@ describe('tests related to product resolver', () => {
       })
     })
     test('specifications groups should have expected format and translated values', async () => {
+      mockContext.clients.catalog.skuStockKeepingUnitById.mockImplementationOnce((_id: string) => promisify({
+        'ProductSpecifications': [
+          {
+            "FieldGroupId": "1",
+            "FieldGroupName": "Tamanho"
+          },
+          {
+            "FieldGroupId": "2",
+            "FieldGroupName": "allSpecifications"
+          }
+          ],
+        })
+      )
       mockContext.vtex.locale = 'fr-FR'
       const product = getProduct()
       mockContext.clients.search.filtersInCategoryFromId.mockImplementationOnce(() => ([{
@@ -224,11 +237,11 @@ describe('tests related to product resolver', () => {
       const result = await resolvers.Product.specificationGroups(product as any, {}, mockContext as any)
 
       expect(result[0]).toMatchObject({
-        name: 'Tamanho (((16))) <<<pt-BR>>>',
+        name: 'Tamanho (((1))) <<<pt-BR>>>',
         specifications: [{ name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>', values: ["35 (((specification-Id))) <<<pt-BR>>>"] }]
       })
       expect(result[1]).toMatchObject({
-        name: 'allSpecifications (((16))) <<<pt-BR>>>',
+        name: 'allSpecifications (((2))) <<<pt-BR>>>',
         specifications: [{ name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>', values: ["35 (((specification-Id))) <<<pt-BR>>>"] }]
       })
     })

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -281,12 +281,13 @@ export const resolvers = {
         return noTranslationSpecificationGroups
       }
 
-      const filterIdFromNameMap = await getProductSpecificationGroupIdMap(sku.itemId, ctx)
+      const groupdNameIdMap = await getProductSpecificationGroupIdMap(sku.itemId, ctx)
+      const filterIdFromNameMap = await getProductFilterIdMap(product, ctx)
 
       const translatedGroups = noTranslationSpecificationGroups.map(group => {
         return {
           originalName: group.name,
-          name: addContextToTranslatableString({ content: group.name, context: filterIdFromNameMap[group.name] }, ctx),
+          name: addContextToTranslatableString({ content: group.name, context: groupdNameIdMap[group.name] }, ctx),
           specifications: group.specifications.map(addTranslationParamsToSpecification(filterIdFromNameMap, ctx))
         }
       })

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -85,7 +85,9 @@ const getProductSpecificationGroupIdMap = async (skuId: string | number, ctx: Co
   const filters = await catalog.skuStockKeepingUnitById(skuId).then(response => response.ProductSpecifications)
   const filterMapFromName = filters.reduce(
     (acc, curr) => {
-      acc[curr.FieldGroupName] = curr.FieldGroupId.toString()
+      if (curr.FieldGroupId && curr.FieldGroupName) {
+        acc[curr.FieldGroupName] = curr.FieldGroupId.toString()
+      }
       return acc
     },
     {} as Record<string, string>
@@ -274,10 +276,11 @@ export const resolvers = {
         })
       )
 
-      if (!shouldTranslateToUserLocale(ctx)) {
+      const sku = product.items[0]
+      if (!shouldTranslateToUserLocale(ctx) || !sku) {
         return noTranslationSpecificationGroups
       }
-      const sku = product.items[0]
+
       const filterIdFromNameMap = await getProductSpecificationGroupIdMap(sku.itemId, ctx)
 
       const translatedGroups = noTranslationSpecificationGroups.map(group => {


### PR DESCRIPTION
#### What problem is this solving?
Currently the context for the product's specification groups translation is the product id, this means the administrator will have to save the same translation for all products of a given cluster. This PR changes it to use the groupId, this will mean only one translation will be necessary. 

#### How should this be manually tested?

You can save a new group translation using the `translateGroup` api from `catalog-api` and see if the result is correct.

In this workspace the specification Group `Blocks` is being translated to `Blocks` (user translation) instead of `Blocs` (automatic translation)
https://fox--motorolacaen.myvtex.com/smartphones-motorola-one-vision/p?__bindingAddress=www.motorola.ca/fr

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
