### PR TITLE
Removed early return from building breadcrumb if text attribute was not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Removed early return from building breadcrumb if textAttribute was not visible
+
 ## [1.21.3] - 2020-10-13
 ### Fixed
 - Now getting last category from tree instead of first for product categoryId

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -477,10 +477,6 @@ export const buildBreadcrumb = (
       return
     }
 
-    if (!value.visible) {
-      return
-    }
-
     breadcrumb.push({
       name: unescape(value.label),
       href: `/${pivotValue.join('/')}?map=${pivotMap.join(',')}`,


### PR DESCRIPTION
#### What problem is this solving?

Now that the productCluster problem was solved, we didn't

#### How should this be manually tested?

https://tornai--dzarm.myvtex.com/outlet

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
