### PR TITLE
Filter visible specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Return only visible product specifications.
 
 ## [1.21.3] - 2020-10-13
 ### Fixed

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -54,6 +54,14 @@ export class Search extends AppClient {
     return url.concat(`&sc=${salesChannel}`)
   }
 
+  private addCompleteSpecifications = (url: string) => {
+    if (!url.includes('?')) {
+      return `${url}?compSpecs=true`
+    }
+
+    return `${url}&compSpecs=true`
+  }
+
   public constructor(ctx: IOContext, opts?: InstanceOptions) {
     super('vtex.catalog-api-proxy@0.x', ctx, opts)
 
@@ -74,13 +82,13 @@ export class Search extends AppClient {
 
   public product = (slug: string) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search/${this.searchEncodeURI(slug && slug.toLowerCase())}/p`,
+      this.addCompleteSpecifications(`/pub/products/search/${this.searchEncodeURI(slug && slug.toLowerCase())}/p`),
       { metric: 'search-product' }
     )
 
   public productByEan = (id: string) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?fq=alternateIds_Ean:${id}`,
+      this.addCompleteSpecifications(`/pub/products/search?fq=alternateIds_Ean:${id}`),
       {
         metric: 'search-productByEan',
       }
@@ -88,16 +96,21 @@ export class Search extends AppClient {
 
   public productsByEan = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      this.addSalesChannel(`/pub/products/search?${ids
-        .map(id => `fq=alternateIds_Ean:${id}`)
-        .join('&')}`, salesChannel),
+      this.addCompleteSpecifications(
+        this.addSalesChannel(`/pub/products/search?${ids
+          .map(id => `fq=alternateIds_Ean:${id}`)
+          .join('&')}`, salesChannel)
+      ),
       { metric: 'search-productByEan' }
     )
 
   public productById = (id: string, cacheable: boolean = true) => {
     const isVtex = this.context.platform === 'vtex'
-    const url = isVtex ? '/pub/products/search?fq=productId:' : '/products/'
-    return this.get<SearchProduct[]>(`${url}${id}`, {
+    const url = isVtex
+      ? this.addCompleteSpecifications(`/pub/products/search?fq=productId:${id}`)
+      : `/products/${id}`
+
+    return this.get<SearchProduct[]>(url, {
       metric: 'search-productById',
       ...(cacheable ? {} : { cacheable: CacheType.None })
     })
@@ -105,15 +118,17 @@ export class Search extends AppClient {
 
   public productsById = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      this.addSalesChannel(`/pub/products/search?${ids
-        .map(id => `fq=productId:${id}`)
-        .join('&')}`, salesChannel),
+      this.addCompleteSpecifications(
+        this.addSalesChannel(`/pub/products/search?${ids
+          .map(id => `fq=productId:${id}`)
+          .join('&')}`, salesChannel)
+      ),
       { metric: 'search-productById' }
     )
 
   public productByReference = (id: string) =>
     this.get<SearchProduct[]>(
-      `/pub/products/search?fq=alternateIds_RefId:${id}`,
+      this.addCompleteSpecifications(`/pub/products/search?fq=alternateIds_RefId:${id}`),
       {
         metric: 'search-productByReference',
       }
@@ -121,9 +136,11 @@ export class Search extends AppClient {
 
   public productsByReference = (ids: string[], salesChannel?: string | number) =>
     this.get<SearchProduct[]>(
-      this.addSalesChannel(`/pub/products/search?${ids
-        .map(id => `fq=alternateIds_RefId:${id}`)
-        .join('&')}`, salesChannel),
+      this.addCompleteSpecifications(
+        this.addSalesChannel(`/pub/products/search?${ids
+          .map(id => `fq=alternateIds_RefId:${id}`)
+          .join('&')}`, salesChannel)
+      ),
       { metric: 'search-productByReference' }
     )
 
@@ -272,6 +289,7 @@ export class Search extends AppClient {
     map = '',
     hideUnavailableItems = false,
     simulationBehavior = SimulationBehavior.DEFAULT,
+    completeSpecifications = true,
   }: SearchArgs) => {
     const sanitizedQuery = encodeURIComponent(
       this.searchEncodeURI(decodeURIComponent(query || '').trim())
@@ -310,6 +328,9 @@ export class Search extends AppClient {
     }
     if (simulationBehavior === SimulationBehavior.SKIP) {
       url += `&simulation=false`
+    }
+    if (completeSpecifications) {
+      url = this.addCompleteSpecifications(url)
     }
     return url
   }

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -127,12 +127,22 @@ export class Search extends AppClient {
       { metric: 'search-productByReference' }
     )
 
-  public productBySku = (skuIds: string[], salesChannel?: string | number) =>
+  public productBySku = (skuId: string) =>
     this.get<SearchProduct[]>(
-      this.addSalesChannel(`/pub/products/search?${skuIds
-        .map(skuId => `fq=skuId:${skuId}`)
-        .join('&')}`, salesChannel),
-      { metric: 'search-productBySku' }
+      this.addCompleteSpecifications(`/pub/products/search?fq=skuId:${skuId}`),
+      {
+        metric: 'search-productBySku',
+      }
+    )
+
+  public productsBySku = (skuIds: string[], salesChannel?: string | number) =>
+    this.get<SearchProduct[]>(
+      this.addCompleteSpecifications(
+        this.addSalesChannel(`/pub/products/search?${skuIds
+          .map(skuId => `fq=skuId:${skuId}`)
+          .join('&')}`, salesChannel)
+      ),
+      { metric: 'search-productsBySku' }
     )
 
   public productsRaw = (args: SearchArgs) => {

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -25,7 +25,7 @@ export const fieldResolvers = {
                 SKU_SEPARATOR
               )
               const discount = effectsParameters[index].value
-              const products = await search.productBySku(skuIds)
+              const products = await search.productsBySku(skuIds)
 
               return products.map((product: any) => {
                 const benefitSKUIds: any = []

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -407,7 +407,7 @@ export const queries = {
         products = await search.productByReference(value)
         break
       case 'sku':
-        products = await search.productBySku([value])
+        products = await search.productBySku(value)
         break
     }
 
@@ -464,7 +464,7 @@ export const queries = {
         products = await search.productsByReference(values, salesChannel)
         break
       case 'sku':
-        products = await search.productBySku(values, salesChannel)
+        products = await search.productsBySku(values, salesChannel)
         break
     }
 

--- a/node/resolvers/search/offer.ts
+++ b/node/resolvers/search/offer.ts
@@ -81,7 +81,7 @@ export const resolvers = {
         return []
       }
 
-      const catalogGiftProducts = await ctx.clients.search.productBySku(GiftSkuIds).catch(() => null)
+      const catalogGiftProducts = await ctx.clients.search.productsBySku(GiftSkuIds).catch(() => null)
 
       if (!catalogGiftProducts || catalogGiftProducts.length === 0) {
         return []

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -244,22 +244,37 @@ export const resolvers = {
 
     specificationGroups: async (product: SearchProduct, _: unknown, ctx: Context) => {
       const allSpecificationsGroups = (product.allSpecificationsGroups ?? []).concat(['allSpecifications'])
-      const noTranslationSpecificationGroups = allSpecificationsGroups.map(
-        (groupName: string) => ({
-          originalName: groupName,
-          name: groupName,
-          specifications: ((product as unknown as DynamicKey<string[]>)?.[groupName] ?? []).map(
-            (name: string) => {
-              const values = (product as unknown as DynamicKey<string[]>)[name] || []
-              return {
-                originalName: name,
-                name,
-                values,
+
+      const visibleSpecifications = product.completeSpecifications
+        ? product.completeSpecifications.reduce<Record<string, boolean>>((acc, specification) => {
+            acc[specification.Name] = specification.IsOnProductDetails
+            return acc
+          }, {})
+        : {}
+
+      let noTranslationSpecificationGroups = allSpecificationsGroups.map(
+        (groupName: string) => {
+          let groupSpecifications = (product as unknown as DynamicKey<string[]>)?.[groupName] ?? []
+
+          groupSpecifications = groupSpecifications.filter(specificationName => visibleSpecifications[specificationName])
+
+          return {
+            originalName: groupName,
+            name: groupName,
+            specifications: groupSpecifications.map((name) => {
+                const values = (product as unknown as DynamicKey<string[]>)[name] || []
+                return {
+                  originalName: name,
+                  name,
+                  values,
+                }
               }
-            }
-          ),
-        })
+            ),
+          }
+        }
       )
+
+      noTranslationSpecificationGroups = noTranslationSpecificationGroups.filter(group => group.specifications.length > 0)
 
       if (!shouldTranslateToUserLocale(ctx)) {
         return noTranslationSpecificationGroups

--- a/node/resolvers/search/sku.ts
+++ b/node/resolvers/search/sku.ts
@@ -43,7 +43,7 @@ export const resolvers = {
       !kitItems
         ? []
         : kitItems.map(async kitItem => {
-            const products = await search.productBySku([kitItem.itemId])
+            const products = await search.productBySku(kitItem.itemId)
             const { items: skus = [], ...product } = head(products) || {}
             const sku = find(({ itemId }) => itemId === kitItem.itemId, skus)
             return { ...kitItem, product, sku }

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -25,6 +25,7 @@ interface SearchArgs extends QueryArgs {
   to: number | null
   hideUnavailableItems: boolean | null
   simulationBehavior: 'skip' | 'default' | null
+  completeSpecifications: boolean
 }
 
 interface Metadata {
@@ -101,6 +102,7 @@ interface SearchProduct {
   Specifications?: string[]
   allSpecifications?: string[]
   allSpecificationsGroups?: string[]
+  completeSpecifications?: CompleteSpecification[]
   skuSpecifications?: SkuSpecification[]
 }
 
@@ -129,6 +131,18 @@ interface SearchItem {
     itemId: string
     amount: number
   }[]
+}
+
+interface CompleteSpecification {
+  Values: {
+    Id: string
+    Position: number
+    Value: string
+  }[]
+  Name: string
+  Position: number
+  IsOnProductDetails: boolean
+  FieldId: string
 }
 
 interface SearchItemExtended extends SearchItem {


### PR DESCRIPTION
#### What problem is this solving?

(**Tip for reviewers**: review commit by commit)

Remove specifications that have "Show Specification" not checked

<img src="https://user-images.githubusercontent.com/284515/96186545-f6898380-0f11-11eb-919f-213cb0249a15.png" width=620 />


#### How should this be manually tested?


Workspace | Production
---|---
[Link](https://brenovtex--marinbrasil.myvtex.com/cuba-de-embutir-tramontina-ceres-40-bl-em-aco-inox-acetinado-40-x-35-x-19-cm/p) | [Link](https://marinbrasil.myvtex.com/cuba-de-embutir-tramontina-ceres-40-bl-em-aco-inox-acetinado-40-x-35-x-19-cm/p)
![image](https://user-images.githubusercontent.com/284515/96188500-39992600-0f15-11eb-9135-7160a806440a.png) | ![image](https://user-images.githubusercontent.com/284515/96188534-4ae23280-0f15-11eb-8a14-231726fd2f27.png)


API using the query string `?compSpecs=true`:
https://marinbrasil.vtexcommercestable.com.br/api/catalog_system/pub/products/search/cuba-de-embutir-tramontina-ceres-40-bl-em-aco-inox-acetinado-40-x-35-x-19-cm/p?&compSpecs=true
![image](https://user-images.githubusercontent.com/284515/96188680-82e97580-0f15-11eb-87e0-0e002df11c9b.png)

