### PR TITLE
Revert product query with search product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed 
+
+- Revert `Products` query with biggy search
+
 ## [1.22.2] - 2020-10-26
 
 ## Fixed
+
 - Add `activeprivatesellers` to hiddenActiveValues
 
 ## [1.22.1] - 2020-10-21
+
 ### Fixed
 - Return only visible product specifications.
 
@@ -23,7 +29,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Products query to use biggy's search
 
 ## [1.21.5] - 2020-10-16
-
 ### Fixed
 - Filter trade-policy and private-seller from appearing on breadcrumb
 

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -384,7 +384,7 @@ const convertSKU = (
  * @param {OrderBy} orderBy VTEX OrderBy.
  * @returns {string} Biggy's sort.
  */
-export const convertOrderBy = (orderBy?: string | null): string => {
+export const convertOrderBy = (orderBy?: string): string => {
   switch (orderBy) {
     case 'OrderByPriceDESC':
       return 'price:desc'


### PR DESCRIPTION
#### What problem is this solving?
reverting the products search changes because a specific type of query it's not working on biggy's search 
example: https://marinbrasil.myvtex.com/ 
on marinbrasil account the shelfs `queridinhos` it's not working. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://ullayne--marinbrasil.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/20619554/97182419-44f11a80-177b-11eb-8501-1f6ecab1ed24.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
