### PR TITLE
Add activeprivatesellers to hiddenActiveValues too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+- Add `activeprivatesellers` to hiddenActiveValues
+
 ## [1.22.1] - 2020-10-21
 ### Fixed
 - Return only visible product specifications.

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -456,7 +456,8 @@ export const buildBreadcrumb = (
       : 1
   )
 
-  activeValues.filter(x => x.key.toLowerCase() !== "trade-policy" && x.key.toLowerCase() !== "private-seller").forEach(value => {
+  const hiddenActiveValues = ["trade-policy", "private-seller", "activeprivatesellers"]
+  activeValues.filter(x => !hiddenActiveValues.includes(x.attributeKey.toLowerCase())).forEach(value => {
     pivotValue.push(value.key)
     pivotMap.push(value.attributeKey)
 


### PR DESCRIPTION
#### What problem is this solving?

activePrivateSellers field was showing in breadcrumbs after we did some changes and it started apprearing.

#### How should this be manually tested?

bad breadcrumb
https://modeloramanow.myvtex.com/cervezas/

good breadcrumb
https://tornai--modeloramanow.myvtex.com/cervezas/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
