### PR TITLE
Fix titleTag for collections, brand and category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- SearchMetadata for category, brand and collection.
 
 ## [0.16.3] - 2020-12-07
 ### Fixed

--- a/node/resolvers/search/modules/metadata.ts
+++ b/node/resolvers/search/modules/metadata.ts
@@ -124,7 +124,8 @@ const getClusterMetadata = async (
     from: null,
     to: null,
     hideUnavailableItems: null,
-    simulationBehavior: null
+    simulationBehavior: null,
+    completeSpecifications: false,
   })
 
   const clusterId = head(args.query?.split(',') ?? [])

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
the `titleTag` was not returned for `productClusterIds`, and the function to get the `titleTag` from category and brand did not consider the maps `category` and `brand`, only `c` and `b`.

#### How should this be manually tested?

[Before](https://titletest--acctglobal.myvtex.com/141?map=productClusterIds)
[Workspace](https://testedecodeuri--acctglobal.myvtex.com/141?map=productClusterIds)

#### Screenshots or example usage

**Before:**

![image](https://user-images.githubusercontent.com/20840671/97448608-992d0380-190f-11eb-8a5f-c242b20caf70.png)

![image](https://user-images.githubusercontent.com/20840671/97448866-dbeedb80-190f-11eb-84ec-eec16c817429.png)

![image](https://user-images.githubusercontent.com/20840671/97448904-e5784380-190f-11eb-8588-64faa373c369.png)

**After:**

![image](https://user-images.githubusercontent.com/20840671/97449186-2d976600-1910-11eb-9b6e-befc3edfd077.png)

![image](https://user-images.githubusercontent.com/20840671/97449320-4bfd6180-1910-11eb-82f7-b962bd33eabd.png)

![image](https://user-images.githubusercontent.com/20840671/97449370-5ae41400-1910-11eb-8493-2d5b02d0e541.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
