### PR TITLE
Fix titleTag for collections, brand and category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- SearchMetadata for category, brand and collection.
+
 ## [1.28.4] - 2020-12-07
 
 ### Fixed

--- a/node/resolvers/search/modules/metadata.ts
+++ b/node/resolvers/search/modules/metadata.ts
@@ -2,7 +2,6 @@ import {
   tail,
   head,
   compose,
-  equals,
   prop,
   join,
   map,
@@ -22,10 +21,7 @@ import { formatTranslatableProp, translateManyToCurrentLanguage, Message, should
 
 type TupleString = [string, string]
 
-const isTupleMap = compose<TupleString, string, boolean>(
-  equals('c'),
-  prop('1')
-)
+const isTupleMap = (t: TupleString) => t[1] ? (t[1] === 'c' || t[1] === 'category') : false
 
 const getLastCategoryIndex = findLastIndex(isTupleMap)
 
@@ -105,17 +101,65 @@ export const getSpecificationFilterName = (name: string) => {
   return toTitleCase(searchDecodeURI(decodeURI(name)))
 }
 
+const getClusterMetadata = async (
+  args: SearchMetadataArgs,
+  ctx: Context,
+): Promise<SearchMetadata> => {
+  const {
+    clients: { search }
+  } = ctx
+
+  const searchArgs: SearchArgs = Object.assign({}, {
+    query: args.query ?? "",
+    map: args.map ?? "",
+    selectedFacets: args.selectedFacets
+  }, {
+    category: null,
+    specificationFilters: null,
+    collection: null,
+    salesChannel: null,
+    orderBy: null,
+    from: null,
+    to: null,
+    hideUnavailableItems: null,
+    simulationBehavior: null,
+    completeSpecifications: false,
+  })
+
+  const clusterId = head(args.query?.split(',') ?? [])
+  const products = await search.products(searchArgs)
+  const productWithCluster = products?.find(
+    ({ productClusters }) => !!productClusters[clusterId]
+  )
+  const clusterName = (productWithCluster && productWithCluster.productClusters[clusterId]) || ""
+
+  try {
+    return {
+      titleTag: decodeURI(clusterName),
+      metaTagDescription: null,
+    }
+  } catch {
+    return {
+      titleTag: clusterName,
+      metaTagDescription: null,
+    }
+  }
+}
+
 const getPrimaryMetadata = (
   args: SearchMetadataArgs,
   ctx: Context
 ): Promise<SearchMetadata> | SearchMetadata => {
   const map = args.map || ''
   const firstMap = head(map.split(','))
-  if (firstMap === 'c') {
+  if (firstMap === 'c' || firstMap === 'category') {
     return getCategoryMetadata(args, ctx)
   }
-  if (firstMap === 'b') {
+  if (firstMap === 'b' || firstMap === 'brand') {
     return getBrandMetadata(args.query, ctx)
+  }
+  if (firstMap === 'productClusterIds') {
+    return getClusterMetadata(args, ctx)
   }
   if (firstMap && firstMap.includes('specificationFilter')) {
     const cleanQuery = args.query || ''
@@ -155,7 +199,7 @@ const getNameForRemainingMaps = async (
           return pagetype.name
         }
       }
-      if (map === 'b' && !isGC) {
+      if ((map === 'b' || map === 'brand') && !isGC) {
         const brand = await search.pageType(decodeURI(query), 'map=b').catch(() => null)
         if (brand) {
           return brand.name
@@ -218,6 +262,7 @@ export const getSearchMetaData = async (
   const validTuples = tailTuples.filter(
     ([_, m]) =>
       m === 'b' ||
+      m === 'brand' ||
       m.includes('specificationFilter') ||
       (m === 'c' && !isFirstCategory)
   )

--- a/node/resolvers/search/modules/metadata.ts
+++ b/node/resolvers/search/modules/metadata.ts
@@ -21,7 +21,9 @@ import { formatTranslatableProp, translateManyToCurrentLanguage, Message, should
 
 type TupleString = [string, string]
 
-const isTupleMap = (t: TupleString) => t[1] ? (t[1] === 'c' || t[1] === 'category') : false
+const categoryKeys = ['c', 'category', 'category-1', 'category-2', 'category-3']
+
+const isTupleMap = (t: TupleString) => t[1] ? categoryKeys.includes(t[1]) : false
 
 const getLastCategoryIndex = findLastIndex(isTupleMap)
 
@@ -152,7 +154,7 @@ const getPrimaryMetadata = (
 ): Promise<SearchMetadata> | SearchMetadata => {
   const map = args.map || ''
   const firstMap = head(map.split(','))
-  if (firstMap === 'c' || firstMap === 'category') {
+  if (categoryKeys.includes(firstMap)) {
     return getCategoryMetadata(args, ctx)
   }
   if (firstMap === 'b' || firstMap === 'brand') {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
the `titleTag` was not returned for `productClusterIds`, and the function to get the `titleTag` from category and brand did not consider the maps `category` and `brand`, only `c` and `b`.

#### How should this be manually tested?

[Before](https://titletest--acctglobal.myvtex.com/141?map=productClusterIds)
[Workspace](https://testedecodeuri--acctglobal.myvtex.com/141?map=productClusterIds)
[alssports](https://thalyta--alssports.myvtex.com/clothing/jackets/Mens?map=c,c,specificationFilter_7721)

#### Screenshots or example usage

**Before:**

![image](https://user-images.githubusercontent.com/20840671/97448608-992d0380-190f-11eb-8a5f-c242b20caf70.png)

![image](https://user-images.githubusercontent.com/20840671/97448866-dbeedb80-190f-11eb-84ec-eec16c817429.png)

![image](https://user-images.githubusercontent.com/20840671/97448904-e5784380-190f-11eb-8588-64faa373c369.png)

**After:**

![image](https://user-images.githubusercontent.com/20840671/97449186-2d976600-1910-11eb-9b6e-befc3edfd077.png)

![image](https://user-images.githubusercontent.com/20840671/97449320-4bfd6180-1910-11eb-82f7-b962bd33eabd.png)

![image](https://user-images.githubusercontent.com/20840671/97449370-5ae41400-1910-11eb-8493-2d5b02d0e541.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
