### PR TITLE
PER-1340: Change how resolver handles numerical facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Always return `range` for numeric facets.
+- Show `maxValue` and `minValue` instead of `*` for bucket numeric facets.
+
 ## [1.23.0] - 2020-10-29
 
 ### Changed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -325,7 +325,7 @@ export const queries = {
 
     const {
       clients: { biggySearch, search, checkout, vbase },
-      vtex: { segment, account },
+      vtex: { segment },
     } = ctx
 
     const sellers = await getSellers(vbase, checkout, segment?.channel ,segment?.regionId)
@@ -366,7 +366,7 @@ export const queries = {
     )
 
     return {
-      facets: attributesToFilters({ ...result, account, breadcrumb }),
+      facets: attributesToFilters({ ...result, breadcrumb }),
       queryArgs: {
         map: args.map,
         query: args.query,

--- a/node/utils/attributes.test.ts
+++ b/node/utils/attributes.test.ts
@@ -22,7 +22,6 @@ describe('attributesToFilters', () => {
             type: 'text' as 'text',
           },
         ],
-        account: 'lions-pride',
         breadcrumb: [],
       })
     ).toEqual([
@@ -80,7 +79,6 @@ describe('attributesToFilters', () => {
             maxValue: 100,
           },
         ],
-        account: 'lions-pride',
         breadcrumb: [],
       })
     ).toEqual([
@@ -138,7 +136,6 @@ describe('attributesToFilters', () => {
             maxValue: 0,
           },
         ],
-        account: 'samsungbr',
         breadcrumb: [],
       })
     ).toEqual([
@@ -149,10 +146,14 @@ describe('attributesToFilters', () => {
         values: [
           {
             key: 'polegadas',
-            name: '0 - *',
+            name: '0 - 0',
             quantity: 13,
             selected: false,
-            value: '0:*',
+            value: '0:0',
+            range: {
+              from: 0,
+              to: 0,
+            },
           },
         ],
       },
@@ -188,7 +189,6 @@ describe('attributesToFilters', () => {
             maxValue: 6533501.777013255,
           },
         ],
-        account: 'localizaseminovos',
         breadcrumb: [],
       })
     ).toEqual([
@@ -203,6 +203,10 @@ describe('attributesToFilters', () => {
             quantity: 71,
             selected: false,
             value: 'l:0:5505580',
+            range: {
+              from: 0,
+              to: 5505580,
+            },
           },
           {
             key: 'location',
@@ -210,6 +214,10 @@ describe('attributesToFilters', () => {
             quantity: 53,
             selected: false,
             value: 'l:0:4477620',
+            range: {
+              from: 0,
+              to: 4477620,
+            },
           },
         ],
       },
@@ -247,7 +255,6 @@ describe('attributesToFilters', () => {
             maxValue: 6533501.777013255,
           },
         ],
-        account: 'localizaseminovos',
         breadcrumb: [],
       })
     ).toEqual([
@@ -262,6 +269,10 @@ describe('attributesToFilters', () => {
             quantity: 124,
             selected: true,
             value: 'l:0:3605120',
+            range: {
+              from: 2421698.143072009,
+              to: 6533501.777013255,
+            },
           },
         ],
       },


### PR DESCRIPTION
#### What problem is this solving?

Return both bucket configuration and range configuration, accommodating both use cases without hardcoding an `accountName`.

Also instead of showing `*` on bucket facet names, use `minValue` and `maxValue`.

#### How should this be manually tested?

*Slider:* 
https://christian--localizaseminovos.myvtex.com/15932:60282/seminovo/toyota?map=quilometragem,tipo,ft&order=OrderByPriceASC
https://localizaseminovos.myvtex.com/15932:60282/seminovo/toyota?map=quilometragem,tipo,ft&order=OrderByPriceASC

*Bucket:*
https://christian--samsungbr.myvtex.com/tv-e-audio?order=OrderByPriceDESC
https://samsungbr.myvtex.com/tv-e-audio?order=OrderByPriceDESC

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/34144667/97638586-a20afb80-1a1b-11eb-806d-76cb2d1507f6.png)
![image](https://user-images.githubusercontent.com/34144667/97638594-a800dc80-1a1b-11eb-9678-13709cd979c0.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
