### PR TITLE
add hideUnavailableItems field to the products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `hideUnavailableItems` field to the `products` query.
+
 ## [1.24.0] - 2020-11-11
 
 ### Added

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -468,7 +468,7 @@ export const queries = {
       clients: { biggySearch, vbase, checkout },
       vtex: { segment }
     } = ctx
-    const { query, to, from, orderBy, simulationBehavior } = args
+    const { query, to, from, orderBy, simulationBehavior, hideUnavailableItems } = args
 
     if (to && to > 2500) {
       throw new UserInputError(
@@ -486,7 +486,8 @@ export const queries = {
       tradePolicy: segment && segment.channel,
       query: query,
       sellers: sellers,
-      sort: convertOrderBy(orderBy)
+      sort: convertOrderBy(orderBy),
+      hideUnavailableItems,
     }
 
     if (to !== null && from !== null) {

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -38,7 +38,7 @@ interface SearchResultArgs {
   fullText: string
   searchState?: string
   sellers?: RegionSeller[]
-  hideUnavailableItems?: boolean
+  hideUnavailableItems?: boolean | null
 }
 
 interface RegionSeller {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Currently, the hideUnavailable times only work on the producSearch and facets query. This Pr adds this field to the products query, as well.

#### How should this be manually tested?

[Workspace](https://hiago--dzarm.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

