### PR TITLE
PER-1460 Fix price with simulationBehavior default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Price` when `simulationBehavior` is `default`.
+
 ## [1.27.0] - 2020-11-16
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -156,12 +156,14 @@ const fillSearchItemWithSimulation = (searchItem: SearchItem, orderFormItems: Or
         console.warn(`Product ${searchItem.itemId} is unavailable for seller ${seller.sellerId}`)
         return
       }
+      const unitMultiplier = orderFormItem.unitMultiplier ? orderFormItem.unitMultiplier : 1
+      const { listPrice, price, priceValidUntil, sellingPrice } = orderFormItem
 
       seller.commertialOffer.AvailableQuantity = orderFormItem?.availability === 'available' ? 10000 : 0
-      seller.commertialOffer.Price = orderFormItem.sellingPrice ? orderFormItem.sellingPrice / 100 : orderFormItem.price / 100
-      seller.commertialOffer.PriceValidUntil = orderFormItem.priceValidUntil
-      seller.commertialOffer.ListPrice = orderFormItem.listPrice / 100
-      seller.commertialOffer.PriceWithoutDiscount = orderFormItem.price / 100
+      seller.commertialOffer.Price = sellingPrice ? sellingPrice / (unitMultiplier * 100) : price / 100
+      seller.commertialOffer.PriceValidUntil = priceValidUntil
+      seller.commertialOffer.ListPrice = listPrice / 100
+      seller.commertialOffer.PriceWithoutDiscount = price / 100
 
       const installmentOptions = orderFormItem?.paymentData?.installmentOptions || []
 


### PR DESCRIPTION
#### What problem is this solving?
the price that comes from the simulation is the price multiplied by the `unitMultiplier`, and therefore is different from the price that comes from the catalog. we need to divide the value that comes from the simulation by the `unitMultiplier` to get the original price.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://vtexsearch--jumbo.myvtex.com/admin/graphql-ide)


#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/20840671/98972927-ddb0c580-24f1-11eb-9976-75d58c27f100.png)

Catalog response:
![image](https://user-images.githubusercontent.com/20840671/98973001-f325ef80-24f1-11eb-9cc6-121e9dafc94c.png)


After:
![image](https://user-images.githubusercontent.com/20840671/98972828-bd810680-24f1-11eb-9567-0c7d77c90eb0.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
