### PR TITLE
PER-1324: Add language for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- `language` for queries.
+
 ### Changed
 - Increase maxReplicas to 150.
 

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -25,17 +25,22 @@ const buildBSearchFilterCookie = (sellers?: RegionSeller[]) =>
 
 export class BiggySearchClient extends ExternalClient {
   private store: string
+  private language: string | undefined
 
   public constructor(context: IOContext, options?: InstanceOptions) {
     super('http://search.biggylabs.com.br/search-api/v1/', context, options)
 
-    const { account } = context
+    const { account, locale, tenant } = context
     this.store = account
+    this.language = locale ?? tenant?.locale
   }
 
   public async topSearches(): Promise<any> {
     const result = await this.http.get(`${this.store}/api/top_searches`, {
       metric: 'top-searches',
+      params: {
+        language: this.language,
+      }
     })
 
     return result
@@ -49,6 +54,7 @@ export class BiggySearchClient extends ExternalClient {
       {
         params: {
           term: decodeURIComponent(term),
+          language: this.language,
         },
         metric: 'suggestion-searches',
       }
@@ -90,6 +96,9 @@ export class BiggySearchClient extends ExternalClient {
       },
       {
         metric: 'suggestion-products',
+        params: {
+          language: this.language,
+        },
         headers: {
           Cookie: buildBSearchFilterCookie(sellers),
           "X-VTEX-IS-ID": `${this.store}`,
@@ -124,6 +133,7 @@ export class BiggySearchClient extends ExternalClient {
         sort,
         operator,
         fuzzy,
+        language: this.language,
         bgy_leap: leap ? true : undefined,
         ...parseState(searchState),
       },
@@ -164,6 +174,7 @@ export class BiggySearchClient extends ExternalClient {
         sort,
         operator,
         fuzzy,
+        language: this.language,
         bgy_leap: leap ? true : undefined,
         ['hide-unavailable-items']: hideUnavailableItems ? 'true' : 'false',
         ...parseState(searchState),
@@ -223,6 +234,7 @@ export class BiggySearchClient extends ExternalClient {
         sort,
         operator,
         fuzzy,
+        language: this.language,
         bgy_leap: leap ? true : undefined,
         ['hide-unavailable-items']: hideUnavailableItems ? 'true' : 'false',
         ...parseState(searchState),
@@ -247,6 +259,7 @@ export class BiggySearchClient extends ExternalClient {
     const result = await this.http.getRaw(url, {
       params: {
         query: decodeURIComponent(fullText),
+        language: this.language,
       },
       metric: 'search-result',
     })
@@ -266,6 +279,7 @@ export class BiggySearchClient extends ExternalClient {
       {
         params: {
           term: decodeURIComponent(fullText),
+          language: this.language,
         },
         metric: 'search-autocomplete-suggestions',
       }
@@ -282,6 +296,7 @@ export class BiggySearchClient extends ExternalClient {
     const result = await this.http.getRaw(url, {
       params: {
         query: decodeURIComponent(fullText),
+        language: this.language,
       },
       metric: 'search-correction',
     })
@@ -299,6 +314,7 @@ export class BiggySearchClient extends ExternalClient {
     const result = await this.http.getRaw(url, {
       params: {
         query: decodeURIComponent(fullText),
+        language: this.language,
       },
       metric: 'search-suggestions',
     })


### PR DESCRIPTION
#### What problem is this solving?
Add language to queries to allow the API to return translated results.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--ironeuropa.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
