### PR TITLE
Add hideUnavailableItems to productSuggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `hideUnavailableItems` to the `productSuggestions` query.
+
 ## [1.32.2] - 2021-01-28
 
 ### Changed

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -110,7 +110,8 @@ export class BiggySearchClient extends ExternalClient {
       facetValue: attributeValue,
       tradePolicy,
       indexingType,
-      sellers
+      sellers,
+      hideUnavailableItems = false,
     } = args
     const attributes: { key: string; value: string }[] = []
 
@@ -138,6 +139,7 @@ export class BiggySearchClient extends ExternalClient {
         metric: 'suggestion-products',
         params: {
           locale: this.locale,
+          ['hide-unavailable-items']: hideUnavailableItems ?? false,
         },
         headers: {
           Cookie: buildBSearchFilterCookie(sellers),

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.9.7",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://hideunavailable--checkoutio.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.38.0+build1611934674/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.39.0/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",
@@ -55,10 +55,10 @@
     "typemoq": "^2.1.0",
     "vtex.catalog-api-proxy": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.catalog-api-proxy@0.10.1/public/_types/react",
     "vtex.messages": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.61.0/public/@types/vtex.messages",
-    "vtex.rewriter": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.52.1/public/@types/vtex.rewriter",
-    "vtex.sae-analytics": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.2.0/public/@types/vtex.sae-analytics",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.37.0/public/@types/vtex.search-graphql",
-    "vtex.search-resolver": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.29.0/public/_types/react"
+    "vtex.rewriter": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.53.0/public/@types/vtex.rewriter",
+    "vtex.sae-analytics": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.4.0/public/@types/vtex.sae-analytics",
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.39.0/public/@types/vtex.search-graphql",
+    "vtex.search-resolver": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.32.2/public/_types/react"
   },
   "version": "1.32.2"
 }

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "slugify": "^1.2.6",
     "typescript": "3.9.7",
     "unescape": "^1.0.1",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.37.0/public"
+    "vtex.search-graphql": "http://hideunavailable--checkoutio.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.38.0+build1611934674/public"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.37.1",
+    "@vtex/api": "6.39.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -56,6 +56,7 @@ interface SuggestionProductsArgs {
   productOriginVtex: boolean
   simulationBehavior: 'skip' | 'default' | null
   sellers?: RegionSeller[]
+  hideUnavailableItems?: boolean | null
 }
 
 interface SuggestionSearchesArgs {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.37.1":
-  version "6.37.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
-  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
+"@vtex/api@6.39.0":
+  version "6.39.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.0.tgz#5f5b6c54713f4e3c6671d86feb3faec543b449f2"
+  integrity sha512-YoHLnMb0V2LMxoXQgIskbsHNkG/TprXjsE60RItHNjALx2b6/+gYFLSa8x/sJp+O6OJQQT3pSkFT7Ff5A8ER9g==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5163,21 +5163,21 @@ verror@1.10.0:
   version "1.61.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.61.0/public/@types/vtex.messages#9f539aa5e98ad8024b2b92e7218c2ae5a1a59a94"
 
-"vtex.rewriter@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.52.1/public/@types/vtex.rewriter":
-  version "1.52.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.52.1/public/@types/vtex.rewriter#c7e856428a22957c295e6ea76ae9997ff32e80a2"
+"vtex.rewriter@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.53.0/public/@types/vtex.rewriter":
+  version "1.53.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.53.0/public/@types/vtex.rewriter#90aa934f19138cf65adb554117183d2dbf5103ef"
 
-"vtex.sae-analytics@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.2.0/public/@types/vtex.sae-analytics":
-  version "2.2.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.2.0/public/@types/vtex.sae-analytics#7b3036d420f796f6bb4d95091606eb0cb5de71c2"
+"vtex.sae-analytics@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.4.0/public/@types/vtex.sae-analytics":
+  version "2.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.4.0/public/@types/vtex.sae-analytics#6577d7d735b5bf0e05cceb0357080cf4f733703e"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.37.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.39.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.37.0/public#2347dd9f5b9fb375e306df3e9fe364a95b071798"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.39.0/public#5c4b5d473526833769ea5d94df5d5b6add6bff9d"
 
-"vtex.search-resolver@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.29.0/public/_types/react":
+"vtex.search-resolver@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.32.2/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.29.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.32.2/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://hideunavailable--checkoutio.myvtex.com/utmi?_q=utmi&map=ft)
- Type `utmi` in the autocomplete (which is an unavailable product)
- the product should not appear in the autocomplete suggestions


#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/20840671/106312166-03be4a00-6245-11eb-9e25-54bf0cd695b7.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
