### PR TITLE
Add skuSpecifications prop to the product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `skuSpecifications` prop to the product.
+
 ## [1.30.2] - 2021-01-14
 
 ### Fixed

--- a/node/resolvers/search/skuSpecificationField.ts
+++ b/node/resolvers/search/skuSpecificationField.ts
@@ -1,12 +1,13 @@
 import { addContextToTranslatableString } from '../../utils/i18n'
 
+// if it has `originalName`, the specification is already coming from the API in the appropriate format and language
 export const resolvers = {
   SKUSpecificationField: {
     originalName: (value: SKUSpecificationField) => {
-      return value.name
+      return value.originalName ? value.originalName : value.name
     },
     name: (field: SKUSpecificationField, _: any, ctx: Context) => {
-      return addContextToTranslatableString(
+      return field.originalName ? field.name : addContextToTranslatableString(
         {
           content: field.name,
           context: field.id

--- a/node/resolvers/search/skuSpecificationField.ts
+++ b/node/resolvers/search/skuSpecificationField.ts
@@ -1,6 +1,6 @@
 import { addContextToTranslatableString } from '../../utils/i18n'
 
-// if it has `originalName`, the specification is already coming from the API in the appropriate format and language
+// if it has `originalName`, the specification is already coming in the appropriate format and language
 export const resolvers = {
   SKUSpecificationField: {
     originalName: (value: SKUSpecificationField) => {

--- a/node/resolvers/search/skuSpecificationValue.ts
+++ b/node/resolvers/search/skuSpecificationValue.ts
@@ -1,6 +1,6 @@
 import { addContextToTranslatableString } from '../../utils/i18n'
 
-// if it has `originalName`, the specification is already coming from the API in the appropriate format and language
+// if it has `originalName`, the specification is already coming in the appropriate format and language
 export const resolvers = {
   SKUSpecificationValue: {
     originalName: (value: SKUSpecificationValue) => {

--- a/node/resolvers/search/skuSpecificationValue.ts
+++ b/node/resolvers/search/skuSpecificationValue.ts
@@ -1,12 +1,13 @@
 import { addContextToTranslatableString } from '../../utils/i18n'
 
+// if it has `originalName`, the specification is already coming from the API in the appropriate format and language
 export const resolvers = {
   SKUSpecificationValue: {
     originalName: (value: SKUSpecificationValue) => {
-      return value.name
+      return  value.originalName ? value.originalName : value.name
     },
     name: (value: SKUSpecificationValue, _: any, ctx: Context) => {
-      return addContextToTranslatableString(
+      return value.originalName ? value.name : addContextToTranslatableString(
         {
           content: value.name,
           context: value.fieldId

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -156,13 +156,15 @@ interface SkuSpecification {
 
 interface SKUSpecificationField {
   name: string,
-  id: string
+  originalName?: string,
+  id?: string
 }
 
 interface SKUSpecificationValue {
   name: string
-  id: string
-  fieldId: string
+  id?: string
+  fieldId?: string
+  originalName?: string
 }
 
 interface SearchImage {

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -211,6 +211,9 @@ interface BiggyTextAttribute {
   isFilter: boolean
   id: string
   valueId: string
+  isSku: boolean
+  joinedKey: string
+  joinedValue: string
 }
 
 interface BiggyCategoryTree {


### PR DESCRIPTION
#### What problem is this solving?

Currently, the search-resolver 1.x doesn't send the `skuSpecifications` information on the product, so the SKU Selector is builded based on the `variations` prop of the items. 
However, with multilanguage, these variations only have the translated information, thus losing the original names of the attributes to be displayed, which can cause unexpected behavior:
![image](https://user-images.githubusercontent.com/20840671/104940648-cf1ed880-5990-11eb-9cfb-1b01fc053aef.png)

This PR fixes the SKU Selector for multilanguage stores, sending the `skuSpecifications` with property values in the original language and translated ✨ 

#### How should this be manually tested?

[Before](https://skuselector--muji.myvtex.com/gel%20pen?__bindingAddress=www.mujionline.eu/fi&_q=gel%20pen&map=ft)
[After](https://multilanguage--muji.myvtex.com/gel%20pen?__bindingAddress=www.mujionline.eu/fi&_q=gel%20pen&map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Before:

![image](https://user-images.githubusercontent.com/20840671/104941318-ae0ab780-5991-11eb-94ba-eb0c6b94cd97.png)

After

![image](https://user-images.githubusercontent.com/20840671/104941342-b7941f80-5991-11eb-8496-50e2f2253f04.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
