### PR TITLE
Sort products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Sorts to specified product order when querying `"fullText":"product:78;90;356"`
 
 ## [1.31.1] - 2021-01-18
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "search-resolver",
-  "version": "1.31.1",
+  "version": "1.32.0-beta.0",
   "title": "GraphQL resolver for the VTEX store APIs",
   "description": "GraphQL resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What problem is this solving?
When we make a `productSearch` with the variable `fullText` containing a value like: 
```
"fullText":"product:78;90;356"
```

We should receive the products in THIS specific order. This PR implements a o(n) counting sort like algorithm to sort products and return them in the specified order

This could be eventually moved to the search API

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Use the following curl and change the product orders. Verify that the return respects the input

```
curl --location -g --request GET 'https://beta--btglobal.myvtex.com/graphql/?operationName=SearchQuery&extensions=%7B%22persistedQuery%22%3A%7B%22sha256Hash%22%3A%222a98ddd90399920528a52bee471806486cb577a1ecf5e0e4133f277e532158e1%22}}&variables={%22orderBy%22:%22%22,%22selectedFacets%22:[{%22key%22:%22c%22,%22value%22:%22bath-and-body%22},{%22key%22:%22c%22,%22value%22:%22moisturizers%22}],%22fullText%22:%22product:78;90;356%22,%22query%22:%22bath-and-body/moisturizers%22,%22map%22:%22c,c%22,%22from%22:0,%22to%22:2}' \
--header 'authority: preview-4--btglobal.vtex.app' \
--header 'pragma: no-cache' \
--header 'cache-control: no-cache' \
--header 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36' \
--header 'x-vtex-graphql-referer: preview-4--btglobal.vtex.app' \
--header 'accept: */*' \
--header 'sec-fetch-site: same-origin' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-dest: empty' \
--header 'referer: https://preview-4--btglobal.vtex.app/bath-and-body/moisturizers' \
--header 'accept-language: en-US,en;q=0.9,pt;q=0.8,fr;q=0.7,it;q=0.6,es;q=0.5' \
--header 'cookie: VtexRCMacIdv7=1d7566a0-205e-11eb-b4de-47e7f90be60a; _gcl_au=1.1.921870553.1604689264; _ga=GA1.2.1037428866.1604689264; VtexFingerPrint=c73918e2916fa4c21d01bf36202fc0f7; cto_bundle=NTm4dF85Y3V0bmFmQWhwOTh4ZW1CcHpWRnNUb0k4R2NVcU8lMkZqbzhSYW1scnhhUHolMkI0Sk45YSUyRk5CdUJhRjNmeGExQnBlZTluTmJCc2xHamhCSnRZMHpLd1BiNThPOVhSY05yM1dzdndZV1lSOGNMY1V5T3VsZ3lmYSUyQkh0alBRc1NTNG1YV0xrZ3I4aFlqYURETzJ4ZWcyNTBZQSUzRCUzRA; _gid=GA1.2.1620583741.1610898297; VtexRCSessionIdv7=0%3Abd81faf0-5be6-11eb-8a2a-335b0fea1f00; _gat_UA-121537381-1=1; VtexStoreVersion=v2; VtexRCRequestCounter=7'
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
