### PR TITLE
Fix specificationGroups when the names of the specification and the specification group are the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `specificationGroups` when the group and the specification names are the same.
+
 ## [1.32.0] - 2021-01-21
 ### Fixed
 - Sorts to specified product order when querying `"fullText":"product:78;90;356"`

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -171,7 +171,7 @@ export const convertBiggyProduct = async (
   }
 
   allSpecificationsGroups.forEach((specificationGroup) => {
-    convertedProduct[specificationGroup] = specificationGroups[specificationGroup]
+    convertedProduct[specificationGroup] = convertedProduct[specificationGroup] ?? specificationGroups[specificationGroup]
   })
 
   return convertedProduct


### PR DESCRIPTION
#### What problem is this solving?

In some cases, the `specificationGroup` has the same name of the `specification`. In these scenarios, the values of the `specification` were being overwritten by the values of the `specificationGroup` (which was the specification itself) :kaotico:


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Before](https://palmerjane.myvtex.com/)
[Workspace](https://storeqa--palmerjane.myvtex.com/)

#### Screenshots or example usage

Before:
![image (2)](https://user-images.githubusercontent.com/20840671/105851751-3e648000-5fc2-11eb-8ea6-2d8d5a96fb5a.png)


After:
![image](https://user-images.githubusercontent.com/20840671/105851693-33115480-5fc2-11eb-967b-743ce6919255.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
