### PR TITLE
Decode searchState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Decode `searchState`.
+
 ## [1.32.1] - 2021-01-26
 
 ### Fixed

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -258,6 +258,7 @@ export class BiggySearchClient extends ExternalClient {
           sort,
           operator,
           fuzzy,
+          locale: this.locale,
           bgy_leap: leap ? true : undefined,
           ['hide-unavailable-items']: hideUnavailableItems ? 'true' : 'false',
           ...parseState(searchState),

--- a/node/utils/searchState.ts
+++ b/node/utils/searchState.ts
@@ -1,5 +1,3 @@
-import { either, isEmpty, isNil } from 'ramda'
-
 /**
  * Parse `searchState` string into a `object`.
  * We treat `searchState` as a stringified javascript object.
@@ -14,12 +12,12 @@ import { either, isEmpty, isNil } from 'ramda'
  * @memberof BiggySearchClient
  */
 export const parseState = (state?: string): { [key: string]: string } => {
-  if (either(isNil, isEmpty)(state)) {
+  if (!state) {
     return {}
   }
 
   try {
-    const parsed = JSON.parse(state!)
+    const parsed = JSON.parse(decodeURI(state))
     if (typeof parsed === 'object') {
       return parsed
     }


### PR DESCRIPTION
#### What problem is this solving?
 
`searchState` can now be passed to the search-resolver using existing values in `sessionStorage` (https://github.com/vtex-apps/search-result/pull/485)

in some scenarios this value comes encoded:
c&a:
![image](https://user-images.githubusercontent.com/20840671/106186650-52a3ab00-6183-11eb-8330-7b5af20bced5.png)
![image](https://user-images.githubusercontent.com/20840671/106186625-4c153380-6183-11eb-90a2-3274a2bbd0c1.png)

localizaseminovos:
![image](https://user-images.githubusercontent.com/20840671/106186845-97c7dd00-6183-11eb-9c06-f5ab262daea0.png)

we need to decode this value to prevent `JSON.parse` function from throwing an error.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://searchstate--localizaseminovos.myvtex.com/sedan?map=categoria-do-veiculo&order=location:asc&searchState={%22location%22:%22l:-22.9:-43.2%22})

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
