### PR TITLE
Fix/SKU selector images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Fields `name`, `nameComplete`, `ean` and `Videos` to SKU.
+### Fixed
+- Different SKU with the same image.
+
 ## [1.33.0] - 2021-02-01
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -384,7 +384,7 @@ const convertSKU = (
   indexingType?: IndexingType,
   tradePolicy?: string
 ) => (sku: BiggySearchSKU): SearchItem & { [key: string]: any } => {
-  const images = convertImages(product.images, indexingType)
+  const images = convertImages(sku.images ?? product.images, indexingType)
 
   const sellers =
     indexingType === IndexingType.XML
@@ -397,8 +397,8 @@ const convertSKU = (
     sellers,
     images,
     itemId: sku.id,
-    name: product.name,
-    nameComplete: product.name,
+    name: sku.name,
+    nameComplete: sku.nameComplete,
     complementName: product.name,
     referenceId: [
       {
@@ -409,9 +409,9 @@ const convertSKU = (
     measurementUnit: sku.measurementUnit || product.measurementUnit,
     unitMultiplier: sku.unitMultiplier || product.unitMultiplier,
     variations,
-    ean: '',
+    ean: sku.ean ?? '',
     modalType: '',
-    Videos: [],
+    Videos: sku.videos ?? [],
     attachments: [],
     isKit: false,
   }

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -320,7 +320,7 @@ const getSellersIndexedByApi = (
       sellerId: seller.id,
       sellerName: seller.name,
       addToCartLink: "",
-      sellerDefault: false,
+      sellerDefault: seller.default ?? false,
       commertialOffer,
     }
   })

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -169,7 +169,7 @@ interface BiggySearchSKU {
   ean?: string
   reference: string
   image: string
-  images: any[]
+  images: BiggyProductImage[]
   videos?: string[]
   stock: number
   oldPrice: number
@@ -194,6 +194,7 @@ interface BiggySeller {
   price: number
   stock: number
   tax: number
+  default: boolean
   installment?: BiggyInstallment
 }
 

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -164,9 +164,13 @@ interface BiggyProductExtraData {
 
 interface BiggySearchSKU {
   name: string
+  nameComplete: string
   id: string
+  ean?: string
   reference: string
   image: string
+  images: any[]
+  videos?: string[]
   stock: number
   oldPrice: number
   price: number


### PR DESCRIPTION
#### What problem is this solving?
Add new fields to `product.items` and fix bug with SKU Selector where all the SKUs had the same image

Fixes vtex-apps/store-discussion#516

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Instoreqa - graphql](https://testsku2--instoreqa.myvtex.com/admin/graphql-ide)
[Muji - sku selector](https://multilanguage--muji.myvtex.com/refil%20gen%20ink?__bindingAddress=www.mujionline.eu/uk&_q=refil%20gen%20ink&map=ft)

#### Screenshots or example usage

**SKU selector**
Before:
![skuselc2](https://user-images.githubusercontent.com/20840671/106649751-c58c9780-6570-11eb-8fd4-6f0a51263752.gif)

After:
![skuselector2](https://user-images.githubusercontent.com/20840671/106649771-ca514b80-6570-11eb-9c90-df7b7d1d103b.gif)

**New fields**

Before:
![image](https://user-images.githubusercontent.com/20840671/106647393-a04a5a00-656d-11eb-887b-d51a9502b2e5.png)

After:
![image](https://user-images.githubusercontent.com/20840671/106647248-72fdac00-656d-11eb-9af2-12668f7a8eb9.png)



#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
