### PR TITLE
PER-1675: Fix `commertialOffer` price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `commertialOffer` price.
+
 ## [1.34.1] - 2021-02-05
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -190,7 +190,9 @@ const fillSearchItemWithSimulation = (searchItem: SearchItem, orderFormItems: Or
       const { listPrice, price, priceValidUntil, sellingPrice } = orderFormItem
 
       seller.commertialOffer.AvailableQuantity = orderFormItem?.availability === 'available' ? 10000 : 0
-      seller.commertialOffer.Price = sellingPrice ? sellingPrice / (unitMultiplier * 100) : price / 100
+      seller.commertialOffer.Price = sellingPrice
+        ? Number((sellingPrice / (unitMultiplier * 100)).toFixed(2))
+        : price / 100
       seller.commertialOffer.PriceValidUntil = priceValidUntil
       seller.commertialOffer.ListPrice = listPrice / 100
       seller.commertialOffer.PriceWithoutDiscount = price / 100


### PR DESCRIPTION
#### What problem is this solving?

the price of the commercial offer was not being rounded, so the discount flag appears even when the product has no discount due to a difference in cents

![image](https://user-images.githubusercontent.com/20840671/106936398-46779a80-66fb-11eb-94a0-5f44ff7f38a3.png)


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Before](https://testprice--cassol.myvtex.com/pisos-e-revestimentos/porcelanatos-polidos/eliane/eliane?fuzzy=0&initialMap=c&initialQuery=pisos-e-revestimentos&map=category-1,category-2,brand,marca&operator=and&order=OrderByTopSaleDESC&priceRange=98%20TO%20174&searchState=)
[After](https://thalyta--cassol.myvtex.com/pisos-e-revestimentos/porcelanatos-polidos/eliane/eliane?fuzzy=0&initialMap=c&initialQuery=pisos-e-revestimentos&map=category-1,category-2,brand,marca&operator=and&order=OrderByTopSaleDESC&priceRange=98%20TO%20174&searchState)

#### Screenshots or example usage

Before:
![image](https://user-images.githubusercontent.com/20840671/106936036-d832d800-66fa-11eb-922f-be98c5fff14a.png)

After:
![image](https://user-images.githubusercontent.com/20840671/106936057-dec14f80-66fa-11eb-9fa1-b8fd1edc5cdc.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
