### PR TITLE
Add teasers to sellers on compatibility-layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Field `teasers` to Seller.
+
 ## [1.34.0] - 2021-02-03
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -260,6 +260,7 @@ const buildCommertialOffer = (
   price: number,
   oldPrice: number,
   stock: number,
+  teasers: object[],
   installment?: BiggyInstallment,
   tax?: number,
 ): CommertialOffer => {
@@ -280,7 +281,7 @@ const buildCommertialOffer = (
     DeliverySlaSamples: [],
     AvailableQuantity: availableQuantity,
     DiscountHighLight: [],
-    Teasers: [],
+    Teasers: teasers,
     Installments: installments,
     Price: price,
     ListPrice: oldPrice,
@@ -313,8 +314,9 @@ const getSellersIndexedByApi = (
     const installment = seller.installment || product.installment
 
     const stock = seller.stock || sku.stock || product.stock
+    const teasers = seller.teasers ?? [];
 
-    const commertialOffer = buildCommertialOffer(price, oldPrice, stock, installment, seller.tax)
+    const commertialOffer = buildCommertialOffer(price, oldPrice, stock, teasers, installment, seller.tax)
 
     return {
       sellerId: seller.id,
@@ -333,7 +335,7 @@ const getSellersIndexedByXML = (product: BiggySearchProduct): Seller[] => {
 
   const stock = product.stock
 
-  const commertialOffer = buildCommertialOffer(price, oldPrice, stock, installment, product.tax)
+  const commertialOffer = buildCommertialOffer(price, oldPrice, stock, [], installment, product.tax)
 
   return [{
     sellerId: '1',

--- a/node/resolvers/search/discount.ts
+++ b/node/resolvers/search/discount.ts
@@ -1,23 +1,54 @@
-import { prop } from 'ramda'
+import { has, prop } from 'ramda'
 
 export const resolvers = {
   Discount: {
-    name: prop('<Name>k__BackingField'),
+    name: (discount: any) =>
+      has('name', discount)
+        ? prop('name', discount)
+        : prop('<Name>k__BackingField', discount),
   },
   Teaser: {
-    name: prop('<Name>k__BackingField'),
-    conditions: prop('<Conditions>k__BackingField'),
-    effects: prop('<Effects>k__BackingField'),
+    name: (teaser: any) =>
+      has('name', teaser)
+        ? prop('name', teaser)
+        : prop('<Name>k__BackingField', teaser),
+
+    conditions: (teaser: any) =>
+      has('conditions', teaser)
+        ? prop('conditions', teaser)
+        : prop('<Conditions>k__BackingField', teaser),
+
+    effects: (teaser: any) =>
+      has('effects', teaser)
+        ? prop('effects', teaser)
+        : prop('<Effects>k__BackingField', teaser),
   },
   TeaserCondition: {
-    minimumQuantity: prop('<MinimumQuantity>k__BackingField'),
-    parameters: prop('<Parameters>k__BackingField'),
+    minimumQuantity: (teaserCondition: any) =>
+      has('minimumQuantity', teaserCondition)
+        ? prop('minimumQuantity', teaserCondition)
+        : prop('<MinimumQuantity>k__BackingField', teaserCondition),
+
+    parameters: (teaserCondition: any) =>
+      has('parameters', teaserCondition)
+        ? prop('parameters', teaserCondition)
+        : prop('<Parameters>k__BackingField', teaserCondition),
   },
   TeaserEffects: {
-    parameters: prop('<Parameters>k__BackingField'),
+    parameters: (teaserEffects: any) =>
+      has('parameters', teaserEffects)
+        ? prop('parameters', teaserEffects)
+        : prop('<Parameters>k__BackingField', teaserEffects),
   },
   TeaserValue: {
-    name: prop('<Name>k__BackingField'),
-    value: prop('<Value>k__BackingField'),
-  }
+    name: (teaserValue: any) =>
+      has('name', teaserValue)
+        ? prop('name', teaserValue)
+        : prop('<Name>k__BackingField', teaserValue),
+
+    value: (teaserValue: any) =>
+      has('value', teaserValue)
+        ? prop('value', teaserValue)
+        : prop('<Value>k__BackingField', teaserValue),
+  },
 }

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -193,7 +193,7 @@ interface CommertialOffer {
   Installments: SearchInstallment[]
   DiscountHighLight: any[]
   GiftSkuIds: string[]
-  Teasers: any[]
+  Teasers: object[]
   BuyTogether: any[]
   ItemMetadataAttachment: any[]
   Price: number

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -195,6 +195,7 @@ interface BiggySeller {
   stock: number
   tax: number
   default: boolean
+  teasers?: object[]
   installment?: BiggyInstallment
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Adding teasers information that is indexed in IS.

#### How should this be manually tested?

[Workspace](https://christian--muji.myvtex.com/Home-Living/Kitchen-and-Dining/Tableware?__bindingAddress=www.mujionline.eu/uk)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Search with teasers information:
![image](https://user-images.githubusercontent.com/34144667/107044428-0bc93d00-67a3-11eb-94fe-feec48089d4d.png)

Search without teasers information:
![image](https://user-images.githubusercontent.com/34144667/107044461-1683d200-67a3-11eb-8a89-5045be47c6e5.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
