### PR TITLE
Fix breadcrumb translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Breadcrumb and title translations.
+
 ## [1.34.2] - 2021-02-08
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -502,7 +502,7 @@ export const buildBreadcrumb = (
     selectedFacet => selectedFacet.value
   )
   activeValues.sort((a, b) =>
-    selectedFacetsValues.indexOf(a.key) < selectedFacetsValues.indexOf(b.key)
+    selectedFacetsValues.indexOf(a.originalKey ?? a.key) < selectedFacetsValues.indexOf(b.originalKey ?? b.key)
       ? -1
       : 1
   )

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -99,6 +99,8 @@ interface ElasticAttribute {
   label: string
   type: string
   values: ElasticAttributeValue[]
+  originalKey?: string
+  originalLabel?: string
   minValue?: number
   maxValue?: number
 }
@@ -109,6 +111,8 @@ interface ElasticAttributeValue {
   key: string
   label: string
   id: string
+  originalKey?: string
+  originalLabel?: string
 }
 
 interface Breadcrumb {


### PR DESCRIPTION
#### What problem is this solving?

Breadcrumb sort when page language is not the default language of the store
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://intsearch2--ametllerorigen.myvtex.com/fruta/naranjas-y-citricos?__bindingAddress=www.ametllerorigen.com/es/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Before:
![image](https://user-images.githubusercontent.com/20840671/107069211-5e652200-67c0-11eb-882d-5d6bada2042e.png)

After:
![image](https://user-images.githubusercontent.com/20840671/107073837-9f603500-67c6-11eb-984d-93520af96bc5.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
