### PR TITLE
Check for knowPriceKeys using originalKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `priceRange` not working for non-standard translations.
+
 ## [1.34.3] - 2021-02-08
 
 ### Fixed

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -120,7 +120,7 @@ const convertValues = (
   // the type `'PRICERANGE'`.
   const knownPriceKeys = ['price', 'pre-', 'precio', 'preco', 'pret', 'prezzo', 'prix']
 
-  if (attribute.type === 'number' && knownPriceKeys.some(p => p === attribute.key)) {
+  if (attribute.type === 'number' && (knownPriceKeys.some(p => p === attribute.key) || knownPriceKeys.some(p => p === attribute.originalKey))) {
     return {
       type: 'PRICERANGE',
       values: attribute.values.map((value: any) => {


### PR DESCRIPTION
#### What problem is this solving?

Add price slider using `originalKey` instead of `key`, making non-standard price facets or multi-language stores work again. 

#### How should this be manually tested?

[Old Workspace](https://fstudio.myvtex.com/trepied?map=ft)
[Fixed Workspace](https://christian--fstudio.myvtex.com/trepied?map=ft)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Old workspace:
![image](https://user-images.githubusercontent.com/34144667/107231572-37486380-69ff-11eb-991a-f0982598548e.png)

Fixed workspace:
![image](https://user-images.githubusercontent.com/34144667/107231638-4d562400-69ff-11eb-8c7c-11b15f6d8651.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
