### PR TITLE
Fix/extradata override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `extraData` being overrided by `textAttributes`
+
 ## [1.34.4] - 2021-02-08
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -157,10 +157,12 @@ export const convertBiggyProduct = async (
 
   if (product.textAttributes) {
     allSpecifications.forEach((specification) => {
-      const attributes = product.textAttributes.filter((attribute) => attribute.labelKey == specification)
-      convertedProduct[specification] = attributes.map((attribute) => {
+      if(!convertedProduct[specification]){
+        const attributes = product.textAttributes.filter((attribute) => attribute.labelKey == specification)
+        convertedProduct[specification] = attributes.map((attribute) => {
         return attribute.labelValue
       })
+      }
     })
 
     product.textAttributes.filter((attribute) => attribute.labelKey === "productClusterNames").forEach((attribute) => {

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -160,8 +160,8 @@ export const convertBiggyProduct = async (
       if(!convertedProduct[specification]){
         const attributes = product.textAttributes.filter((attribute) => attribute.labelKey == specification)
         convertedProduct[specification] = attributes.map((attribute) => {
-        return attribute.labelValue
-      })
+          return attribute.labelValue
+        })
       }
     })
 

--- a/node/package.json
+++ b/node/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.39.0",
+    "@vtex/api": "6.39.1",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.39.0":
-  version "6.39.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.0.tgz#5f5b6c54713f4e3c6671d86feb3faec543b449f2"
-  integrity sha512-YoHLnMb0V2LMxoXQgIskbsHNkG/TprXjsE60RItHNjALx2b6/+gYFLSa8x/sJp+O6OJQQT3pSkFT7Ff5A8ER9g==
+"@vtex/api@6.39.1":
+  version "6.39.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
+  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Extradata being override by textAttributes even when filled

#### How should this be manually tested?

Check "Quilometragem" field in portaldolojista's response, this field is in extradata and has value, but the API is not bringing duo the override by textattribute, that has no value

[Without Fix](https://master--portaldolojista.myvtex.com/37775:37990/ka%20hatch%20se%201.0/seminovo?map=price,ft,tipo&order=OrderByPriceASC)

[With Fix](https://iespinoza--portaldolojista.myvtex.com/37775:37990/ka%20hatch%20se%201.0/seminovo?map=price,ft,tipo&order=OrderByPriceASC)

#### Screenshots or example usage

After
![image](https://user-images.githubusercontent.com/13649073/107405358-fb3bfe00-6ae5-11eb-8bbb-d4f3296ee580.png)

Before
![image](https://user-images.githubusercontent.com/13649073/107407319-49520100-6ae8-11eb-9ade-7ca3e2cd2abb.png)



#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
