### PR TITLE
Fix breadcrumb href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Breadcrumb `href`.
+
 ## [1.35.0] - 2021-02-11
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -494,7 +494,7 @@ export const buildBreadcrumb = (
         activeValues.push({
           ...value,
           visible: attribute.visible,
-          attributeKey: attribute.key,
+          attributeKey: attribute.originalKey,
         })
       }
     })

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -101,8 +101,8 @@ interface ElasticAttribute {
   label: string
   type: string
   values: ElasticAttributeValue[]
-  originalKey?: string
-  originalLabel?: string
+  originalKey: string
+  originalLabel: string
   minValue?: number
   maxValue?: number
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5171,9 +5171,9 @@ verror@1.10.0:
   version "2.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.4.0/public/@types/vtex.sae-analytics#6577d7d735b5bf0e05cceb0357080cf4f733703e"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.39.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.40.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.39.0/public#5c4b5d473526833769ea5d94df5d5b6add6bff9d"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.40.0/public#6b58bbccf25512e5812a7729e006c3e33059ffdc"
 
 "vtex.search-resolver@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.32.2/public/_types/react":
   version "0.0.0"


### PR DESCRIPTION
#### What problem is this solving?

When the store has renames for the filters (category, department, etc), the attribute key comes with this rename. 
example: if category 1 is renamed to `animale`, the key for this attribute will be `animale` instead of `category-1`. 

this breaks the ordering of the breadcrumb since it alphabetically sorts the filters that have a map other than `category-n` or `brand`. so, we need to use `originalKey` (attribute key without rename) instead of `key`.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://testbreadcrumb--arcaplanet.myvtex.com/prodotti-per-cani/cibo-per-cani/cibo-secco)
- pay attention to the ordering of the breadcrumb: Prodotti per cani (department) > Cibo per cani (category) > Cibo Secco (subcategory)
- click on "Cibo per cani" on breadcrumb
- check if the breadcrumb maintains the correct order: Prodotti per cani (department) > Cibo per cani (category)

#### Screenshots or example usage

Before:
![before](https://user-images.githubusercontent.com/20840671/109167328-6af3ef00-775c-11eb-8af7-8fa497a42ee9.gif)


After:
![after](https://user-images.githubusercontent.com/20840671/109167334-6d564900-775c-11eb-9a45-62a4106c5fee.gif)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
