### PR TITLE
Number attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `numberAttributes` to the `skuSpecifications`.
+
 ## [1.35.1] - 2021-02-26
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -93,31 +93,24 @@ export const convertBiggyProduct = async (
 
   const numberSpecKeys = Object.keys(numberSpecificationsByKey)
 
-  // eslint-disable-next-line no-console
-  console.log("NumberSpecKeys", numberSpecKeys)
-
   const skuNumberSpecifications = numberSpecKeys.map((key) => {
     const originalFieldName = numberSpecificationsByKey[key][0].labelKey
 
-    // eslint-disable-next-line no-console
-    const x = specificationsByKey[key].map((specification) => {
+    const values = numberSpecificationsByKey[key].map((specification) => {
       return {
-        name: specification.value,
-        originalName: specification.value,
+        name: specification.value.toString(),
+        originalName: specification.value.toString(),
       }
     })
 
-    const y = x.sort((x, y) => Number(x.name) - Number(y.name))
-
-    // eslint-disable-next-line no-console
-    console.log("x", x, "      y", y)
+    values.sort((x, y) => Number(x.name) - Number(y.name))
 
     return {
       field: {
-        name: originalFieldName,
-        originalName: originalFieldName,
+        name: originalFieldName.toString(),
+        originalName: originalFieldName.toString(),
       },
-      values: y
+      values
     }
   })
 
@@ -150,7 +143,7 @@ export const convertBiggyProduct = async (
       items: []
     },
     selectedProperties,
-    allSkuSpecification,
+    skuSpecifications: allSkuSpecification,
     // This field is only maintained for backwards compatibility reasons, it shouldn't exist.
     skus: skus.find(sku => sku.sellers && sku.sellers.length > 0),
   }

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -82,6 +82,47 @@ export const convertBiggyProduct = async (
     }
   })
 
+  const numberAttributes = product.numberAttributes ?? []
+
+  const numberSpecificationsByKey = numberAttributes.reduce((specsByKey: {[key: string]: BiggyTextAttribute[]}, spec) => {
+    const value = spec.labelKey
+    specsByKey[value] = (specsByKey[value] || []).concat(spec)
+
+    return specsByKey
+  }, {})
+
+  const numberSpecKeys = Object.keys(numberSpecificationsByKey)
+
+  // eslint-disable-next-line no-console
+  console.log("NumberSpecKeys", numberSpecKeys)
+
+  const skuNumberSpecifications = numberSpecKeys.map((key) => {
+    const originalFieldName = numberSpecificationsByKey[key][0].labelKey
+
+    // eslint-disable-next-line no-console
+    const x = specificationsByKey[key].map((specification) => {
+      return {
+        name: specification.value,
+        originalName: specification.value,
+      }
+    })
+
+    const y = x.sort((x, y) => Number(x.name) - Number(y.name))
+
+    // eslint-disable-next-line no-console
+    console.log("x", x, "      y", y)
+
+    return {
+      field: {
+        name: originalFieldName,
+        originalName: originalFieldName,
+      },
+      values: y
+    }
+  })
+
+  const allSkuSpecification = skuSpecifications.concat(skuNumberSpecifications)
+
   const convertedProduct: SearchProduct & { cacheId?: string, [key: string]: any } = {
     categories,
     categoriesIds,
@@ -109,7 +150,7 @@ export const convertBiggyProduct = async (
       items: []
     },
     selectedProperties,
-    skuSpecifications,
+    allSkuSpecification,
     // This field is only maintained for backwards compatibility reasons, it shouldn't exist.
     skus: skus.find(sku => sku.sellers && sku.sellers.length > 0),
   }

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -148,6 +148,7 @@ interface BiggySearchProduct {
   productSpecifications: string[]
   specificationGroups: string
   textAttributes: BiggyTextAttribute[]
+  numberAttributes: BiggyTextAttribute[]
   split: BiggySplit
   categoryTrees: BiggyCategoryTree[]
   clusterHighlights: Record<string, string>


### PR DESCRIPTION
#### What problem is this solving?

Number attributes such as "polegadas" and "quilometragem" are not being displayed on the product-summary.
This PR adds those attributes to the GraphQL response.

#### How should this be manually tested?

[Workspace](https://hiago--samsungbr.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
