### PR TITLE
Feature/allow region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Handle for `regionId` as query parameter. 
+
 ## [1.36.1] - 2021-03-17
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -23,7 +23,7 @@ export const convertBiggyProduct = async (
   simulationBehavior: 'skip' | 'default' | null,
   tradePolicy?: string,
   priceTable?: string,
-  regionId?: string,
+  regionId?: string | null,
   indexingType?: IndexingType,
 ) => {
   const categories: string[] = []

--- a/node/commons/products.ts
+++ b/node/commons/products.ts
@@ -7,16 +7,17 @@ interface ConvertProductInput {
   ctx: any
   simulationBehavior?: 'skip' | 'default' | null
   tradePolicy?: string | null
+  regionId?: string | null
 }
 
-export const productsBiggy = async ({ searchResult, ctx, simulationBehavior = 'default', tradePolicy }: ConvertProductInput) => {
+export const productsBiggy = async ({ searchResult, ctx, simulationBehavior = 'default', tradePolicy, regionId }: ConvertProductInput) => {
   const { segment } = ctx.vtex
   const checkout = ctx.clients.checkout
   const products: any[] = []
 
   searchResult.products.forEach((product: any) => {
     try {
-      products.push(convertBiggyProduct(product, checkout, simulationBehavior, tradePolicy ?? segment?.channel, segment?.priceTables, segment?.regionId))
+      products.push(convertBiggyProduct(product, checkout, simulationBehavior, tradePolicy ?? segment?.channel, segment?.priceTables, regionId))
     } catch (err) {
       console.error(err)
     }

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -601,7 +601,7 @@ export const queries = {
     const sellers = await getSellers(vbase, checkout, segment?.channel, regionId || segment?.regionId)
     const [count, page] = getProductsCountAndPage(from, to)
 
-    const tradePolicy = getTradePolicyFromSelectedFacets(args.selectedFacets) || segment?.channel
+    const tradePolicy = getTradePolicyFromSelectedFacets(args.selectedFacets)
 
     const biggyArgs = {
       page,
@@ -611,7 +611,7 @@ export const queries = {
       searchState,
       attributePath: buildAttributePath(selectedFacets),
       query: fullText,
-      tradePolicy: tradePolicy,
+      tradePolicy: segment && segment.channel,
       sort: convertOrderBy(args.orderBy),
       sellers,
       hideUnavailableItems,
@@ -722,7 +722,7 @@ export const queries = {
       vtex: { segment },
     } = ctx
 
-    const regionId = args.regionId || segment?.regionId
+    const regionId = args.regionId || segment?.regionIdgst
 
     const sellers = await getSellers(vbase, checkout, segment?.channel, regionId)
 

--- a/node/typings/Checkout.ts
+++ b/node/typings/Checkout.ts
@@ -250,5 +250,5 @@ interface SimulationPayload {
 }
 
 interface ShippingData {
-  logisticsInfo?: { regionId?: string }[]
+  logisticsInfo?: { regionId?: string | null }[]
 }

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -57,7 +57,8 @@ interface SuggestionProductsArgs {
   productOriginVtex: boolean
   simulationBehavior: 'skip' | 'default' | null
   sellers?: RegionSeller[]
-  hideUnavailableItems?: boolean | null
+  hideUnavailableItems?: boolean | null,
+  regionId?: string
 }
 
 interface SuggestionSearchesArgs {


### PR DESCRIPTION
#### What problem is this solving?

Allow set region Id for headless stores
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

graphql: https://ullayne--bighiper.myvtex.com/_v/private/vtex.search-graphql@0.40.0/graphiql/v1
Query: 
```

  # Welcome to Altair GraphQL Client.
  # You can send your request using CmdOrCtrl + Enter.

  # Enter your graphQL query here.
query{
  productSearch(fullText: "vinho", selectedFacets: {key: "region-id", value: "U1cjYmlnaGlwZXIzNzA1"}, simulationBehavior: default){
    products{
      ...Product
    }
    recordsFiltered
    titleTag
    metaTagDescription
    canonical
    operator
    fuzzy
    searchState
    redirect
  }
}


fragment Product on Product {
  productName
  productId
  productReference
  description
  priceRange {
    sellingPrice {
      highPrice
      lowPrice
    }
    listPrice {
      highPrice
      lowPrice
    }
  }
  items {
    itemId
    name
    referenceId {
      Key
      Value
    }
    variations {
      originalName
      name
      values
    }
    estimatedDateArrival
    images {
      imageUrl
    }
    measurementUnit
    unitMultiplier
    sellers {
      sellerId
      commertialOffer {
        ListPrice
        Price
        AvailableQuantity
        DeliverySlaSamples {
          DeliverySlaPerTypes {
            TypeName
            Price
            EstimatedTimeSpanToDelivery
          }
          Region {
            IsPersisted
            IsRemoved
            Id
            Name
            CountryCode
            ZipCode
            CultureInfoName
          }
        }
        Installments {
          Value
          InterestRate
          NumberOfInstallments
          TotalValuePlusInterestRate
          PaymentSystemName
          PaymentSystemGroupName
          Name
        }
      }
    }
  }
  link
  brand
  properties {
    originalName
    name
    values
  }
  categoryTree {
    id
    name
    children {
      id
      name
      children {
        id
        name
        children {
          id
          name
        }
      }
    }
  }
  clusterHighlights {
    id
    name
  }
}
```
Request sent to search API: 
<img width="569" alt="image" src="https://user-images.githubusercontent.com/20619554/111492111-2afca800-871b-11eb-8ddd-0bc4e3be73ac.png">


- Should not work with this regionId: U1cjY2FycmVmb3VyYnI5ODI=
<img width="1752" alt="image" src="https://user-images.githubusercontent.com/20619554/111492744-b118ee80-871b-11eb-9695-6f474b368451.png">

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
