### PR TITLE
Change facet values ordering to keep selected values at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Facet Value ordering, keeping selected values at the top.
 
 ## [1.37.4] - 2021-03-25
 ### Changed

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -235,7 +235,15 @@ export const sortAttributeValuesByCatalog = (
     const aPosition = findPositionByLabel(a.label)
     const bPosition = findPositionByLabel(b.label)
 
-    return aPosition < bPosition ? -1 : 1
+    // Order attribute values keeping selected ones at the top.
+    if (a.active && !b.active) {
+      return -1;
+    } else if (b.active && !a.active) {
+      return 1;
+    } else {
+      // If both, or neither, are selected, order using catalog's position.
+      return aPosition < bPosition ? -1 : 1
+    }
   })
 }
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5171,9 +5171,9 @@ verror@1.10.0:
   version "2.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.4.0/public/@types/vtex.sae-analytics#6577d7d735b5bf0e05cceb0357080cf4f733703e"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.40.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.43.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.40.0/public#6b58bbccf25512e5812a7729e006c3e33059ffdc"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.43.0/public#8f397a75ce8575dfd27acb6e5d9fd0afcb81fca6"
 
 "vtex.search-resolver@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.32.2/public/_types/react":
   version "0.0.0"


### PR DESCRIPTION
#### What problem is this solving?

When facets values  are ordered, if the selected values are not at the top
of the list, `FilterNavigator` will drop that facet value on the next facet selection.

*This does not cover the edge case where there are more facet values selected
than requested by the client, in that case, some values may be dropped*  

#### How should this be manually tested?

The original issue was first discovered here:
[bestride.ro](https://www.bestride.ro/en-gb/auto/street?map=category-1,usage)

The fixed version can be found here:
[christian--bestride.myvtex.com](https://christian--bestride.myvtex.com/auto/street?__bindingAddress=www.bestride.ro/en-gb&map=category-1,utilizare)

Selecting a filter that is collapsed, you can see that the filter does not appear on
the `FilterNavigator` as selected, and as such, will be removed on further navigation
through facets.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

https://user-images.githubusercontent.com/34144667/112542180-034cb600-8d93-11eb-8d84-677cbde57a14.mov


https://user-images.githubusercontent.com/34144667/112542320-3131fa80-8d93-11eb-8f0e-5ba165bf49d4.mov


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
