### PR TITLE
Fix regionalization for product shelves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Regionalization not working on shelves.
 
 ## [1.37.4] - 2021-03-25
 ### Changed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -499,7 +499,7 @@ export const convertOrderBy = (orderBy?: string | null): string => {
 export const buildBreadcrumb = (
   attributes: ElasticAttribute[],
   fullText: string,
-  selectedFacets: SelectedFacet[]
+  selectedFacets: SelectedFacet[] = []
 ) => {
   const pivotValue: string[] = []
   const pivotMap: string[] = []

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -418,7 +418,7 @@ export const queries = {
       vtex: { segment },
     } = ctx
 
-    const [regionId, selectedFacets] = getRegionIdFromSelectedFacets(args.selectedFacets ?? [])
+    const [regionId, selectedFacets] = getRegionIdFromSelectedFacets(args.selectedFacets)
 
     const tradePolicy = getTradePolicyFromSelectedFacets(selectedFacets) || segment?.channel
 
@@ -457,7 +457,7 @@ export const queries = {
     const breadcrumb = buildBreadcrumb(
       result.attributes || [],
       decodeURIComponent(args.fullText),
-      args.selectedFacets ?? []
+      args.selectedFacets
     )
 
     const attributesWithVisibilitySet = await setFilterVisibility(vbase, search, result.attributes ?? [])
@@ -474,7 +474,7 @@ export const queries = {
       queryArgs: {
         map: args.map,
         query: args.query,
-        selectedFacets: args.selectedFacets ?? [],
+        selectedFacets: args.selectedFacets,
       },
       breadcrumb,
     }
@@ -628,7 +628,7 @@ export const queries = {
       simulationBehavior,
       hideUnavailableItems,
     } = args
-    let [regionId, selectedFacets] = getRegionIdFromSelectedFacets(args.selectedFacets ?? [])
+    let [regionId, selectedFacets] = getRegionIdFromSelectedFacets(args.selectedFacets)
 
     regionId = regionId || segment?.regionId
 

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -57,7 +57,7 @@ interface SuggestionProductsArgs {
   productOriginVtex: boolean
   simulationBehavior: 'skip' | 'default' | null
   sellers?: RegionSeller[]
-  hideUnavailableItems?: boolean | null,
+  hideUnavailableItems?: boolean | null
   regionId?: string
 }
 
@@ -84,7 +84,7 @@ interface ProductSearchInput {
   query: string
   from: number
   to: number
-  selectedFacets: SelectedFacet[]
+  selectedFacets?: SelectedFacet[]
   fullText: string
   fuzzy: string
   operator: string

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5171,9 +5171,9 @@ verror@1.10.0:
   version "2.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.sae-analytics@2.4.0/public/@types/vtex.sae-analytics#6577d7d735b5bf0e05cceb0357080cf4f733703e"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.40.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.43.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.40.0/public#6b58bbccf25512e5812a7729e006c3e33059ffdc"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.43.0/public#8f397a75ce8575dfd27acb6e5d9fd0afcb81fca6"
 
 "vtex.search-resolver@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-resolver@1.32.2/public/_types/react":
   version "0.0.0"


### PR DESCRIPTION
#### What problem is this solving?

After `v1.37.x` regionalization stopped working on shelves, that was due to the `products` query
using the `productsBiggy` method that was changed to accept a `regionId`, but nothing was being
passed when calling the `products` query.

I've also taken the opportunity to fix two issues that bugged me when testing queries on `graphql-ide`:
- `query` having no effect on `productSearch` and `facets`, now it's a fallback, if you do not pass `fullText`,
`query` will be used instead.
- `selectedFacets` if not passed, would throw an error, now it defaults to `[]`.

#### How should this be manually tested?

- Go to workspace.
- Use the 85805-690 zip code.
- Check that the product `Chopp Brahma Claro 10L` is marked as Unavailable on the fixed workspace, but available on master workspace.
 
[master workspace](https://choppbrahmaexpress.myvtex.com/)

[fixed workspace](https://christian--choppbrahmaexpress.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/34144667/112635334-73eae580-8e1a-11eb-97ce-d9d4ed30d4fb.png)

![image](https://user-images.githubusercontent.com/34144667/112635350-79483000-8e1a-11eb-957d-ff155450008c.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
