### PR TITLE
Fix regionalization not working on shelves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Regionalization not working on shelves (`products` query).
 
 ## [1.37.7] - 2021-03-26
 ### Changed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -503,8 +503,6 @@ export const queries = {
 
     const vtexSegment = (!cookie || (!cookie?.regionId && rawArgs.regionId)) ? buildVtexSegment(cookie, salesChannel, rawArgs.regionId) : ctx.vtex.segmentToken
 
-
-
     switch (field) {
       case 'id':
         products = await search.productById(value, vtexSegment, salesChannel)
@@ -567,7 +565,8 @@ export const queries = {
 
     const products = await biggySearch.productSearch(biggyArgs)
 
-    const convertedProducts = await productsBiggy({ ctx, simulationBehavior, searchResult: products })
+    const regionId = segment?.regionId
+    const convertedProducts = await productsBiggy({ ctx, simulationBehavior, searchResult: products, regionId })
     convertedProducts.forEach(product => product.cacheId = `sae-productSearch-${product.cacheId || product.linkText}`)
 
     return convertedProducts


### PR DESCRIPTION
#### What problem is this solving?

This PR is a cherry-pick of the changes made on #183, without the changes that
caused the navigation pages outage.

After `v1.37.x` regionalization stopped working on shelves, that was due to the `products` query
using the `productsBiggy` method that was changed to accept a `regionId`, but nothing was being
passed when calling the `products` query.

#### How should this be manually tested?

- Go to workspace.
- Use the 85805-690 zip code.
- Check that the product `Chopp Brahma Claro 10L` is marked as Unavailable on the fixed workspace, but available on the other workspace (not using master workspace as this account has a beta version of this fix running on master).
 
[v1.37.7 workspace](https://christian2--choppbrahmaexpress.myvtex.com/)

[fixed workspace](https://christian--choppbrahmaexpress.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/34144667/112635334-73eae580-8e1a-11eb-97ce-d9d4ed30d4fb.png)

![image](https://user-images.githubusercontent.com/34144667/112635350-79483000-8e1a-11eb-957d-ff155450008c.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
