### PR TITLE
fix: adjusting the parameters to api calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add `encodeURI` to facet key into `compatibility-layer`
+
 ## [1.38.1] - 2021-04-26
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -574,6 +574,8 @@ export const buildBreadcrumb = (
   return breadcrumb
 }
 
+const encodeSafeURI = (uri: string) => encodeURI(decodeURI(uri))
+
 export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {
   return selectedFacets
     ? selectedFacets.reduce((attributePath, facet) => {
@@ -583,7 +585,7 @@ export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {
       }
 
       return facet.key !== 'ft'
-        ? `${attributePath}${encodeURI(facet.key)}/${removeDiacriticsFromURL(encodeURI(facet.value)).replace(/ |%20/, '-')}/`
+        ? `${attributePath}${encodeSafeURI(facet.key)}/${removeDiacriticsFromURL(encodeSafeURI(facet.value)).replace(/ |%20/, '-')}/`
         : attributePath
     }, '')
     : ''

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -583,7 +583,7 @@ export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {
       }
 
       return facet.key !== 'ft'
-        ? `${attributePath}${encodeURI(facet.key)}/${removeDiacriticsFromURL(facet.value).replace(/ |%20/, '-')}/`
+        ? `${attributePath}${encodeURI(facet.key)}/${removeDiacriticsFromURL(encodeURI(facet.value)).replace(/ |%20/, '-')}/`
         : attributePath
     }, '')
     : ''

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -583,7 +583,7 @@ export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {
       }
 
       return facet.key !== 'ft'
-        ? `${attributePath}${facet.key}/${removeDiacriticsFromURL(facet.value).replace(/ |%20/, '-')}/`
+        ? `${attributePath}${encodeURI(facet.key)}/${removeDiacriticsFromURL(facet.value).replace(/ |%20/, '-')}/`
         : attributePath
     }, '')
     : ''


### PR DESCRIPTION
#### What problem is this solving?

Some calls to the api were passing not encoded values that break some sites

#### How should this be manually tested?

[Workspace](https://demo2check--ruwhirlpoolqa.myvtex.com/%D1%82%D0%BE%D0%B2%D0%B0%D1%80%D1%8B/%D0%B7%D0%B0%D0%B1%D0%BE%D1%82%D0%B0-%D0%BE-%D1%82%D0%BA%D0%B0%D0%BD%D1%8F%D1%85/%D1%81%D1%82%D0%B8%D1%80%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B5-%D0%BC%D0%B0%D1%88%D0%B8%D0%BD%D1%8B?__bindingAddress=whirlpoolqa.ru/ru&map=category-1,category-2,category-3,%D0%B2%D0%BC%D0%B5%D1%81%D1%82%D0%B8%D0%BC%D0%BE%D1%81%D1%82%D1%8C,%D0%B2%D0%BC%D0%B5%D1%81%D1%82%D0%B8%D0%BC%D0%BE%D1%81%D1%82%D1%8C&order=&query=/%D1%82%D0%BE%D0%B2%D0%B0%D1%80%D1%8B/%D0%B7%D0%B0%D0%B1%D0%BE%D1%82%D0%B0-%D0%BE-%D1%82%D0%BA%D0%B0%D0%BD%D1%8F%D1%85/%D1%81%D1%82%D0%B8%D1%80%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%B5-%D0%BC%D0%B0%D1%88%D0%B8%D0%BD%D1%8B/6/7&searchState)

Click on the side filters and the screen should load the correct amount of products.

![image](https://user-images.githubusercontent.com/49077396/115440249-ebc3ea00-a1e5-11eb-9498-c4858608f2a6.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media.giphy.com/media/j0eRJzyW7XjMpu1Pqd/giphy.gif)