### PR TITLE
Add complementName to BiggySKU and conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `items.complementName` to compatibility layer.
 
 ## [1.38.3] - 2021-04-28
 

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -444,7 +444,7 @@ const convertSKU = (
     itemId: sku.id,
     name: sku.name,
     nameComplete: sku.nameComplete,
-    complementName: product.name,
+    complementName: sku.complementName ?? '',
     referenceId: [
       {
         Key: 'RefId',

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -57,7 +57,7 @@ interface SuggestionProductsArgs {
   productOriginVtex: boolean
   simulationBehavior: 'skip' | 'default' | null
   sellers?: RegionSeller[]
-  hideUnavailableItems?: boolean | null,
+  hideUnavailableItems?: boolean | null
   regionId?: string
 }
 
@@ -174,6 +174,7 @@ interface BiggyProductExtraData {
 interface BiggySearchSKU {
   name: string
   nameComplete: string
+  complementName?: string
   id: string
   ean?: string
   reference: string

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4615,7 +4615,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Remove `product.name` fallback for `complementName` and use the correctly indexed one.

#### How should this be manually tested?

Check the workspace below:
[Workspace](https://chrissearch--bighiper.myvtex.com/admin/graphql-ide)

```
{
  productSearch(fullText: "limao thaiti"){
    products {
      productId
      productName,
      items {
        complementName
      }
    }
  }
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Old:
![image](https://user-images.githubusercontent.com/34144667/116459186-e3019280-a83b-11eb-807c-c34696d103c1.png)

With changes:
![image](https://user-images.githubusercontent.com/34144667/116459437-2f4cd280-a83c-11eb-99cd-c7c2973b0bcf.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
