### PR TITLE
Revert caching changes made on `1.37.9`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Revert caching changes made on `1.37.9`.
+- Force `top-searches` maxAge to `3600`.
 
 ## [1.38.4] - 2021-04-28
 ### Added

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -78,6 +78,7 @@ export class BiggySearchClient extends ExternalClient {
   public async topSearches(): Promise<any> {
     const result = await this.http.get(`${this.store}/api/top_searches`, {
       metric: 'top-searches',
+      forceMaxAge: 3600,
       params: {
         locale: this.locale,
       }

--- a/node/index.ts
+++ b/node/index.ts
@@ -15,11 +15,13 @@ const SIX_SECONDS_MS = 6 * 1000
 const MAX_SEGMENT_CACHE = 10000
 const segmentCache = new LRUCache<string, Cached>({ max: MAX_SEGMENT_CACHE })
 const searchCache = new LRUCache<string, Cached>({ max: 3000 })
+const biggySearchCache = new LRUCache<string, Cached>({ max: 3000 })
 const messagesCache = new LRUCache<string, Cached>({ max: 3000 })
 const vbaseCache = new LRUCache<string, Cached>({ max: 3000 })
 
 metrics.trackCache('segment', segmentCache)
 metrics.trackCache('search', searchCache)
+metrics.trackCache('biggySearch', biggySearchCache)
 metrics.trackCache('messages', messagesCache)
 metrics.trackCache('vbase', vbaseCache)
 
@@ -48,6 +50,7 @@ export default new Service<Clients, RecorderState, CustomContext>({
       },
       biggySearch: {
         concurrency: 10,
+        memoryCache: biggySearchCache,
         timeout: SIX_SECONDS_MS,
       },
       vbase: {

--- a/node/index.ts
+++ b/node/index.ts
@@ -15,15 +15,16 @@ const SIX_SECONDS_MS = 6 * 1000
 const MAX_SEGMENT_CACHE = 10000
 const segmentCache = new LRUCache<string, Cached>({ max: MAX_SEGMENT_CACHE })
 const searchCache = new LRUCache<string, Cached>({ max: 3000 })
-const biggySearchCache = new LRUCache<string, Cached>({ max: 3000 })
 const messagesCache = new LRUCache<string, Cached>({ max: 3000 })
 const vbaseCache = new LRUCache<string, Cached>({ max: 3000 })
 
+const biggySearchCache = new LRUCache<string, Cached>({ max: 300 })
+
 metrics.trackCache('segment', segmentCache)
 metrics.trackCache('search', searchCache)
-metrics.trackCache('biggySearch', biggySearchCache)
 metrics.trackCache('messages', messagesCache)
 metrics.trackCache('vbase', vbaseCache)
+metrics.trackCache('biggySearch', biggySearchCache)
 
 export default new Service<Clients, RecorderState, CustomContext>({
   clients: {


### PR DESCRIPTION
#### What problem is this solving?

Reverts LRUCache on resolver, with 10% of its original limits.
Also, forces max age on top-searches, as the API does not retun `max-age` header on response.

#### How should this be manually tested?

Test the topSearches request on a workspace, checking latency of the request, subsequent requests will
be cached.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/34144667/116618358-54f9da80-a915-11eb-986a-2bc1b569d943.png)

![image](https://user-images.githubusercontent.com/34144667/116618372-5a572500-a915-11eb-8407-ce4d39996319.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
