### PR TITLE
use the locale from the search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Use the locale returned by the search queries.
+
 ## [1.39.2] - 2021-05-17
 
 ### Fixed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -435,6 +435,10 @@ export const queries = {
 
     const result = await biggySearch.facets(biggyArgs)
 
+    if (ctx.vtex.tenant) {
+      ctx.vtex.tenant.locale = result.locale
+    }
+
     // FIXME: This is used to sort values based on catalog API.
     // Remove it when it is not necessary anymore
     if (result && result.attributes) {
@@ -566,6 +570,10 @@ export const queries = {
 
     const products = await biggySearch.productSearch(biggyArgs)
 
+    if (ctx.vtex.tenant) {
+      ctx.vtex.tenant.locale = products.locale
+    }
+
     const regionId = segment?.regionId
     const convertedProducts = await productsBiggy({ ctx, simulationBehavior, searchResult: products, regionId })
     convertedProducts.forEach(product => product.cacheId = `sae-productSearch-${product.cacheId || product.linkText}`)
@@ -660,6 +668,10 @@ export const queries = {
     }
 
     const result = await biggySearch.productSearch(biggyArgs)
+
+    if (ctx.vtex.tenant) {
+      ctx.vtex.tenant.locale = result.locale
+    }
 
     const productResolver = args.productOriginVtex
       ? productsCatalog
@@ -775,6 +787,10 @@ export const queries = {
       salesChannel: tradePolicy,
       sellers
     })
+
+    if (ctx.vtex.tenant) {
+      ctx.vtex.tenant.locale = result.locale
+    }
 
     const productResolver = args.productOriginVtex
       ? productsCatalog

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -669,7 +669,7 @@ export const queries = {
 
     const result = await biggySearch.productSearch(biggyArgs)
 
-    if (ctx.vtex.tenant) {
+    if (ctx.vtex.tenant && !args.productOriginVtex) {
       ctx.vtex.tenant.locale = result.locale
     }
 
@@ -788,7 +788,7 @@ export const queries = {
       sellers
     })
 
-    if (ctx.vtex.tenant) {
+    if (ctx.vtex.tenant && !args.productOriginVtex) {
       ctx.vtex.tenant.locale = result.locale
     }
 


### PR DESCRIPTION
#### What problem is this solving?

This PR prevents search information from being translated twice.

#### How should this be manually tested?

[Workspace](https://hiago--muji.myvtex.com/bluse?__bindingAddress=www.muji.eu/de&_q=bluse&map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
