### PR TITLE
use the textAttributes to build te allspecifications object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `textAttributes` to build the `allSpecifications` object.
+
 ## [1.43.0] - 2021-05-26
 
 ### Changed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -40,8 +40,6 @@ export const convertBiggyProduct = async (
     convertSKU(product, indexingType, tradePolicy)
   )
 
-  const allSpecifications = (product.productSpecifications ?? []).concat(getSKUSpecifications(product))
-
   const specificationGroups = product.specificationGroups ? JSON.parse(product.specificationGroups) : {}
 
   const allSpecificationsGroups = [...Object.keys(specificationGroups)]
@@ -56,6 +54,8 @@ export const convertBiggyProduct = async (
   ]
 
   const specificationAttributes = product.textAttributes?.filter(attribute => attribute.isSku) ?? []
+
+  const allSpecifications = specificationAttributes.map(specification => specification.labelKey)
 
   const specificationsByKey = specificationAttributes.reduce((specsByKey: {[key: string]: BiggyTextAttribute[]}, spec) => {
     // the joinedKey has the format text@@@key@@@labelKey@@@originalKey@@@originalLabelKey
@@ -195,7 +195,7 @@ export const convertBiggyProduct = async (
   if (product.textAttributes) {
     allSpecifications.forEach((specification) => {
       if(!convertedProduct[specification]){
-        const attributes = product.textAttributes.filter((attribute) => attribute.joinedKey.split('@@@')[4] == specification)
+        const attributes = product.textAttributes.filter((attribute) => attribute.labelKey == specification)
 
         convertedProduct[specification] = attributes.map((attribute) => {
           return attribute.labelValue
@@ -295,10 +295,6 @@ const getSimulationPayloads = (product: SearchProduct) => {
 
 const getVariations = (sku: BiggySearchSKU): string[] => {
   return sku.attributes.map((attribute) => attribute.key)
-}
-
-const getSKUSpecifications = (product: BiggySearchProduct): string[] => {
-  return product.skus.map((sku) => sku.attributes.map((attribute) => attribute.key)).reduce((acc, val) => acc.concat(val), []).filter(distinct)
 }
 
 const buildCommertialOffer = (


### PR DESCRIPTION
#### What problem is this solving?

We are using the `sku.attributes` to build the `allSpecifications` object. The problem is that it is not translated. That's why we should use the `textAttributes`

#### How should this be manually tested?

[Workspace](https://hiago--abibewebshop.myvtex.com/bier?__bindingAddress=www.jupilershop.be/nl)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
