### PR TITLE
Fix | Search Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Uses `query` param from `selectedFacets` in `searchMetadata` query if no `query` was passed
 
 ## [1.43.2] - 2021-05-31
 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -734,7 +734,7 @@ export const queries = {
 
     if (args.selectedFacets) {
       const map = args.selectedFacets.map(x => x.key).join(',')
-      const query = args.selectedFacets.map(x => x.value).join(',')
+      const query = args.selectedFacets.map(x => x.value).join('/')
 
       args.map = map
       args.query = args.query || query

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -733,8 +733,11 @@ export const queries = {
     }
 
     if (args.selectedFacets) {
-      const [map] = getMapAndPriceRangeFromSelectedFacets(args.selectedFacets)
+      const map = args.selectedFacets.map(x => x.key).join(',')
+      const query = args.selectedFacets.map(x => x.value).join(',')
+
       args.map = map
+      args.query = args.query || query
     }
 
     const query = await getTranslatedSearchTerm(


### PR DESCRIPTION
#### What problem is this solving?
Makes the searchMetadata query to work if only selectedFacets are passed.

After removing `query` and `map` entirely from the front-end, our metadata disappeared. This is because we don't create the query param after the `selectedFacets`. This PR fixes this issue by building the `query` param after the `selectedFacets` if no `query` param was already passed

#### How should this be manually tested?
Perform the following query at account `btglobal`:
```
{
    searchMetadata(
      selectedFacets:[{key: "c", value:"bath-and-body"}]
    ) {
      titleTag
      metaTagDescription
    }
  }
```

You should now receive the correct metadata

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
