### PR TITLE
Increase min replicas

### DIFF
--- a/node/service.json
+++ b/node/service.json
@@ -8,7 +8,7 @@
   },
   "ttl": 30,
   "timeout": 12,
-  "minReplicas": 2,
+  "minReplicas": 30,
   "maxReplicas": 150,
   "workers": 2
 }


### PR DESCRIPTION
#### What problem is this solving?
Preventing timeout during deployments of new versions.

When new versions are released they only have 2 replicas.
If the housekeeper updates accounts too fast, these replicas will receive a surge in traffic.
What will increase latency and create timeouts.

Min replicas are only respected in the app first minutes inside the cluster, so they won't affect long term cost.

#### How should this be manually tested?
👀 

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
👀 

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

👀 