### PR TITLE
Fix search with encoded values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Breadcrumb and filters with encoded values.
+
 ## [1.44.0] - 2021-06-08
 
 ### Added

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -460,7 +460,7 @@ export const queries = {
 
     const breadcrumb = buildBreadcrumb(
       result.attributes || [],
-      decodeURIComponent(args.fullText),
+      args.fullText,
       args.selectedFacets
     )
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4626,7 +4626,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
We have a problem with searches with slash. if you search for something with slash and then select some facet, the term is separated into two parts (before and after the slash) and the rewriter cannot correctly map what the search term was, which breaks the search results as the term is no longer the same as what was initially used.

For example: Go to [search for "48m/s"](https://biscoind.myvtex.com/48m%2fs?_q=48m/s&map=ft) and select some facet. 

You will see that after selecting the facet, the term is "48m", and the search result brings a different amount of products than what was expected when selecting the filter, since now the search considers a new term:

![image](https://user-images.githubusercontent.com/20840671/121024483-a39f5d80-c77a-11eb-80cf-9e6097aff356.png)

![image](https://user-images.githubusercontent.com/20840671/121024172-5b803b00-c77a-11eb-9941-fc8cd92110e4.png)

To fix this, we need to keep the encoded term which is used to build the breadcrumb and facets, so the rewriter will not split it and change the search.


<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--biscoind.myvtex.com/48m%2fs?_q=48m/s&map=ft)

#### Screenshots or example usage

href before:
![image](https://user-images.githubusercontent.com/20840671/121025009-1e687880-c77b-11eb-9313-85f078af4f5e.png)

href after:
![image](https://user-images.githubusercontent.com/20840671/121025082-304a1b80-c77b-11eb-9387-ad2b2992df2d.png)

Fixed search:
![image](https://user-images.githubusercontent.com/20840671/121025227-5374cb00-c77b-11eb-972d-10201d7930cb.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
