### PR TITLE
Use `itemId` instead of `productId` on benefit calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `itemId` instead of `productId` on benefit calls.
+
 ## [1.44.0] - 2021-06-08
 
 ### Added

--- a/node/resolvers/benefits/index.ts
+++ b/node/resolvers/benefits/index.ts
@@ -56,7 +56,7 @@ export const fieldResolvers = {
 export const getBenefits = async (
   itemId: string,
   { clients: { checkout } }: Context
-) => {
+): Promise<unknown[]> => {
   const requestBody = {
     items: [
       {

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -1,4 +1,4 @@
-import { compose, last, omit, pathOr, split } from 'ramda'
+import { compose, last, omit, pathOr, split, flatten } from 'ramda'
 
 import {
   addContextToTranslatableString,
@@ -160,8 +160,8 @@ export const resolvers = {
       'brandId'
     ),
 
-    benefits: ({ productId }: SearchProduct, _: any, ctx: Context) =>
-      getBenefits(productId, ctx),
+    benefits: async ({ items }: SearchProduct, _: any, ctx: Context) =>
+      flatten(await Promise.all(items?.map(item => getBenefits(item.itemId, ctx)))),
 
     categoryTree: productCategoriesToCategoryTree,
 


### PR DESCRIPTION
#### What problem is this solving?

When calling benefits, the old code used to call simulation using the `productId`, this is incorrect, the `getBenefits` function states that it needs an `itemId`, and in a lot of cases the `itemId` is not the same as the `productId`, it could lead to problems where some other products benefits would then be shown, this commit fixes this.

#### How should this be manually tested?

You can compare the screenshots below, or use the workspace below:

[Workspace](https://chris--easycl.myvtex.com/admin/graphql-ide)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/34144667/121722321-af14c080-cabb-11eb-945d-d8fe7e6ab45f.png)

![image](https://user-images.githubusercontent.com/34144667/121722351-b8059200-cabb-11eb-96b4-8a361a284d66.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
