### PR TITLE
Fix search with percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Searches with percentage.
+
 ## [1.47.2] - 2021-06-29
 ### Fixed
 - Adds fallback image label

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -36,6 +36,14 @@ const validNavigationPage = (attributePath: string, query?: string) => {
   return attributePath.split('/').filter(value => value).length % 2 === 0
 }
 
+const decodeQuery = (query: string) => {
+  try {
+    return decodeURIComponent(query)
+  } catch (e) {
+    return query
+  }
+}
+
 const isProductQuery = /^product:(([0-9])+;)+([0-9])+$/g
 const sortProducts = (search: { total: number, products: {id: string}[]}, query: string | undefined) => {
   if (typeof query === 'string' && isProductQuery.test(query) && search.total > 0) {
@@ -219,7 +227,7 @@ export class BiggySearchClient extends ExternalClient {
 
     const result = await this.http.getRaw(url, {
       params: {
-        query: decodeURIComponent(query ?? ''),
+        query: decodeQuery(query ?? ''),
         page,
         count,
         sort,
@@ -262,7 +270,7 @@ export class BiggySearchClient extends ExternalClient {
     )}`
 
     const params = {
-      query: decodeURIComponent(query ?? ''),
+      query: decodeQuery(query ?? ''),
       page,
       count,
       sort,


### PR DESCRIPTION
#### What problem is this solving?

when trying to search for a term with percentage (`%`) the search always returned empty.
this was because before sending the query to the API we tried to call `decodeURIComponent` which throws an error for the percentage that is not encoded.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

- Try searching for something that has a percentage (`%`). for example: `100% natural`
- The search should return products

#### Screenshots or example usage

Before:
![before](https://user-images.githubusercontent.com/20840671/124161322-a76d8980-da73-11eb-835b-1eec311adaf9.gif)

After:
![after](https://user-images.githubusercontent.com/20840671/124161334-a9cfe380-da73-11eb-82e2-f33a3a734542.gif)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
