### PR TITLE
enables adding custom query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Feature
+- Per-workspace search params
+
 ## [1.50.0] - 2021-07-27
 
 ### Added

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -128,6 +128,7 @@ export class BiggySearchClient extends ExternalClient {
       indexingType,
       sellers,
       hideUnavailableItems = false,
+      workspaceSearchParams
     } = args
     const attributes: { key: string; value: string }[] = []
 
@@ -156,6 +157,7 @@ export class BiggySearchClient extends ExternalClient {
         params: {
           locale: this.locale,
           ['hide-unavailable-items']: hideUnavailableItems ?? false,
+          ...workspaceSearchParams
         },
         headers: {
           Cookie: buildBSearchFilterCookie(sellers),
@@ -286,8 +288,6 @@ export class BiggySearchClient extends ExternalClient {
       ...parseState(searchState),
       ...workspaceSearchParams, // important that this be last so that it can override master settings above
     }
-
-    console.log("supdude", workspaceSearchParams)
 
     if (isLinked) {
       // eslint-disable-next-line no-console

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -263,7 +263,8 @@ export class BiggySearchClient extends ExternalClient {
       searchState,
       sellers,
       hideUnavailableItems,
-      options
+      options,
+      workspaceSearchParams
     } = args
 
     const cache = validNavigationPage(args.attributePath, query) ? { forceMaxAge: 3600 } : {}
@@ -283,7 +284,10 @@ export class BiggySearchClient extends ExternalClient {
       allowRedirect: options?.allowRedirect === false ? false : true,
       ['hide-unavailable-items']: hideUnavailableItems ? 'true' : 'false',
       ...parseState(searchState),
+      ...workspaceSearchParams, // important that this be last so that it can override master settings above
     }
+
+    console.log("supdude", workspaceSearchParams)
 
     if (isLinked) {
       // eslint-disable-next-line no-console

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,11 +1,13 @@
 import './globals'
 
-import { Cached, LRUCache, RecorderState, Service } from '@vtex/api'
+import { Cached, LRUCache, RecorderState, Service, method } from '@vtex/api'
 import schema from 'vtex.search-graphql/graphql'
 
 import { Clients } from './clients'
 import { schemaDirectives } from './directives'
 import { resolvers } from './resolvers'
+import { setWorkspaceSearchParams, getWorkspaceSearchParams } from './routes/workspaceSearchParams'
+
 
 const TWO_SECONDS_MS = 2 * 1000
 const THREE_SECONDS_MS = 3 * 1000
@@ -65,5 +67,13 @@ export default new Service<Clients, RecorderState, CustomContext>({
     resolvers,
     schema,
     schemaDirectives,
+  },
+  routes: {
+    setWorkspaceSearchParams: method({
+      GET: setWorkspaceSearchParams
+    }),
+    getWorkspaceSearchParams: method({
+      GET: getWorkspaceSearchParams
+    }),
   },
 })

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -45,6 +45,7 @@ import {
 import { staleFromVBaseWhileRevalidate } from '../../utils/vbase'
 import { Checkout } from '../../clients/checkout'
 import setFilterVisibility from '../../utils/setFilterVisibility'
+import { getWorkspaceSearchParamsFromStorage } from '../../routes/workspaceSearchParams'
 
 interface ProductIndentifier {
   field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'
@@ -576,6 +577,9 @@ export const queries = {
 
     const sellers = await getSellers(vbase, checkout, segment?.channel, segment?.regionId)
 
+    const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
+    console.log("supsude1", workspaceSearchParams)
+
     const biggyArgs: SearchResultArgs = {
       fullText: query,
       attributePath: buildAttributePath(selectedFacets),
@@ -584,6 +588,7 @@ export const queries = {
       sellers: sellers,
       sort: convertOrderBy(orderBy),
       hideUnavailableItems,
+      workspaceSearchParams,
     }
 
     if (to !== null && from !== null) {
@@ -678,7 +683,10 @@ export const queries = {
 
     const [count, page] = getProductsCountAndPage(from, to)
 
-    const biggyArgs = {
+    const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
+    console.log("supsude1", workspaceSearchParams)
+
+    const biggyArgs : SearchResultArgs = {
       page,
       count,
       fuzzy,
@@ -686,11 +694,13 @@ export const queries = {
       searchState,
       attributePath: buildAttributePath(selectedFacets),
       query: fullText,
+      fullText,
       tradePolicy,
       sort: convertOrderBy(args.orderBy),
       sellers,
       hideUnavailableItems,
       options,
+      workspaceSearchParams,
     }
 
     const result = await biggySearch.productSearch(biggyArgs)

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -578,7 +578,6 @@ export const queries = {
     const sellers = await getSellers(vbase, checkout, segment?.channel, segment?.regionId)
 
     const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
-    console.log("supsude1", workspaceSearchParams)
 
     const biggyArgs: SearchResultArgs = {
       fullText: query,
@@ -684,7 +683,6 @@ export const queries = {
     const [count, page] = getProductsCountAndPage(from, to)
 
     const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
-    console.log("supsude1", workspaceSearchParams)
 
     const biggyArgs : SearchResultArgs = {
       page,
@@ -832,10 +830,13 @@ export const queries = {
 
     const sellers = await getSellers(vbase, checkout, tradePolicy, regionId)
 
+    const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
+
     const result = await biggySearch.suggestionProducts({
       ...args,
       salesChannel: tradePolicy,
-      sellers
+      sellers,
+      workspaceSearchParams
     })
 
     if (ctx.vtex.tenant && !args.productOriginVtex) {

--- a/node/routes/workspaceSearchParams.ts
+++ b/node/routes/workspaceSearchParams.ts
@@ -1,0 +1,35 @@
+const BUCKET = 'workspace-search-params'
+const MASTER = 'master'
+
+function disableCache(ctx: Context) {
+    ctx.set('Cache-control', 'no-cache,no-store')
+}
+
+export async function getWorkspaceSearchParamsFromStorage(ctx: Context) {   
+    const masterParams = await ctx.clients.vbase.getJSON<object>(BUCKET, MASTER, true)
+    if (ctx.vtex.workspace == MASTER) return masterParams
+    const filePath = ctx.vtex.workspace
+    const params = await ctx.clients.vbase.getJSON<object>(BUCKET, filePath, true)
+    // Logic: workspaces inherit params from master, and can override as desired
+    return {
+        ...masterParams,
+        ...params
+    }
+}
+
+export async function getWorkspaceSearchParams(ctx: Context, next: () => Promise<object>) {
+    const data = await getWorkspaceSearchParamsFromStorage(ctx)
+    disableCache(ctx)
+    ctx.body = data
+    ctx.status = 200
+    await next()
+}
+
+export async function setWorkspaceSearchParams(ctx: Context, next: () => Promise<object>) {
+    const filePath = ctx.vtex.workspace
+    await ctx.clients.vbase.saveJSON<object>(BUCKET, filePath, ctx.query)
+    disableCache(ctx)
+    ctx.body = ctx.query
+    ctx.status = 200
+    await next()
+}

--- a/node/service.json
+++ b/node/service.json
@@ -10,5 +10,19 @@
   "timeout": 12,
   "minReplicas": 30,
   "maxReplicas": 150,
-  "workers": 2
+  "workers": 2,
+  "routes": {
+    "setWorkspaceSearchParams": {
+      "path": "/_v/setWorkspaceSearchParams",
+      "public": false,
+      "cache": false,
+      "smartcache": false
+    },
+    "getWorkspaceSearchParams": {
+      "path": "/_v/getWorkspaceSearchParams",
+      "public": false,
+      "cache": false,
+      "smartcache": false
+    }
+  }
 }

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -62,6 +62,7 @@ interface SuggestionProductsArgs {
   sellers?: RegionSeller[]
   hideUnavailableItems?: boolean | null
   regionId?: string
+  workspaceSearchParams?: object
 }
 
 interface SuggestionSearchesArgs {

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -42,6 +42,7 @@ interface SearchResultArgs {
   removeHiddenFacets?: boolean | null
   options?: Options
   initialAttributes?: string
+  workspaceSearchParams?: object
 }
 
 interface RegionSeller {


### PR DESCRIPTION
#### What problem is this solving?

Enable setting per-store per-workspace parameters for queries submitted to search-api. Today, this is done by creating beta versions of search-resolver. Per-store search-api parameters could be set on the search-api backend, but not per store per-workspace.

The semantics are of inheritance: workspaces inherit master parameters, and can override existing parameters or define new values.

#### How should this be manually tested?

Run the following script: 

```python
#!/bin/bash

import argparse
import json
import os

import requests

parser = argparse.ArgumentParser()
parser.add_argument("--version", required=True, default='1')
parser.add_argument("--account", required=True)
parser.add_argument("--workspace", required=True)
parser.add_argument("--params")

args = parser.parse_args()

tokens = json.loads(open(os.path.expanduser("~/.vtex/session/tokens.json")).read())

token = tokens[args.account]

if args.params is None:
    uri = 'getWorkspaceSearchParams'
else:
    uri = f'setWorkspaceSearchParams?{args.params}'
r = requests.get(
    f"https://app.io.vtex.com/vtex.search-resolver/v{args.version}/{args.account}/{args.workspace}/_v/{uri}",
    headers={"VtexIdclientAutCookie": token, "Content-Type": "application/json"},
)
print(r.text)
```

Output:

```bash
$ python3 workspace_search_params.py --account biggy --workspace master --version 99 --params a=1  # set master params
$ python3 workspace_search_params.py --account biggy --workspace testsearchparams6 --version 99  # get workspace params
{"a":"1"} # note that it inherits from master
$ python3 workspace_search_params.py --account biggy --workspace testsearchparams6 --version 99 --params b=1 # set a new param on workspace
$ python3 workspace_search_params.py --account biggy --workspace testsearchparams6 --version 99 
{"a":"1","b":"1"} # note we add a new param on top of master params
$ python3 workspace_search_params.py --account biggy --workspace testsearchparams6 --version 99 --params 'a=2&b=1'  # override master param
$ python3 workspace_search_params.py --account biggy --workspace testsearchparams6 --version 99 
{"a":"2","b":"1"}  # overrode master
# last example below of adding new param to master
$ python3 workspace_search_params.py --account biggy --workspace master --version 99 --params 'a=1&c=1'
$ python3 workspace_search_params.py --account biggy --workspace master --version 99 
{"a":"1","c":"1"}
$ python3 workspace_search_params.py --account biggy --workspace testsearchparams6 --version 99 
{"a":"2","c":"1","b":"1"}
```

#### Checklist/Reminders

- [✔️ ] Updated `README.md`.
- [ ✔️] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
