### PR TITLE
fix: Expected Iterable, but did not find one for field

### DIFF
--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -328,7 +328,7 @@ export const resolvers = {
   },
   OnlyProduct: {
     categoryTree: productCategoriesToCategoryTree,
-    productClusters: ({ productClusters }: any) => productClusters ?? [],
-    clusterHighlights: ({ clusterHighlights }: any) => clusterHighlights ?? [],
+    productClusters: ({ productClusters }: any) => ([] as any[]).concat(productClusters ?? []),
+    clusterHighlights: ({ clusterHighlights }: any) => ([] as any[]).concat(clusterHighlights ?? []),
   },
 }

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -328,5 +328,7 @@ export const resolvers = {
   },
   OnlyProduct: {
     categoryTree: productCategoriesToCategoryTree,
+    productClusters: ({ productClusters }: any) => productClusters ?? [],
+    clusterHighlights: ({ clusterHighlights }: any) => clusterHighlights ?? [],
   },
 }


### PR DESCRIPTION
#### What problem is this solving?
This PR fixes the issue on OnlyProduct fields of ```Expected Iterable, but did not find one for field```  by adding an empty array when this data does not exist

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
