### PR TITLE
Add initialAttributes to facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `initialAttributes` to `facets` query.
+
 ## [1.47.4] - 2021-07-05
 
 ## [1.47.3] - 2021-07-05

--- a/node/clients/biggy-search.ts
+++ b/node/clients/biggy-search.ts
@@ -217,7 +217,8 @@ export class BiggySearchClient extends ExternalClient {
       leap,
       searchState,
       sellers,
-      hideUnavailableItems
+      hideUnavailableItems,
+      initialAttributes
     } = args
 
     const cache = validNavigationPage(args.attributePath, query) ? { forceMaxAge: 3600 } : {}
@@ -235,6 +236,7 @@ export class BiggySearchClient extends ExternalClient {
         fuzzy,
         locale: this.locale,
         bgy_leap: leap ? true : undefined,
+        initialAttributes,
         ['hide-unavailable-items']: hideUnavailableItems ? 'true' : 'false',
         ...parseState(searchState),
       },

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -407,7 +407,7 @@ export const queries = {
       args
     )) as FacetsInput
 
-    let { fullText, searchState } = args
+    let { fullText, searchState, initialAttributes } = args
 
     if (fullText) {
       fullText = await translateToStoreDefaultLanguage(ctx, args.fullText!)
@@ -431,6 +431,7 @@ export const queries = {
       tradePolicy,
       sellers,
       hideUnavailableItems: args.hideUnavailableItems,
+      initialAttributes,
     }
 
     const result = await biggySearch.facets(biggyArgs)
@@ -642,7 +643,7 @@ export const queries = {
       searchState,
       simulationBehavior,
       hideUnavailableItems,
-      options
+      options,
     } = args
     let [regionId, selectedFacets] = getRegionIdFromSelectedFacets(args.selectedFacets)
 

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -41,6 +41,7 @@ interface SearchResultArgs {
   hideUnavailableItems?: boolean | null
   removeHiddenFacets?: boolean | null
   options?: Options
+  initialAttributes?: string
 }
 
 interface RegionSeller {
@@ -83,6 +84,7 @@ interface FacetsInput {
   searchState?: string
   removeHiddenFacets: boolean
   hideUnavailableItems: boolean
+  initialAttributes?: string
 }
 
 interface ProductSearchInput {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4626,7 +4626,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--carrefourbr.myvtex.com/admin/graphql-ide)
example:
```
query {
  facets(
    hideUnavailableItems: false,
    behavior: "static",
    initialAttributes: "c,c",
    selectedFacets: [
      {key: "c", value: "eletrodomesticos"},
      {key: "c", value: "geladeira"},
      {key: "b", value: "vonder"}
    ]){
    facets{
      name
      type
      quantity
      values {
        name
        key
        range {
          from
          to
        }
      }
    }
  }
}
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
