### PR TITLE
Fix productId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `productId` that was different from the catalog ID.
+
 ## [1.51.0] - 2021-07-29
 
 ### Feature

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -123,7 +123,7 @@ export const convertBiggyProduct = async (
   const convertedProduct: SearchProduct & { cacheId?: string, [key: string]: any } = {
     categories,
     categoriesIds,
-    productId: product.id,
+    productId: product.product,
     cacheId: `sp-${product.id}`,
     productName: product.name,
     productReference: product.reference,


### PR DESCRIPTION
#### What problem is this solving?

The `product.id` of our API is not always the same as the product ID in the catalog, as it can sometimes contain SKU information. Therefore, we must use `product.product` which is always equal to the catalog ID

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://hiago--paylessus.myvtex.com/admin/graphql-ide)
```
query{
  productSearch(
    selectedFacets: [
      {key:"c", value: "footwear"}, 
      {key:"gender", value: "women"}
    ],
  ) {
    products{
      productId
    }
  }
}
```
#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

[Before](https://paylessus.myvtex.com/admin/graphql-ide):
![image](https://user-images.githubusercontent.com/20840671/126690564-2004b482-7e67-4117-85c0-86a45048a57e.png)

[After](https://hiago--paylessus.myvtex.com/admin/graphql-ide):
![image](https://user-images.githubusercontent.com/20840671/126690586-91a02820-da77-4fc4-b28b-510d854d17f3.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Depends on https://github.com/vtex-apps/search-result/pull/531

<!-- Put any relevant information that doesn't fit in the other sections here. -->
