### PR TITLE
add getFirstNonNullable and new cacheId to the productSuggestion product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.53.0] - 2021-09-02
 
+### Fixed
+- Use the `getFirstNonNullable` to select the correct price
+- Use a exclusive `cacheId` in the `productSuggestion` products. This avoids conflicts when the same product appears twice, on search-result and on autocomplete.
+
 ### Changed
 - Use `vtexis-compatibility-layer` to convert the product and `itemsWithSimulation` to call the simulation API.
 

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -4,6 +4,7 @@ import { Checkout } from '../clients/checkout'
 import { groupBy, prop, indexBy, mergeAll, clone } from 'ramda'
 import { removeDiacriticsFromURL } from '../utils/string'
 import { FilterValue, Attribute } from '../utils/attributes'
+import getFirstNonNullable from '../utils/getFirstNonNull'
 
 const ALLOWED_TEASER_TYPES = ["Catalog", "Profiler", "ConditionalPrice"]
 
@@ -405,11 +406,11 @@ const getSellersIndexedByApi = (
   const biggySellers = (selectedPolicy && selectedPolicy.sellers) || []
 
   return biggySellers.map((seller: BiggySeller): Seller => {
-    const price = seller.price || sku.price || product.price
-    const oldPrice = seller.oldPrice || sku.oldPrice || product.oldPrice
+    const price = getFirstNonNullable<number>([seller.price, sku.price, product.price])!
+    const oldPrice = getFirstNonNullable<number>([seller.oldPrice, sku.oldPrice, product.oldPrice])!
     const installment = seller.installment || product.installment
 
-    const stock = seller.stock || sku.stock || product.stock
+    const stock = getFirstNonNullable<number>([seller.stock, sku.stock, product.stock])!
     const teasers = seller.teasers ?? [];
 
     const commertialOffer = buildCommertialOffer(price, oldPrice, stock, teasers, installment, seller.tax)

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -845,17 +845,23 @@ export const queries = {
       ctx.vtex.tenant.locale = result.locale
     }
 
-    const convertedProducts = args.productOriginVtex ?
+    const convertedProductsPromises = args.productOriginVtex ?
       await productsCatalog(({ ctx, simulationBehavior: args.simulationBehavior, searchResult: result, tradePolicy: String(tradePolicy), regionId })) :
       await convertProducts(result.products, ctx, args.simulationBehavior, tradePolicy, regionId)
 
-      convertedProducts.forEach(product => product.origin = 'intelligent-search')
+    const convertedProducts = await Promise.all(convertedProductsPromises)
+
+    convertedProducts.forEach(product => product.origin = 'intelligent-search')
 
     const {
       count,
       operator,
       correction: { misspelled },
     } = result
+
+    convertedProducts.forEach(product => {
+      product.cacheId = `sae-productSearch-autocomplete-${product.productId}`
+    })
 
     return { count, operator, misspelled, products: convertedProducts }
   },

--- a/node/utils/getFirstNonNull.ts
+++ b/node/utils/getFirstNonNull.ts
@@ -1,0 +1,3 @@
+export default function getFirstNonNullable<T>(arr: T[]): T | undefined {
+  return arr.find(el => el !== null && typeof el !== 'undefined')
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4643,7 +4643,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

1. The number `0` is falsey in Javascript. It was giving us problems when selecting the correct price. That's why I added the `getFirstNonNullable` function.
2. The product on search-result and on autocomplete were sharing the same `cacheId`. This was  causing issues since they will share the same context. Check the video

https://user-images.githubusercontent.com/40380674/132253312-68711bb4-1806-435d-93f2-b6ad5f24be59.mov

#### How should this be manually tested?

[Workspace](https://hiago--carrefourbr.myvtex.com/busca/notebook)

