### PR TITLE
Feature/search refact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Use `vtexis-compatibility-layer` to convert the product and `itemsWithSimulation` to call the simulation API.
 
-## [1.53.2] - 2021-09-17 [YANKED]
+## [1.53.2] - 2021-09-17
 
 ### Fixed
 - Revert `v1.53.1` and `v1.53.0`
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix `clusterHighlights` type.
 
-## [1.53.0] - 2021-09-02
+## [1.53.0] - 2021-09-02 [YANKED]
 
 ### Changed
 - Use `vtexis-compatibility-layer` to convert the product and `itemsWithSimulation` to call the simulation API.

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "vtex.catalog-api-proxy": "0.x",
     "vtex.search-graphql": "0.x",
     "vtex.rewriter": "1.x",
-    "vtex.sae-analytics": "2.x"
+    "vtex.sae-analytics": "2.x",
+    "vtex.store-graphql": "2.x"
   },
   "settingsSchema": {
     "type": "object",
@@ -61,6 +62,9 @@
     },
     {
       "name": "vtex.messages:graphql-translate-messages"
+    },
+    {
+      "name": "vtex.store-graphql:resolve-graphql"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -4,6 +4,7 @@ import { Search } from './search'
 import { Checkout } from './checkout'
 import { Rewriter } from './rewriter'
 import { BiggySearchClient } from './biggy-search'
+import { Store } from './store'
 
 export class Clients extends IOClients {
   public get search() {
@@ -17,5 +18,8 @@ export class Clients extends IOClients {
   }
   public get biggySearch() {
     return this.getOrSet('biggySearch', BiggySearchClient)
+  }
+  public get store() {
+    return this.getOrSet('store', Store)
   }
 }

--- a/node/clients/store/index.ts
+++ b/node/clients/store/index.ts
@@ -1,0 +1,37 @@
+import { AppGraphQLClient, IOContext, InstanceOptions } from '@vtex/api'
+
+import { itemsWithSimulation } from './queries'
+
+interface ItemsWithSimulationPayload {
+  items: {
+    itemId: string
+    sellers: { sellerId: string }[]
+  }[],
+  regionId?: string
+}
+
+export class Store extends AppGraphQLClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super('vtex.store-graphql@2.x', context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+      },
+    })
+  }
+
+  public itemsWithSimulation = (variables: ItemsWithSimulationPayload) => {
+    return this.graphql.query<
+      { itemsWithSimulation: SearchItem[] },
+      ItemsWithSimulationPayload
+    >(
+      {
+        query: itemsWithSimulation,
+        variables,
+      },
+      {
+        metric: 'search-items-with-simulation',
+      }
+    )
+  }
+}

--- a/node/clients/store/queries.ts
+++ b/node/clients/store/queries.ts
@@ -1,0 +1,45 @@
+export const itemsWithSimulation = `
+query itemsWithSimulation($items: [ItemInput], $regionId: String) {
+  itemsWithSimulation(items: $items, regionId: $regionId) {
+    itemId
+    sellers {
+      sellerId
+      commertialOffer {
+        AvailableQuantity
+        Price
+        ListPrice
+        spotPrice
+        PriceValidUntil
+        PriceWithoutDiscount
+        discountHighlights {
+          name
+        }
+        teasers {
+          name
+          conditions {
+            minimumQuantity
+            parameters {
+              name
+              value
+            }
+          }
+          effects {
+            parameters {
+              name
+              value
+            }
+          }
+        }
+        Installments {
+        	Value
+          InterestRate
+          TotalValuePlusInterestRate
+          NumberOfInstallments
+          Name
+          PaymentSystemName
+      	}
+      }
+    }
+  }
+}
+`

--- a/node/index.ts
+++ b/node/index.ts
@@ -6,12 +6,15 @@ import schema from 'vtex.search-graphql/graphql'
 import { Clients } from './clients'
 import { schemaDirectives } from './directives'
 import { resolvers } from './resolvers'
-import { setWorkspaceSearchParams, getWorkspaceSearchParams } from './routes/workspaceSearchParams'
-
+import {
+  setWorkspaceSearchParams,
+  getWorkspaceSearchParams,
+} from './routes/workspaceSearchParams'
 
 const TWO_SECONDS_MS = 2 * 1000
 const THREE_SECONDS_MS = 3 * 1000
 const SIX_SECONDS_MS = 6 * 1000
+const NINE_SECONDS_MS = 9 * 1000
 
 // Segments are small and immutable.
 const MAX_SEGMENT_CACHE = 10000
@@ -69,6 +72,10 @@ export default new Service<Clients, RecorderState, CustomContext>({
         memoryCache: vbaseCache,
         timeout: TWO_SECONDS_MS,
       },
+      store: {
+        retries: 0,
+        timeout: NINE_SECONDS_MS,
+      },
     },
   },
   graphql: {
@@ -78,10 +85,10 @@ export default new Service<Clients, RecorderState, CustomContext>({
   },
   routes: {
     setWorkspaceSearchParams: method({
-      GET: setWorkspaceSearchParams
+      GET: setWorkspaceSearchParams,
     }),
     getWorkspaceSearchParams: method({
-      GET: getWorkspaceSearchParams
+      GET: getWorkspaceSearchParams,
     }),
   },
 })

--- a/node/package.json
+++ b/node/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@gocommerce/utils": "^0.6.11",
+    "@vtex/vtexis-compatibility-layer": "^0.1.0",
     "atob": "^2.1.2",
     "axios": "^0.19.0",
     "camelcase": "^5.0.0",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -38,7 +38,7 @@ import {
   convertOrderBy,
   buildBreadcrumb,
 } from '../../commons/compatibility-layer'
-import { productsCatalog, productsBiggy } from '../../commons/products'
+import { productsCatalog } from '../../commons/products'
 import {
   attributesToFilters,
   sortAttributeValuesByCatalog,
@@ -47,6 +47,7 @@ import { staleFromVBaseWhileRevalidate } from '../../utils/vbase'
 import { Checkout } from '../../clients/checkout'
 import setFilterVisibility from '../../utils/setFilterVisibility'
 import { getWorkspaceSearchParamsFromStorage } from '../../routes/workspaceSearchParams'
+import { convertProducts } from '../../utils/compatibility-layer'
 
 interface ProductIndentifier {
   field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'
@@ -103,8 +104,8 @@ const getTradePolicyFromSelectedFacets = (selectedFacets: SelectedFacet[] = []):
   return tradePolicy.length > 0 ? tradePolicy[0].value : null
 }
 
-const getRegionIdFromSelectedFacets = (selectedFacets: SelectedFacet[] = []): [(string | null), SelectedFacet[]] => {
-  let regionId = null
+const getRegionIdFromSelectedFacets = (selectedFacets: SelectedFacet[] = []): [(string | undefined), SelectedFacet[]] => {
+  let regionId = undefined
 
   const regionIdIndex = selectedFacets.findIndex(selectedFacet => selectedFacet.key === "region-id")
 
@@ -598,15 +599,15 @@ export const queries = {
       biggyArgs["page"] = page
     }
 
-    const products = await biggySearch.productSearch(biggyArgs)
+    const result = await biggySearch.productSearch(biggyArgs)
 
     if (ctx.vtex.tenant) {
-      ctx.vtex.tenant.locale = products.locale
+      ctx.vtex.tenant.locale = result.locale
     }
 
-    const regionId = segment?.regionId
-    const convertedProducts = await productsBiggy({ ctx, simulationBehavior, searchResult: products, regionId })
-    convertedProducts.forEach(product => product.cacheId = `sae-productSearch-${product.cacheId || product.linkText}`)
+    const convertedProducts = await convertProducts(result.products, ctx, simulationBehavior)
+
+    convertedProducts.forEach(product => product.origin = 'intelligent-search')
 
     return convertedProducts
   },
@@ -676,7 +677,7 @@ export const queries = {
     } = args
     let [regionId, selectedFacets] = getRegionIdFromSelectedFacets(args.selectedFacets)
 
-    regionId = regionId || segment?.regionId
+    regionId = regionId ?? segment?.regionId
 
     const tradePolicy = getTradePolicyFromSelectedFacets(args.selectedFacets) || segment?.channel
 
@@ -709,13 +710,11 @@ export const queries = {
       ctx.vtex.tenant.locale = result.locale
     }
 
-    const productResolver = args.productOriginVtex
-      ? productsCatalog
-      : productsBiggy
-    const convertedProducts = await productResolver({ ctx, simulationBehavior, searchResult: result, tradePolicy, regionId })
+    const convertedProducts = args.productOriginVtex ?
+      await productsCatalog(({ ctx, simulationBehavior, searchResult: result, tradePolicy, regionId })) :
+      await convertProducts(result.products, ctx, simulationBehavior, tradePolicy, regionId)
 
-    // Add prefix to the cacheId to avoid conflicts. Repeated cacheIds in the same page are causing strange behavior.
-    convertedProducts.forEach(product => product.cacheId = `sae-productSearch-${product.cacheId || product.linkText}`)
+    convertedProducts.forEach(product => product.origin =  args.productOriginVtex ? 'catalog' : 'intelligent-search')
 
     return {
       searchState,
@@ -828,15 +827,16 @@ export const queries = {
 
     const regionId = args.regionId || segment?.regionId
 
-    const tradePolicy = args.salesChannel || segment?.channel
+    const salesChannel = args.salesChannel || segment?.channel
+    const tradePolicy = salesChannel ? String(salesChannel) : undefined
 
-    const sellers = await getSellers(vbase, checkout, tradePolicy, regionId)
+    const sellers = await getSellers(vbase, checkout, salesChannel, regionId)
 
     const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
 
     const result = await biggySearch.suggestionProducts({
       ...args,
-      salesChannel: tradePolicy,
+      salesChannel,
       sellers,
       workspaceSearchParams
     })
@@ -845,19 +845,11 @@ export const queries = {
       ctx.vtex.tenant.locale = result.locale
     }
 
-    const productResolver = args.productOriginVtex
-      ? productsCatalog
-      : productsBiggy
+    const convertedProducts = args.productOriginVtex ?
+      await productsCatalog(({ ctx, simulationBehavior: args.simulationBehavior, searchResult: result, tradePolicy: String(tradePolicy), regionId })) :
+      await convertProducts(result.products, ctx, args.simulationBehavior, tradePolicy, regionId)
 
-    const convertedProducts = productResolver(
-      {
-        ctx,
-        searchResult: result,
-        simulationBehavior: args.simulationBehavior,
-        tradePolicy: String(tradePolicy),
-        regionId
-      }
-    )
+      convertedProducts.forEach(product => product.origin =  args.productOriginVtex ? 'catalog' : 'intelligent-search')
 
     const {
       count,

--- a/node/resolvers/search/offer.ts
+++ b/node/resolvers/search/offer.ts
@@ -74,7 +74,9 @@ export const resolvers = {
       )
       return [value]
     },
-    teasers: propOr([], 'Teasers'),
+    teasers: (offer: CommertialOffer) => {
+      return offer.teasers ?? offer.Teasers ?? []
+    },
     giftSkuIds: propOr([], 'GiftSkuIds'),
     gifts: async ({ GiftSkuIds }: CommertialOffer, _: any, ctx: Context) => {
       if (GiftSkuIds.length === 0) {
@@ -127,6 +129,9 @@ export const resolvers = {
     },
     discountHighlights: propOr([], 'DiscountHighLight'),
     spotPrice: (offer: CommertialOffer) => {
+      if (offer.spotPrice) {
+        return offer.spotPrice
+      }
       const sellingPrice = offer.Price
       const spotPrice: number | undefined = offer.Installments.find(({NumberOfInstallments, Value}) => {
         return (NumberOfInstallments === 1 && Value < sellingPrice)

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -170,8 +170,13 @@ export const resolvers = {
     cacheId: ({ linkText, cacheId }: SearchProductWithCache) =>
       cacheId || linkText,
 
-    clusterHighlights: ({ clusterHighlights = {} }: SearchProduct) =>
-      objToNameValue('id', 'name', clusterHighlights),
+    clusterHighlights: ({origin, clusterHighlights }: SearchProduct) => {
+      if (origin === 'intelligent-search') {
+        return clusterHighlights
+      }
+
+      return objToNameValue('id', 'name', clusterHighlights)
+    },
 
     jsonSpecifications: (product: SearchProduct) => {
       const { Specifications = [] } = product
@@ -185,8 +190,13 @@ export const resolvers = {
       return JSON.stringify(specificationsMap)
     },
 
-    productClusters: ({ productClusters = {} }: SearchProduct) =>
-      objToNameValue('id', 'name', productClusters),
+    productClusters: ({origin, productClusters }: SearchProduct) => {
+      if (origin === 'intelligent-search') {
+        return productClusters
+      }
+
+      return objToNameValue('id', 'name', productClusters)
+    },
 
     properties: async (product: SearchProduct, _: unknown, ctx: Context) => {
       const valuesUntranslated = (product.allSpecifications ?? []).map((name: string) => {

--- a/node/resolvers/search/sku.ts
+++ b/node/resolvers/search/sku.ts
@@ -53,7 +53,8 @@ export const resolvers = {
       if (!sku) {
         return sku
       }
-      const variations = (sku.variations || []).map(variationName => {
+      const variations = (sku.variations || []).map(variationObj => {
+        const variationName = typeof variationObj === 'string' ? variationObj : (variationObj as {name: string}).name
         const fieldId = (sku.skuSpecifications || []).find(specification => specification.field.name === variationName)?.field?.id
         const variationsValues = (sku as any)[variationName] as string[]
         return {

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -78,6 +78,7 @@ enum FacetsBehavior {
 }
 
 interface SearchProduct {
+  origin?: string
   productId: string
   productName: string
   brand: string
@@ -194,10 +195,12 @@ interface CommertialOffer {
   DiscountHighLight: any[]
   GiftSkuIds: string[]
   Teasers: object[]
+  teasers?: object[]
   BuyTogether: any[]
   ItemMetadataAttachment: any[]
   Price: number
   ListPrice: number
+  spotPrice?: number
   PriceWithoutDiscount: number
   RewardValue: number
   PriceValidUntil: string

--- a/node/utils/compatibility-layer.ts
+++ b/node/utils/compatibility-layer.ts
@@ -1,0 +1,62 @@
+import {
+  convertISProduct,
+  mergeProductWithItems,
+} from '@vtex/vtexis-compatibility-layer'
+import { Store } from '../clients/store'
+
+const fillProductWithSimulation = async (
+  product: SearchProduct,
+  store: Store,
+  ctx: Context,
+  regionId?: string,
+) => {
+  const { vtex: { logger } } = ctx
+
+  const payload = {
+    items: product.items.map(item => ({
+      itemId: item.itemId,
+      sellers: item.sellers.map(seller => ({
+        sellerId: seller.sellerId,
+      })),
+    })),
+    regionId,
+  }
+
+  try {
+    const itemsWithSimulation = await store.itemsWithSimulation(payload)
+
+    if (!itemsWithSimulation.data) {
+      return product
+    }
+
+    return mergeProductWithItems(
+      product,
+      itemsWithSimulation.data.itemsWithSimulation
+    )
+  } catch(error) {
+    logger.error({
+      message: error.message,
+      error,
+    })
+
+    return product
+  }
+}
+
+export const convertProducts = async (products: BiggySearchProduct[], ctx: Context, simulationBehavior: 'skip' | 'default' | null, channel?: string, regionId?: string) => {
+  const {
+    vtex: { segment },
+    clients: { store },
+  } = ctx
+  const salesChannel = channel ?? segment?.channel?.toString()
+
+  let convertedProducts =  products
+    .map(product => convertISProduct(product, salesChannel))
+
+  if (simulationBehavior === 'default') {
+    const simulationPromises = convertedProducts.map(product => fillProductWithSimulation(product as SearchProduct, store, ctx, regionId))
+    convertedProducts = (await Promise.all(simulationPromises)) as SearchProduct[]
+  }
+
+  return convertedProducts
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -839,6 +839,13 @@
     "@types/jest" "^24.0.18"
     "@types/node" "^12.7.2"
 
+"@vtex/vtexis-compatibility-layer@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@vtex/vtexis-compatibility-layer/-/vtexis-compatibility-layer-0.1.0.tgz#ed3156d4b189f9fdadc178136925cd6b1bc6448d"
+  integrity sha512-YWFtOW/sv/JQTjC+IO/bOYE+QYH9whKUU5QUW26+W1AlG282zFXQtRuPNE79xlJs0BiS/g47bGo3z9i0GQKB4A==
+  dependencies:
+    ramda "^0.27.1"
+
 "@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
@@ -4149,6 +4156,11 @@ ramda@^0.26.0, ramda@^0.26.1:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
+
 raw-body@^2.3.3:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
@@ -4631,7 +4643,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4643,7 +4643,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

We were facing a lot of simulation timeout errors on `v1.54.0`. This PR re-revert the `v1.54.0` version and fixes the problem by setting `{timeout: 9000ms, retries: 0}` on `search-resolver` and `{timeout: 3000ms, retries 2}` on [`store-graphql`](https://github.com/vtex-apps/store-graphql/pull/572).

#### How should this be manually tested?

[Workspace](https://hiago--rihappynovo.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Depends on
https://github.com/vtex-apps/store-graphql/pull/572
