### PR TITLE
Remove splunk log from simulation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove splunk log from simulation errors.
+
 ## [1.54.2] - 2021-09-27
 
 ## [1.54.1] - 2021-09-24

--- a/node/utils/compatibility-layer.ts
+++ b/node/utils/compatibility-layer.ts
@@ -7,11 +7,8 @@ import { Store } from '../clients/store'
 const fillProductWithSimulation = async (
   product: SearchProduct,
   store: Store,
-  ctx: Context,
   regionId?: string,
 ) => {
-  const { vtex: { logger } } = ctx
-
   const payload = {
     items: product.items.map(item => ({
       itemId: item.itemId,
@@ -34,10 +31,10 @@ const fillProductWithSimulation = async (
       itemsWithSimulation.data.itemsWithSimulation
     )
   } catch(error) {
-    logger.error({
-      message: error.message,
-      error,
-    })
+    // TODO: PER-2503 - Improve error observability
+    if (process.env.VTEX_APP_LINK) {
+      console.error(error)
+    }
 
     return product
   }
@@ -54,7 +51,7 @@ export const convertProducts = async (products: BiggySearchProduct[], ctx: Conte
     .map(product => convertISProduct(product, salesChannel))
 
   if (simulationBehavior === 'default') {
-    const simulationPromises = convertedProducts.map(product => fillProductWithSimulation(product as SearchProduct, store, ctx, regionId))
+    const simulationPromises = convertedProducts.map(product => fillProductWithSimulation(product as SearchProduct, store, regionId))
     convertedProducts = (await Promise.all(simulationPromises)) as SearchProduct[]
   }
 


### PR DESCRIPTION
#### What problem is this solving?

We were facing an overnotification of simulation errors on the `v1.54.2`. We didn't have this before the search-refact. Comparing both codes (the old and the new) I noticed that the previous version was just  [using the `console.error` to log simulations errors](https://github.com/vtex-apps/search-resolver/blob/v1.x/node/commons/products.ts#L22), So I did the same to the refactored version.

1. Does it mean that we will not have simulation errors visibility after this deploy?
No. We will have exactly the same visibility we had before the 
refactoring.

2. Should we investigate why we had so many errors during the `v1.54.2`?
Yes! I added a topic called Search-resolver simulation error to the [PER-2503](https://vtex-dev.atlassian.net/browse/PER-2503).

#### How should this be manually tested?

[Workspace](https://hiago--rihappynovo.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
