### PR TITLE
Fix itemsWithSimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `itemsWithSimulation` that was not considering `salesChannel` argument.
+
 ## [1.58.1] - 2021-10-13
 
 ### Changed

--- a/node/clients/store/index.ts
+++ b/node/clients/store/index.ts
@@ -8,9 +8,11 @@ interface ItemsWithSimulationPayload {
     sellers: { sellerId: string }[]
   }[],
   regionId?: string
+  salesChannel?: string
 }
 
 export class Store extends AppGraphQLClient {
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
   constructor(context: IOContext, options?: InstanceOptions) {
     super('vtex.store-graphql@2.x', context, {
       ...options,

--- a/node/clients/store/queries.ts
+++ b/node/clients/store/queries.ts
@@ -1,6 +1,6 @@
 export const itemsWithSimulation = `
-query itemsWithSimulation($items: [ItemInput], $regionId: String) {
-  itemsWithSimulation(items: $items, regionId: $regionId) {
+query itemsWithSimulation($items: [ItemInput], $regionId: String, $salesChannel: String) {
+  itemsWithSimulation(items: $items, regionId: $regionId, salesChannel: $salesChannel) {
     itemId
     sellers {
       sellerId

--- a/node/utils/compatibility-layer.ts
+++ b/node/utils/compatibility-layer.ts
@@ -9,6 +9,7 @@ const fillProductWithSimulation = async (
   store: Store,
   simulationBehavior: 'default' | 'only1P',
   regionId?: string,
+  salesChannel?: string,
 ) => {
   const payload = {
     items: product.items.map(item => ({
@@ -18,6 +19,7 @@ const fillProductWithSimulation = async (
       })),
     })),
     regionId,
+    salesChannel,
   }
 
   try {
@@ -42,7 +44,13 @@ const fillProductWithSimulation = async (
   }
 }
 
-export const convertProducts = async (products: BiggySearchProduct[], ctx: Context, simulationBehavior: 'skip' | 'default' | 'only1P' | null, channel?: string, regionId?: string) => {
+export const convertProducts = async (
+  products: BiggySearchProduct[], 
+  ctx: Context, 
+  simulationBehavior: 'skip' | 'default' | 'only1P' | null, 
+  channel?: string, 
+  regionId?: string
+) => {
   const {
     vtex: { segment },
     clients: { store },
@@ -53,7 +61,15 @@ export const convertProducts = async (products: BiggySearchProduct[], ctx: Conte
     .map(product => convertISProduct(product, salesChannel))
 
   if (simulationBehavior === 'default' || simulationBehavior === 'only1P') {
-    const simulationPromises = convertedProducts.map(product => fillProductWithSimulation(product as SearchProduct, store, simulationBehavior, regionId))
+    const simulationPromises = convertedProducts.map(product => 
+      fillProductWithSimulation(
+        product as SearchProduct,
+        store,
+        simulationBehavior,
+        regionId,
+        salesChannel
+      )
+    )
     convertedProducts = (await Promise.all(simulationPromises)) as SearchProduct[]
   }
 


### PR DESCRIPTION
#### What problem is this solving?
Some stores don't have the `segment` cookie or want to use different info than the cookie, so they use search passing `regionId` and `salesChannel` as parameters. 
However, now that the `search-resolver` uses the `itemsWithSimulation` query to get the simulation info for a product, we weren't passing the `salesChannel` to the simulation like we do with the `regionId`,  so simulation was always getting the salesChannel from segment, instead of using the one the store provides as an argument to `productSearch`.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Workspace](https://thalyta--jumbo.myvtex.com/admin/graphql-ide)

#### Screenshots or example usage

If you try to use a different trade policy (AKA sales channel), it should return the price of the sales channel you used, instead of returning the price of the sales channel from the segment (in this case, 1)

[Before](https://thalyta1--jumbo.myvtex.com/admin/graphql-ide): (wrong price, from salesChannel 1)
![image](https://user-images.githubusercontent.com/20840671/137498559-8c0aa792-4d9e-40a7-b9c6-291673ec27e3.png)


After: (price from sales channel 50)
![image](https://user-images.githubusercontent.com/20840671/137497366-5cdf0673-3fef-4197-bd80-2956344ef789.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
Depends on https://github.com/vtex-apps/store-graphql/pull/576
