### PR TITLE
Always translate linkText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Translated `linkText`.
+
 ## [1.58.3] - 2021-10-18
 
 ### Fixed

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -32,6 +32,7 @@ declare global {
     cookie: string
     originalPath: string
     vtex: CustomIOContext
+    translated?: boolean
   }
 
   interface CustomIOContext extends IOContext {

--- a/node/package.json
+++ b/node/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@gocommerce/utils": "^0.6.11",
-    "@vtex/vtexis-compatibility-layer": "0.2.3",
+    "@vtex/vtexis-compatibility-layer": "^0.2.5",
     "atob": "^2.1.2",
     "axios": "^0.19.0",
     "camelcase": "^5.0.0",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -493,7 +493,7 @@ export const queries = {
     const [intelligentSearchFacets, solrFacets] = await Promise.all(facetPromises)
 
     if (ctx.vtex.tenant) {
-      ctx.vtex.tenant.locale = intelligentSearchFacets.locale
+      ctx.translated = intelligentSearchFacets.translated
     }
 
     // FIXME: This is used to sort values based on catalog API.
@@ -635,7 +635,7 @@ export const queries = {
     const result = await biggySearch.productSearch(biggyArgs)
 
     if (ctx.vtex.tenant) {
-      ctx.vtex.tenant.locale = result.locale
+      ctx.translated = result.translated
     }
 
     const convertedProducts = await convertProducts(result.products, ctx, simulationBehavior)
@@ -744,7 +744,7 @@ export const queries = {
     const result = await biggySearch.productSearch(biggyArgs)
 
     if (ctx.vtex.tenant && !args.productOriginVtex) {
-      ctx.vtex.tenant.locale = result.locale
+      ctx.translated = result.translated
     }
 
     const convertedProducts = args.productOriginVtex ?
@@ -882,7 +882,7 @@ export const queries = {
     })
 
     if (ctx.vtex.tenant && !args.productOriginVtex) {
-      ctx.vtex.tenant.locale = result.locale
+      ctx.translated = result.translated
     }
 
     const convertedProducts = args.productOriginVtex ?

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -248,7 +248,7 @@ export const resolvers = {
       const { clients: { rewriter, apps }, vtex: { binding } } = ctx
       const settings: AppSettings = await apps.getAppSettings(APP_NAME)
 
-      if (!shouldTranslateToBinding(ctx)) {
+      if (!shouldTranslateToBinding(ctx, true)) {
         return settings.slugifyLinks ? Slugify(linkText) : linkText
       }
       const route = await rewriter.getRoute(productId, 'product', binding!.id!)

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -74,8 +74,8 @@ export const translateManyToCurrentLanguage = (messages: Message[], ctx: Context
 
 export const shouldTranslateToUserLocale = ({ vtex: { tenant, locale } }: Context) => tenant?.locale !== locale
 
-export const shouldTranslateToBinding = ({ vtex: { binding, tenant } }: Context) =>
-  Boolean(tenant?.locale && binding?.locale && tenant.locale !== binding.locale)
+export const shouldTranslateToBinding = ({ translated }: Context, ignoreIndexedTranslation?: boolean) =>
+  !translated || ignoreIndexedTranslation
 
-  export const shouldTranslateToTenantLocale = ({ vtex: { locale, tenant } }: Context) =>
+export const shouldTranslateToTenantLocale = ({ vtex: { locale, tenant } }: Context) =>
   Boolean(tenant?.locale && locale && tenant.locale !== locale)

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -839,10 +839,10 @@
     "@types/jest" "^24.0.18"
     "@types/node" "^12.7.2"
 
-"@vtex/vtexis-compatibility-layer@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@vtex/vtexis-compatibility-layer/-/vtexis-compatibility-layer-0.2.3.tgz#de73388088d7be57ef58b532c3b28299af264395"
-  integrity sha512-WefYd+Q72Il04I9b1QLSAwXrAGZPzeoHmHfIR/+/bWFfhMy35lrhMtEGe2U2PnwPzRvxayi5xYXOZjnFXmltEA==
+"@vtex/vtexis-compatibility-layer@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@vtex/vtexis-compatibility-layer/-/vtexis-compatibility-layer-0.2.5.tgz#74875544688fb0f22ecf3e72b6391e149cd2c83c"
+  integrity sha512-7oz/JziJYIPGBx4Of1H88JLsU4KIMYvmcWKRSwfB6+Ao0ZLA0uPDmO8sUo40DOuZQdRHVeBJTMWtRV5+c6dtSQ==
   dependencies:
     ramda "^0.27.1"
 


### PR DESCRIPTION
#### What problem is this solving?

`linkText` was not being translated depending on page language. 
currently, the API doesn't return this translated value, so we should always translate `linkText` in the resolver

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--quebramar.myvtex.com/homem/colecao/camisas?__bindingAddress=www.quebramar.com/en)
- check if the product link is translated to English or Portuguese depending on the language of the store.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/20840671/138354424-393f2f21-125f-4645-812e-7d3923105676.png)

After:
![image](https://user-images.githubusercontent.com/20840671/138354388-2e46cfb9-8c19-4656-86d9-e60996c0db8d.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
