### PR TITLE
PER-2337: Clean breadcrumb link for category, department or brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Clean breadcrumb link for department, category, or brand.
+
 ## [1.58.5] - 2021-11-08
 
 ## [1.58.4] - 2021-11-08

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -554,6 +554,14 @@ export const convertOrderBy = (orderBy?: string | null): string => {
   }
 }
 
+const canCleanMap = (attributeKey: string, map: string[]) => {
+  const categoryKeys = ['category-1', 'category-2']
+  if (map.length > 2) {
+    return false
+  }
+  return categoryKeys.includes(attributeKey) || (attributeKey === 'brand' && map.length === 1)
+}
+
 export const buildBreadcrumb = (
   attributes: ElasticAttribute[],
   fullText: string,
@@ -623,10 +631,17 @@ export const buildBreadcrumb = (
       return
     }
 
-    breadcrumb.push({
-      name: unescape(value.label),
-      href: `/${pivotValue.join('/')}?map=${pivotMap.join(',')}`,
-    })
+    if (canCleanMap(value.attributeKey, pivotMap)) {
+      breadcrumb.push({
+        name: unescape(value.label),
+        href: `/${pivotValue.join('/')}`,
+      })
+    } else {
+      breadcrumb.push({
+        name: unescape(value.label),
+        href: `/${pivotValue.join('/')}?map=${pivotMap.join(',')}`,
+      })
+    }
   })
 
   return breadcrumb

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -555,8 +555,10 @@ export const convertOrderBy = (orderBy?: string | null): string => {
 }
 
 const canCleanMap = (attributeKey: string, map: string[]) => {
-  const categoryKeys = ['category-1', 'category-2']
-  if (map.length > 2) {
+  const categoryKeys = ['category-1', 'category-2', 'category-3', 'category-4']
+
+  // If there is more than one category of the same level, the rewriter cannot handle the link without map
+  if (map.length > 4 || map.length !== Array.from(new Set(map)).length) {
     return false
   }
   return categoryKeys.includes(attributeKey) || (attributeKey === 'brand' && map.length === 1)


### PR DESCRIPTION
#### What problem is this solving?
We don't need the `map` for department, brand and category pages as the rewriter already knows how to handle them. 
We must keep the breadcrumb link clean in these cases, as suggested by Google

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta1--storecomponents.myvtex.com/apparel---accessories/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/20840671/139278420-4720fb6c-dec0-4851-a4ba-2ec836100426.png)
![image](https://user-images.githubusercontent.com/20840671/139278509-a9369e79-a177-4ac7-8089-daab889ded09.png)

After:
![image](https://user-images.githubusercontent.com/20840671/139278373-6b150d33-5c07-4d7d-9b3c-64aa5508224e.png)

![image](https://user-images.githubusercontent.com/20840671/139278270-365fa68a-874c-4c69-9ab8-d16cc5c11eee.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
