### PR TITLE
PER-2976: Add category/department ID to category tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Category ID in `categoriesTree`.
+
 ## [1.59.1] - 2021-11-24
 
 ### Changed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -714,6 +714,7 @@ export const convertSolrTree = (node: SearchFacetCategory, selectedFaces: Select
   )
 
   return {
+    id: node.Id?.toString(),
     quantity: node.Quantity,
     name: node.Name,
     key: node.Map,

--- a/node/utils/attributes.ts
+++ b/node/utils/attributes.ts
@@ -56,6 +56,7 @@ export interface FilterValue {
     to: number
   },
   children?: FilterValue[]
+  id?: string
 }
 
 interface CatalogAttributeValues {


### PR DESCRIPTION
#### What problem is this solving?
Pixel's `pageInfo` events were being sent without the category ID because we didn't return this value in the facet

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--storecomponents.myvtex.com/apparel---accessories/)

#### Screenshots or example usage

Before:
![image](https://user-images.githubusercontent.com/20840671/139713163-f34a7603-a938-4f98-88be-0cfa4bfb57c5.png)

![image](https://user-images.githubusercontent.com/20840671/139712849-aa4f8959-af74-4b39-b9a2-cef8f1b8e8a3.png)


After:
![image](https://user-images.githubusercontent.com/20840671/139713768-6b23dfb7-52ce-4023-8511-d326330e23ee.png)

![image](https://user-images.githubusercontent.com/20840671/139712728-93a8d7fa-ef49-46c4-a32a-c01a207a81d7.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
