### PR TITLE
Use API linkText when binding and tenant locales are the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Use API `linkText` when binding and tenant locales are the same.
+
 ## [1.58.6] - 2021-11-09
 
 ### Changed

--- a/node/package.json
+++ b/node/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.45.3",
+    "@vtex/api": "6.45.6",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -74,8 +74,8 @@ export const translateManyToCurrentLanguage = (messages: Message[], ctx: Context
 
 export const shouldTranslateToUserLocale = ({ vtex: { tenant, locale } }: Context) => tenant?.locale !== locale
 
-export const shouldTranslateToBinding = ({ translated, vtex: { binding } }: Context, ignoreIndexedTranslation?: boolean) =>
-  binding && (!translated || ignoreIndexedTranslation)
+export const shouldTranslateToBinding = ({ translated, vtex: { binding, tenant } }: Context, ignoreIndexedTranslation?: boolean) =>
+  binding?.locale !== tenant?.locale && (!translated || ignoreIndexedTranslation)
 
 export const shouldTranslateToTenantLocale = ({ vtex: { locale, tenant } }: Context) =>
   Boolean(tenant?.locale && locale && tenant.locale !== locale)

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.45.3":
-  version "6.45.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.3.tgz#fe7d08adb4eab1fda5e34143cc6302a4c5aa5f52"
-  integrity sha512-kiD7We1TCKDyBdpYoh2Se3An+jTJRUzXGNpKifoDZylWQ1PyIx+3oL5ZAif9InlY3uJkfEisSAI6nxoKTgvPfw==
+"@vtex/api@6.45.6":
+  version "6.45.6"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
+  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?
Mitigating rewriter bug with invalid routes.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--txboot.myvtex.com/cheyenne?_q=CHEYENNE&map=ft)
[Workspace 2](https://thalyta--quebramar.myvtex.com/homem/colecao/camisas?__bindingAddress=www.quebramar.com/en)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
