### PR TITLE
Feature/add segment to the products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Feature
+- Add segment to the `products` query.
+
 ## [1.59.3] - 2021-12-07
 
 ### Changed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -611,13 +611,15 @@ export const queries = {
 
     const selectedFacets: SelectedFacet[] = buildSelectedFacets(args)
 
+    const selectedFacetsWithSegment = selectedFacets.concat(parseFacetsFromSegment(segment?.facets))
+
     const sellers = await getSellers(vbase, checkout, segment?.channel, segment?.regionId)
 
     const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
 
     const biggyArgs: SearchResultArgs = {
       fullText: query,
-      attributePath: buildAttributePath(selectedFacets),
+      attributePath: buildAttributePath(selectedFacetsWithSegment),
       tradePolicy: segment && segment.channel,
       query: query,
       sellers,


### PR DESCRIPTION
#### What problem is this solving?

Recently we released the [search segment feature](https://www.notion.so/vtexhandbook/Segmented-Catalog-b3d613675f3e4202b00750d96b016a94),  but the `products` query was not respecting this rule. This Pr adds the selected facet that came from the segment cookie to the `products` query

#### How should this be manually tested?

This feature is already in production as a beta. You can test it [here[(https://nadro.myvtex.com/)

