### PR TITLE
remove translate fulltext term from facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove unnecessary `translateToStoreDefaultLanguage` from the `facets` query.
+
 ## [1.59.6] - 2021-12-23
 
 ### Removed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -442,10 +442,6 @@ export const queries = {
 
     let { fullText, searchState, initialAttributes } = args
 
-    if (fullText) {
-      fullText = await translateToStoreDefaultLanguage(ctx, args.fullText!)
-    }
-
     const {
       clients: { biggySearch, search, checkout, vbase },
       vtex: { segment },


### PR DESCRIPTION
#### What problem is this solving?

For some reason, we were trying to translate the fulltext term to the original account language on the `facets` query.

It was causing a bug where the facets were showing different (or sometimes not returning anything) results from the product gallery

For example:
https://master--iccborn.myvtex.com/
Select the english language by selecting the USD option.

![image](https://user-images.githubusercontent.com/40380674/147269534-414fa5ce-0f91-4e5b-81e1-73a54e73a685.png)

Now search for `aman`. You will notice the the facets are empty. this is happening because the term that is being sent to the facets query is `own`, which is the english translation of `aman`

#### How should this be manually tested?

![image](https://user-images.githubusercontent.com/40380674/147273249-04f1cdce-b6bb-4350-a88a-eb6c8194771b.png)


[Workspace](https://hiago--iccborn.myvtex.com/)

Search for `aman`

