### PR TITLE
Use fullText when query is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Use `fullText` when `query` is empty.
+
 ## [0.16.12] - 2022-01-04
 
 ### Fixed

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -267,6 +267,7 @@ export class Search extends AppClient {
 
   private productSearchUrl = ({
     query = '',
+    fullText = '',
     category = '',
     specificationFilters,
     priceRange = '',
@@ -281,7 +282,7 @@ export class Search extends AppClient {
     completeSpecifications = true,
   }: SearchArgs) => {
     const sanitizedQuery = encodeURIComponent(
-      this.searchEncodeURI(decodeURIComponent(query || '').trim())
+      this.searchEncodeURI(decodeURIComponent(query || fullText || '').trim())
     )
     if (hideUnavailableItems) {
       const segmentData = (this.context as CustomIOContext).segment

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -26,6 +26,7 @@ interface SearchArgs extends QueryArgs {
   hideUnavailableItems: boolean | null
   simulationBehavior: 'skip' | 'default' | null
   completeSpecifications: boolean
+  fullText?: string
 }
 
 interface Metadata {


### PR DESCRIPTION
#### What problem is this solving?
search didn't work correctly when passing the search term through `fullText` instead of `query`

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--compracerta.myvtex.com/admin/graphql-ide)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Before: (products not related to the search term)
![image](https://user-images.githubusercontent.com/20840671/153655279-c60d9464-72c4-4a03-b914-fa1172a07737.png)


After:
![image](https://user-images.githubusercontent.com/20840671/153655203-ee16fc7f-5c8f-495d-9cfe-e1eb6cbc166c.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
