### PR TITLE
Bugfix/fix allowredirect on product search and product suggestion queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `productSearch` query ignores the `allowRedirect` property.
+- `productSuggestions` doesn't return any result when there is a redirect set.
 
 ## [1.61.3] - 2022-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `productSearch` query ignores the `allowRedirect` property.
+
 ## [1.61.3] - 2022-02-03
 
 ### Fixed 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -641,6 +641,7 @@ export const queries = {
       from: 0,
       to: 4,
       sort: convertOrderBy(args.orderBy),
+      allowRedirect: false, // When there is a redirect, no product is returned.
       ...workspaceSearchParams,
     }
 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -513,6 +513,7 @@ export const queries = {
       ...args,
       query: fullText,
       sort: convertOrderBy(args.orderBy),
+      ...args.options,
       ...workspaceSearchParams,
     }
 
@@ -639,8 +640,8 @@ export const queries = {
       query: args.fullText,
       from: 0,
       to: 4,
-      ...workspaceSearchParams,
       sort: convertOrderBy(args.orderBy),
+      ...workspaceSearchParams,
     }
 
     // unnecessary field. It's is an object and breaks the @vtex/api cache


### PR DESCRIPTION
#### What problem is this solving?

This Pr fixes two bugs:
- The `allowRedirect` was being ignored on the `productSearch` query. It was always true.
- The `productSuggestions` query was returning zero products when there was a redirect set for the search term

#### How should this be manually tested?

There is a redirect set for `cerveza`

[Workspace](https://hiago--carrefourar.myvtex.com/)

`productSearch`
```
curl --request POST \
  --url https://hiago--carrefourar.myvtex.com/_v/private/graphql/v1 \
  --header 'Content-Type: application/json' \
  --data '{"query":"query productSearchV3($query: String, $fullText: String, $selectedFacets: [SelectedFacetInput], $orderBy: String, $from: Int, $to: Int, $hideUnavailableItems: Boolean = false, $simulationBehavior: SimulationBehavior = default, $productOriginVtex: Boolean = false, $fuzzy: String, $operator: Operator, $searchState: String, $options: Options) @context(sender: \"vtex.store-resources@0.85.0\") {\n  productSearch(query: $query, fullText: $fullText, selectedFacets: $selectedFacets, orderBy: $orderBy, from: $from, to: $to, hideUnavailableItems: $hideUnavailableItems, simulationBehavior: $simulationBehavior, productOriginVtex: $productOriginVtex, fuzzy: $fuzzy, operator: $operator, searchState: $searchState, options: $options) @context(provider: \"vtex.search-graphql\") @runtimeMeta(hash: \"e1d5228ca8b18d1f83b777d849747a7f55c9597f670f20c8557d2b0428bf6be7\") {\n    products {\n\t\t\tproductId\n\t\t}\n  }\n}","variables":{"fullText":"cerveza","options":{"allowRedirect":false}},"operationName":"productSearchV3"}'
```
`productSuggestions`
```
curl --request POST \
  --url https://hiago--carrefourar.myvtex.com/_v/segment/graphql/v1 \
  --header 'Content-Type: application/json' \
  --data '{"query":"query productSuggestions(\n  $fullText: String!\n  $facetKey: String\n  $facetValue: String\n  $productOriginVtex: Boolean = false\n  $simulationBehavior: SimulationBehavior = default\n  $hideUnavailableItems: Boolean = false\n\t$orderBy: String\n) {\n  productSuggestions(\n    fullText: $fullText\n    facetKey: $facetKey\n    facetValue: $facetValue\n    productOriginVtex: $productOriginVtex\n    simulationBehavior: $simulationBehavior\n    hideUnavailableItems: $hideUnavailableItems\n\t\torderBy: $orderBy\n  ) @context(provider: \"vtex.search-graphql\") {\n    count\n    misspelled\n    operator\n    products {\n\t\t\tproductId\n\t\t}\n  }\n}","variables":{"fullText":"cervezas"},"operationName":"productSuggestions"}'
```
