### PR TITLE
Fix discountHighlights that was always empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `discountHighlights` property.
+
 ## [1.61.5] - 2022-05-16
 
 ### Fixed

--- a/node/resolvers/search/offer.ts
+++ b/node/resolvers/search/offer.ts
@@ -127,7 +127,9 @@ export const resolvers = {
 
       return filteredGiftProducts
     },
-    discountHighlights: propOr([], 'DiscountHighLight'),
+    discountHighlights: (offer: CommertialOffer) => {
+      return offer.DiscountHighLight || offer.discountHighlights || []
+    },
     spotPrice: (offer: CommertialOffer) => {
       if (offer.spotPrice) {
         return offer.spotPrice

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -219,6 +219,9 @@ interface CommertialOffer {
   }[]
   GetInfoErrorMessage: any | null
   CacheVersionUsedToCallCheckout: string
+  // Supports the Intelligent Search API which 
+  // uses the same name from the simulation
+  discountHighlights: any[]
 }
 
 interface Seller {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4661,7 +4661,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### How should this be manually tested?

[Workspace](https://thalyta--biggy.myvtex.com/apparel---accessories/)
- Check the 3rd product `Camisa Feminina Top`. it should have a discountHighlight named `Brinde`

#### Screenshots or example usage

Before:
![image](https://user-images.githubusercontent.com/20840671/173133989-850b2047-afba-4111-b840-2c88c2b31cce.png)

![image](https://user-images.githubusercontent.com/20840671/173136382-baa4063a-fe7d-4584-ad5f-9e1b0c84b40c.png)


After:
![image](https://user-images.githubusercontent.com/20840671/173133884-cf46e83f-7cce-44c3-a433-b13080794217.png)

![image](https://user-images.githubusercontent.com/20840671/173135939-8d1cc385-bbc8-4911-9a5e-b655ea917660.png)

**I added the highlight above [on this PR](https://github.com/vtex-apps/search-demo-theme/pull/4)**


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
