### PR TITLE
Add count to productSuggestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `count` to `productSuggestions` query.
+
 ## [1.61.6] - 2022-06-13
 
 ### Fixed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -639,7 +639,7 @@ export const queries = {
       ...args,
       query: args.fullText,
       from: 0,
-      to: 4,
+      to: args.count ? args.count - 1 : 4,
       sort: convertOrderBy(args.orderBy),
       allowRedirect: false, // When there is a redirect, no product is returned.
       ...workspaceSearchParams,

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -71,6 +71,7 @@ interface SuggestionProductsArgs {
   workspaceSearchParams?: object
   segmentedFacets?: SelectedFacet[]
   orderBy?: string
+  count?: number
 }
 
 interface SuggestionSearchesArgs {


### PR DESCRIPTION
#### What problem is this solving?

Add count to productSuggestions query, allowing the store to display more than 5 product suggestions.

Currently, this manipulation of how many products to display is done on the client. The query always returns 5 and if the maximum is less than 5, a `slice` is made. However, if the store wants to display more than 5 suggestions, this doesn't work

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Workspace](https://thalyta--ametllerorigen.myvtex.com)
- Autocomplete should show 12 product suggestions

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
