### PR TITLE
add linkText resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `linkText` resolver.
+
 ## [1.63.0] - 2022-10-04
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "search-resolver",
-  "version": "1.63.0",
+  "version": "1.63.1-beta.0",
   "title": "GraphQL resolver for the VTEX store APIs",
   "description": "GraphQL resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What problem is this solving?

Currently, on `vtex.intelligent-search-api` we [translate the `linkText`  by hitting a rewriter API](https://github.com/vtex/intelligent-search-api/blob/a77ac58efd95c082f17f01922d4bb5b16f7b73a3/node/middlewares/utils/translation.ts#L28-L59), but it only works for search-resolver queries that calls the `vtex.intelligent-search`.

For queries like `productsByIdentifier` those linkTexts are not being translated. This PR translates the `linkText` field for those cases

#### How should this be manually tested?

Before:
```
curl --request POST \
  --url 'https://master--yamamay.myvtex.com/_v/private/graphql/v1?locale=en-GB&__bindingAddress=www.yamamay.com%2Fgr_en' \
  --header 'Content-Type: application/json' \
  --data '{"query":"query {\n productsByIdentifier(field: sku, values: [2173]) @context(provider:\"vtex.search-graphql\") {\n productId\n linkText \n productName}}","variables":{}}'
```

![image](https://user-images.githubusercontent.com/40380674/209197802-f7262e9c-7637-463c-83ca-df5d6456376d.png)

After:
```
curl --request POST \
  --url 'https://hiago--yamamay.myvtex.com/_v/private/graphql/v1?locale=en-GB&__bindingAddress=www.yamamay.com%2Fgr_en' \
  --header 'Content-Type: application/json' \
  --data '{"query":"query {\n productsByIdentifier(field: sku, values: [2173]) @context(provider:\"vtex.search-graphql\") {\n productId\n linkText \n productName}}","variables":{}}'
```

![image](https://user-images.githubusercontent.com/40380674/209197957-51d21c81-f337-4a0e-8760-4bb772a85d71.png)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
