### PR TITLE
Fix issue with shipping option filter that was being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Shipping options filter.
+
 ## [1.64.1] - 2023-02-27
 
 ### Added

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -337,6 +337,10 @@ export const queries = {
     }
   },
   facets: async (_: any, args: FacetsInput, ctx: any) => {
+    const [shippingOptions, facets] = getShippingOptionsFromSelectedFacets(args.selectedFacets)
+
+    args.selectedFacets = facets
+
     args = (await getCompatibilityArgsFromSelectedFacets(
       ctx,
       args
@@ -355,9 +359,7 @@ export const queries = {
     // unnecessary field. It's is an object and breaks the @vtex/api cache
     delete biggyArgs.selectedFacets
 
-    const [shippingOptions, facets] = getShippingOptionsFromSelectedFacets(selectedFacets)
-
-    const result = await intelligentSearchApi.facets({...biggyArgs, query: args.fullText}, buildAttributePath(facets), shippingOptions)
+    const result = await intelligentSearchApi.facets({...biggyArgs, query: args.fullText}, buildAttributePath(selectedFacets), shippingOptions)
 
     if (ctx.vtex.tenant) {
       ctx.translated = result.translated
@@ -492,6 +494,9 @@ export const queries = {
   },
 
   productSearch: async (_: any, args: ProductSearchInput, ctx: any) => {
+    const [shippingOptions, facets] = getShippingOptionsFromSelectedFacets(args.selectedFacets)
+    args.selectedFacets = facets
+
     args = (await getCompatibilityArgsFromSelectedFacets(
       ctx,
       args
@@ -524,9 +529,7 @@ export const queries = {
     // unnecessary field. It's is an object and breaks the @vtex/api cache
     delete biggyArgs.selectedFacets
 
-    const [shippingOptions, facets] = getShippingOptionsFromSelectedFacets(selectedFacets)
-
-    const result = await intelligentSearchApi.productSearch({...biggyArgs}, buildAttributePath(facets), shippingOptions)
+    const result = await intelligentSearchApi.productSearch({...biggyArgs}, buildAttributePath(selectedFacets), shippingOptions)
 
     if (ctx.vtex.tenant && !args.productOriginVtex) {
       ctx.translated = result.translated

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1140,7 +1140,14 @@ axios@0.18.0:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
 
-axios@^0.21.1, axios@^0.21.2:
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
+axios@^0.21.2:
   version "0.21.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
   integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==


### PR DESCRIPTION
#### What problem is this solving?
the `shipping-option` filter was being deleted from the list of `selectedFacets` because it didn't have the value contained in the `query` arg. 
as we really don't need or should keep it in the list, extracting its value must be done before treating the `selectedFacets` value

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://shippingoptions2--biggy.myvtex.com)
- if you select a delivery option, the products should appear in the search page. if you select a pickup option (try zip code 22250-040) no product should appear

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
