### PR TITLE
chore: upgrade to NodeJS 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Change `node` builder to version `7.x`. This version will run in NodeJS 16.
+
 ## [0.16.13] - 2022-02-14
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "search-resolver",
-  "version": "0.17.0-hkignore.1",
+  "version": "0.17.0",
   "title": "GraphQL resolver for the VTEX store APIs",
   "description": "GraphQL resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
   "vendor": "vtex",
   "name": "search-resolver",
-  "version": "0.16.13",
+  "version": "0.17.0-hkignore.1",
   "title": "GraphQL resolver for the VTEX store APIs",
   "description": "GraphQL resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",
   "builders": {
-    "node": "6.x",
+    "node": "7.x",
     "docs": "0.x"
   },
   "dependencies": {


### PR DESCRIPTION
Updating the node builder to v7 to use Node v16.

We are launching a temporary new minor version _0.17.0-hkignore.1_ in order to be able to install it in some accounts.
This version it's `hkignore` to allow concurrent deploys and do not change the beta accounts.

Details on [#codepink-io-nodejs-runtime-upgrade](https://vtex.slack.com/archives/C05DCF0M4AE).