### PR TITLE
Remove catalog-proxy dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Catalog Search client now calls catalog-api directly instead of catalog-proxy
+
 ## [1.67.0] - 2023-08-22
 
 ### Added

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -1,10 +1,10 @@
 import {
-  AppClient,
   InstanceOptions,
   IOContext,
   RequestConfig,
   SegmentData,
   CacheType,
+  JanusClient,
 } from '@vtex/api'
 import { stringify } from 'qs'
 
@@ -44,7 +44,7 @@ interface SearchPageTypeResponse {
 /** Search API
  * Docs: https://documenter.getpostman.com/view/845/catalogsystem-102/Hs44
  */
-export class Search extends AppClient {
+export class Search extends JanusClient {
   private searchEncodeURI: (x: string) => string
   private basePath: string
 
@@ -76,11 +76,9 @@ export class Search extends AppClient {
   }
 
   public constructor(ctx: IOContext, opts?: InstanceOptions) {
-    super('vtex.catalog-api-proxy@0.x', ctx, opts)
+    super(ctx, opts)
 
-    this.basePath = ctx.sessionToken
-      ? '/proxy/authenticated/catalog'
-      : '/proxy/catalog'
+    this.basePath = '/api/catalog_system'
     this.searchEncodeURI = searchEncodeURI(ctx.account)
   }
 

--- a/node/package.json
+++ b/node/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.45.19",
+    "@vtex/api": "6.45.22",
     "@vtex/tsconfig": "^0.6.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -780,10 +780,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.45.19":
-  version "6.45.19"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.19.tgz#97b449850b517d6610e7123aa91caec2a29ae7b1"
-  integrity sha512-WUsAn1Oi+Z7Ih84DcRf4HQH85Mh+zO84L0ta7zuRyb13DoAEq2qMi0Mv6vZMd9BFWOCSD8AcTHVF/gZskwh9Yw==
+"@vtex/api@6.45.22":
+  version "6.45.22"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.22.tgz#fa9bbfde1a4d4fbbaf6cce9f6dbc9bb9ee929ba3"
+  integrity sha512-g5cGUDhF4FADgSMpQmce/bnIZumwGlPG2cabwbQKIQ+cCFMZqOEM/n+YQb1+S8bCyHkzW3u/ZABoyCKi5/nxxg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?

The [Catalog Proxy](https://github.com/vtex-apps/catalog-api-proxy) app doesn't seem to add relevant functionality, is an unnecessary hop and adds a bit of complexity to the search end-to-end flow. After an incident involving the app we figured we might as well cut the losses and remove the dependency.

#### What problem is this solving?

https://vtex-dev.atlassian.net/browse/IS-4858

Also this is tied to a [PR](https://github.com/vtex/intelligent-search-api/pull/81) on intelligent-search-api.

#### How to test it?

I compared searches with and without using the proxy in the accounts `biggy`, `paguemenos` and `lojausereserva`. All seems well.

You can try it yourself on the following workspaces:

https://gabiru--biggy.myvtex.com/
https://vtexis--paguemenos.myvtex.com/
https://vtexis--lojausereserva.myvtex.com/

#### Screenshots or example usage

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/ieBWQkIVEELhbizGAp/giphy.gif?cid=ecf05e47yuryz9tjmfowz2v60mds35wvb2wju02ns102xvmn&ep=v1_gifs_search&rid=giphy.gif&ct=g)

#### Types of changes

- [x] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.