### PR TITLE
Fixed misspelled information for the productSuggestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Misspelled information for the productSuggestions query.
+
 ## [1.76.0] - 2025-02-07
 
 ### Changed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -729,7 +729,8 @@ export const queries = {
 
     return {
       ...result,
-      count: result.recordsFiltered
+      count: result.recordsFiltered,
+      misspelled: result.correction?.misspelled,
     }
   },
   banners: (


### PR DESCRIPTION
#### What problem is this solving?

This pull request fixes an issue with the misspelled information in the productSuggestions response.

The [graphql query](https://github.com/vtex-apps/store-resources/blob/ab99d9e017f0f47d012f5c9dd1d6396f09f916a9/react/queries/productSuggestions.gql#L34) is expecting a root property but this information is available in the `correction` object.

#### How should this be manually tested?

[Workspace](https://felipegarcia--biggy.myvtex.com/)

Check the Event API request for the `search.autocomplete.query` event. Now it includes the misspelled information instead of the `null` value.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

<img width="163" alt="Captura de Tela 2025-04-30 às 10 44 21" src="https://github.com/user-attachments/assets/81d77841-9b79-451e-bbaf-00ca36779d84" />


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
