### PR TITLE
remove invalid character validation from searchMetadata query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Remove invalid character validation from `searchMetadata` query.
+
 ## [1.88.1] - 2025-10-29
 
 ### Added

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -1,5 +1,5 @@
 import { NotFoundError, UserInputError, createMessagesLoader } from '@vtex/api'
-import { pathOr, test } from 'ramda'
+import { pathOr } from 'ramda'
 
 import {
   buildAttributePath,
@@ -535,8 +535,6 @@ export const queries = {
   },
 
   searchMetadata: async (_: any, args: SearchMetadataArgs, ctx: Context) => {
-    const queryTerm = args.query
-
     if (args.selectedFacets) {
       const { maps, queries } = args.selectedFacets.reduce(
         (acc, { key, value }) => {

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -536,11 +536,6 @@ export const queries = {
 
   searchMetadata: async (_: any, args: SearchMetadataArgs, ctx: Context) => {
     const queryTerm = args.query
-    if (queryTerm == null || test(/[?&[\]=]/, queryTerm)) {
-      throw new UserInputError(
-        `The query term contains invalid characters. query=${queryTerm}`
-      )
-    }
 
     if (args.selectedFacets) {
       const { maps, queries } = args.selectedFacets.reduce(


### PR DESCRIPTION
#### What problem is this solving?

Previously, a character validation for special characters like &[]/?= was added to the productSearch query to support legacy behavior before intelligent search was introduced.

This same validation was mistakenly copied to the searchMetadata query. I've removed it, as testing confirmed that all special characters are now handled correctly and the validation is no longer needed.
#### How should this be manually tested?

[Workspace](https://hiago--storecomponents.myvtex.com/)


