### PR TITLE
Fix segment enconding/handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.85.0] - 2025-10-13
+### Fixed
+
+- Segment enconding while making PDP requests.
+
+## [1.85.0] - 2025-10-13 [YANKED]
 
 ### Changed
 

--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -3,6 +3,7 @@ import { ExternalClient } from '@vtex/api'
 
 import { parseState } from '../utils/searchState'
 import type { FetchBannersArgs, IIntelligentSearchClient, FetchProductArgs, FetchProductResponse  } from './intsch/types'
+import { Options, SearchResultArgs } from '../typings/Search'
 
 const isPathTraversal = (str: string) => str.indexOf('..') >= 0
 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -46,6 +46,7 @@ import {
   fetchCorrection,
 } from '../../services/autocomplete'
 import { fetchBanners } from '../../services/banners'
+import { AdvertisementOptions, FacetsInput, ProductSearchInput, ProductsInput, SegmentData, SuggestionProductsArgs } from '../../typings/Search'
 
 enum CrossSellingInput {
   view = 'view',

--- a/node/services/product.test.ts
+++ b/node/services/product.test.ts
@@ -14,7 +14,21 @@ describe('fetchProduct service', () => {
 
   it('should build vtex segment correctly', () => {
     const vtexSegment = buildVtexSegment({
-      vtexSegment: { regionId: '1', countryCode: 'US' } as any,
+      vtexSegment: {
+        campaigns: null,
+        channel: '1',
+        priceTables: null,
+        regionId: 'U1cjMQ==',
+        utm_campaign: null,
+        utm_source: null,
+        utmi_campaign: null,
+        currencyCode: 'ARS',
+        currencySymbol: '$',
+        countryCode: 'ARG',
+        cultureInfo: 'es-AR',
+        admin_cultureInfo: 'es-AR',
+        channelPrivacy: 'public',
+      },
       salesChannel: '2',
       regionId: '3',
     })
@@ -22,8 +36,18 @@ describe('fetchProduct service', () => {
     const result = JSON.parse(Buffer.from(vtexSegment, 'base64').toString())
 
     expect(result.regionId).toBe('3')
-    expect(result.countryCode).toBe('US')
+    expect(result.countryCode).toBe('ARG')
+    expect(result.currencySymbol).toBe('$')
+    expect(result.currencyCode).toBe('ARS')
     expect(result.channel).toBe('2')
+    expect(result.cultureInfo).toBe('es-AR')
+    expect(result.admin_cultureInfo).toBe('es-AR')
+    expect(result.channelPrivacy).toBe('public')
+    expect(result.campaigns).toBeNull()
+    expect(result.priceTables).toBeNull()
+    expect(result.utm_campaign).toBeNull()
+    expect(result.utm_source).toBeNull()
+    expect(result.utmi_campaign).toBeNull()
   })
 
   it('should use intsch directly for b2bstoreqa account', async () => {

--- a/node/services/product.test.ts
+++ b/node/services/product.test.ts
@@ -1,4 +1,4 @@
-import { fetchProduct } from './product'
+import { fetchProduct, buildVtexSegment } from './product'
 import { createContext } from '../mocks/contextFactory'
 
 describe('fetchProduct service', () => {
@@ -10,6 +10,20 @@ describe('fetchProduct service', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+  })
+
+  it('should build vtex segment correctly', () => {
+    const vtexSegment = buildVtexSegment({
+      vtexSegment: { regionId: '1', countryCode: 'US' } as any,
+      salesChannel: '2',
+      regionId: '3',
+    })
+
+    const result = JSON.parse(Buffer.from(vtexSegment, 'base64').toString())
+
+    expect(result.regionId).toBe('3')
+    expect(result.countryCode).toBe('US')
+    expect(result.channel).toBe('2')
   })
 
   it('should use intsch directly for b2bstoreqa account', async () => {

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -127,15 +127,9 @@ export function buildVtexSegment({
   regionId?: string
 }): string {
   const cookie = {
+    ...vtexSegment,
     regionId: regionId ?? vtexSegment?.regionId,
     channel: salesChannel ?? vtexSegment?.channel,
-    utm_campaign: vtexSegment?.utm_campaign ?? null,
-    utm_source: vtexSegment?.utm_source ?? null,
-    utmi_campaign: vtexSegment?.utmi_campaign ?? null,
-    currencyCode: vtexSegment?.currencyCode ?? null,
-    currencySymbol: vtexSegment?.currencySymbol ?? null,
-    countryCode: vtexSegment?.countryCode ?? null,
-    cultureInfo: vtexSegment?.cultureInfo ?? null,
   }
 
   return Buffer.from(JSON.stringify(cookie)).toString('base64')

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -128,17 +128,17 @@ export function buildVtexSegment({
 }): string {
   const cookie = {
     regionId: regionId ?? vtexSegment?.regionId,
-    channel: salesChannel || vtexSegment?.channel,
-    utm_campaign: vtexSegment?.utm_campaign || '',
-    utm_source: vtexSegment?.utm_source || '',
-    utmi_campaign: vtexSegment?.utmi_campaign || '',
-    currencyCode: vtexSegment?.currencyCode || '',
-    currencySymbol: vtexSegment?.currencySymbol || '',
-    countryCode: vtexSegment?.countryCode || '',
-    cultureInfo: vtexSegment?.cultureInfo || '',
+    channel: salesChannel ?? vtexSegment?.channel,
+    utm_campaign: vtexSegment?.utm_campaign ?? null,
+    utm_source: vtexSegment?.utm_source ?? null,
+    utmi_campaign: vtexSegment?.utmi_campaign ?? null,
+    currencyCode: vtexSegment?.currencyCode ?? null,
+    currencySymbol: vtexSegment?.currencySymbol ?? null,
+    countryCode: vtexSegment?.countryCode ?? null,
+    cultureInfo: vtexSegment?.cultureInfo ?? null,
   }
 
-  return Buffer.from(JSON.stringify(cookie), 'base64').toString()
+  return Buffer.from(JSON.stringify(cookie)).toString('base64')
 }
 
 export async function fetchProduct(

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -1,4 +1,5 @@
 import { fetchAppSettings } from './settings'
+import type { SegmentData } from '../typings/Search'
 
 export type ProductIdentifier = {
   field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -1,4 +1,4 @@
-interface SegmentData {
+export type SegmentData = {
   campaigns?: any
   channel: string
   priceTables?: any
@@ -13,14 +13,9 @@ interface SegmentData {
   [key: string]: any
 }
 
-interface ElasticImage {
-  name: string
-  value: string
-}
-
 export type IndexingType = 'API' | 'XML'
 
-interface SearchResultArgs extends AdvertisementOptions {
+export interface SearchResultArgs extends AdvertisementOptions {
   attributePath?: string
   query?: string
   page?: number
@@ -45,17 +40,12 @@ interface SearchResultArgs extends AdvertisementOptions {
   showSponsored?: boolean
 }
 
-interface BannersArgs {
-  fullText: string
-  attributePath: string
-}
-
 interface RegionSeller {
   id: string
   name: string
 }
 
-interface SuggestionProductsArgs {
+export interface SuggestionProductsArgs {
   fullText: string
   facetKey?: string
   facetValue?: string
@@ -74,27 +64,23 @@ interface SuggestionProductsArgs {
   advertisementOptions: AdvertisementOptions
 }
 
-interface SuggestionSearchesArgs {
-  term: string
-}
-
 interface SelectedFacet {
   value: string
   key: string
 }
 
-interface Options {
+export interface Options {
   allowRedirect?: boolean
 }
 
-interface AdvertisementOptions {
+export interface AdvertisementOptions {
   showSponsored?: boolean
   sponsoredCount?: number
   repeatSponsoredProducts?: boolean
   advertisementPlacement?: string
 }
 
-interface FacetsInput {
+export interface FacetsInput {
   map: string
   selectedFacets: SelectedFacet[]
   fullText: string
@@ -106,11 +92,11 @@ interface FacetsInput {
   categoryTreeBehavior: 'default' | 'show' | 'hide'
 }
 
-interface ProductsInput extends SearchArgs {
+export interface ProductsInput extends SearchArgs {
   advertisementOptions?: AdvertisementOptions
 }
 
-interface ProductSearchInput {
+export interface ProductSearchInput {
   query: string
   from: number
   to: number
@@ -127,146 +113,4 @@ interface ProductSearchInput {
   options?: Options
   showSponsored?: boolean
   advertisementOptions?: AdvertisementOptions
-}
-
-interface ElasticAttribute {
-  visible: boolean
-  active: boolean
-  key: string
-  label: string
-  type: string
-  values: ElasticAttributeValue[]
-  originalKey: string
-  originalLabel: string
-  minValue?: number
-  maxValue?: number
-}
-
-interface ElasticAttributeValue {
-  count: number
-  active: boolean
-  key: string
-  label: string
-  id: string
-  originalKey?: string
-  originalLabel?: string
-}
-
-interface Breadcrumb {
-  href: string
-  name: string
-}
-
-interface BiggySearchProduct {
-  name: string
-  id: string
-  timestamp: number
-  product: string
-  description: string
-  reference: string
-  url: string
-  link: string
-  oldPrice: number
-  price: number
-  stock: number
-  brand: string
-  brandId: string
-  installment?: BiggyInstallment
-  measurementUnit: string
-  unitMultiplier: number
-  tax: number
-  images: BiggyProductImage[]
-  skus: BiggySearchSKU[]
-  categories: string[]
-  categoryIds: string[]
-  extraData: BiggyProductExtraData[]
-  productSpecifications: string[]
-  specificationGroups: string
-  textAttributes: BiggyTextAttribute[]
-  numberAttributes: BiggyTextAttribute[]
-  split: BiggySplit
-  categoryTrees: BiggyCategoryTree[]
-  clusterHighlights: Record<string, string>
-}
-
-interface BiggySplit {
-  labelKey: string
-  labelValue: string
-}
-
-interface BiggyProductImage {
-  name: string
-  value: string
-}
-
-interface BiggyProductExtraData {
-  key: string
-  value: string
-}
-
-interface BiggySearchSKU {
-  name: string
-  nameComplete: string
-  complementName?: string
-  id: string
-  ean?: string
-  reference: string
-  image: string
-  images: BiggyProductImage[]
-  videos?: string[]
-  stock: number
-  oldPrice: number
-  price: number
-  measurementUnit: string
-  unitMultiplier: number
-  link: string
-  attributes: BiggySKUAttribute[]
-  sellers: BiggySeller[]
-  policies: BiggyPolicy[]
-}
-
-interface BiggySKUAttribute {
-  key: string
-  value: string
-}
-
-interface BiggySeller {
-  id: string
-  name: string
-  oldPrice: number
-  price: number
-  stock: number
-  tax: number
-  default: boolean
-  teasers?: object[]
-  installment?: BiggyInstallment
-}
-
-interface BiggyInstallment {
-  value: number
-  count: number
-  interest: boolean
-}
-
-interface BiggyPolicy {
-  id: string
-  sellers: BiggySeller[]
-}
-
-interface BiggyTextAttribute {
-  labelKey: string
-  labelValue: string
-  key: string
-  value: string
-  isFilter: boolean
-  id: string
-  valueId: string
-  isSku: boolean
-  joinedKey: string
-  joinedValue: string
-}
-
-interface BiggyCategoryTree {
-  categoryNames: string[]
-  categoryIds: string[]
 }

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -2,10 +2,10 @@ interface SegmentData {
   campaigns?: any
   channel: string
   priceTables?: any
-  utm_campaign: string
+  utm_campaign: string | null
   regionId?: string
-  utm_source: string
-  utmi_campaign: string
+  utm_source: string | null
+  utmi_campaign: string | null
   currencyCode: string
   currencySymbol: string
   countryCode: string
@@ -18,10 +18,7 @@ interface ElasticImage {
   value: string
 }
 
-enum IndexingType {
-  API = 'API',
-  XML = 'XML',
-}
+export type IndexingType = 'API' | 'XML'
 
 interface SearchResultArgs extends AdvertisementOptions {
   attributePath?: string


### PR DESCRIPTION
#### What problem is this solving?

- When we removed the atob/btoa functions to use the Buffer we committed a small mistake which screwed the segment generation.  Basically we do some overrides using the args received in the query before passing the segment to the portal-search api but we failed while generating this new segment.

- The issue is now fixed and I added a test to make sure it doesn't happen anymore :) 

The issue only appeared in some accounts because just a few of them actually pass the args that generate the override.

#### How should this be manually tested?

[Workspace](https://felipe--farmacityar.myvtex.com/suplemento-dietario-pure-wellnes-colageno-x-60-capsulas/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNjh5cHZ2YjdqcnJocDQ2aG9iZ3Bvd243OGN4eWk1NzA2cnNtcHNwMCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/AeUcmWquAI8tW/giphy.gif)