### PR TITLE
Added translated flag to ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `state` parameter to `formatTranslatableStringV2` indicating if the label is already translated
+
 ## [1.88.7] - 2025-12-03
 
 ### Fixed

--- a/node/__mocks__/helpers.ts
+++ b/node/__mocks__/helpers.ts
@@ -68,6 +68,11 @@ const initialCtxState = {
 export const mockContext: any = {
   vtex: {
     ...generateDeepCopy(initialCtxState),
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
   },
   clients: {
     search: searchClientMock,
@@ -76,6 +81,9 @@ export const mockContext: any = {
     rewriter: rewriterClientMock,
     vbase: { getJSON: jest.fn() },
     intelligentSearchApi: isClientMock,
+    apps: {
+      getAppSettings: jest.fn().mockResolvedValue({}),
+    },
   },
   state: {
     messagesBindingLanguage: {

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -1,16 +1,16 @@
 import {
   AppClient,
+  CacheType,
   InstanceOptions,
   IOContext,
   RequestConfig,
   SegmentData,
-  CacheType,
 } from '@vtex/api'
 import { stringify } from 'qs'
 
 import {
-  searchEncodeURI,
   SearchCrossSellingTypes,
+  searchEncodeURI,
 } from '../resolvers/search/utils'
 
 interface AutocompleteArgs {
@@ -308,11 +308,13 @@ export class Search extends AppClient {
       metric: 'search-category',
     })
 
-  public crossSelling = (id: string, type: SearchCrossSellingTypes, groupByProduct = true) =>
+  public crossSelling = (id: string, type: SearchCrossSellingTypes, groupByProduct = true, acceptLanguage?: string) =>
     this.get<SearchProduct[]>(
       `/pub/products/crossselling/${type}/${id}?groupByProduct=${groupByProduct}`,
       {
         metric: 'search-crossSelling',
+        // This Accept Language header is used to request the cross selling products in the desired language from new dataplane endpoint
+        headers: acceptLanguage ? { 'Accept-Language': acceptLanguage } : {}
       }
     )
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -6,8 +6,8 @@ import { Clients } from './clients'
 import { schemaDirectives } from './directives'
 import { resolvers } from './resolvers'
 import {
-  setWorkspaceSearchParams,
   getWorkspaceSearchParams,
+  setWorkspaceSearchParams,
 } from './routes/workspaceSearchParams'
 
 const TWO_SECONDS_MS = 2 * 1000

--- a/node/package.json
+++ b/node/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^20.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "^7.0.0",
+    "@vtex/api": "^7.2.7",
     "@vtex/tsconfig": "^0.6.0",
     "axios": "^0.21.1",
     "jest": "^29.7.0",

--- a/node/resolvers/search/product.test.ts
+++ b/node/resolvers/search/product.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable jest/no-mocks-import */
 /* eslint-disable jest/no-identical-title */
 
-import { resolvers } from './product'
 import {
-  mockContext,
   getBindingLocale,
+  mockContext,
   resetContext,
 } from '../../__mocks__/helpers'
 import { getProduct } from '../../__mocks__/product'
 import productSpecs from '../../__mocks__/productSpecs'
+import { resolvers } from './product'
 
 describe('tests related to product resolver', () => {
   beforeEach(() => {
@@ -280,20 +280,20 @@ describe('tests related to product resolver', () => {
       )) as any
 
       expect(result[0]).toMatchObject({
-        name: 'Tamanho (((16))) <<<pt-BR>>>',
+        name: 'Tamanho (((16))) <<<pt-BR>>> [[[original]]]',
         specifications: [
           {
-            name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>',
-            values: ['35 (((specification-Id))) <<<pt-BR>>>'],
+            name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>> [[[original]]]',
+            values: ['35 (((specification-Id))) <<<pt-BR>>> [[[original]]]'],
           },
         ],
       })
       expect(result[1]).toMatchObject({
-        name: 'allSpecifications (((16))) <<<pt-BR>>>',
+        name: 'allSpecifications (((16))) <<<pt-BR>>> [[[original]]]',
         specifications: [
           {
-            name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>',
-            values: ['35 (((specification-Id))) <<<pt-BR>>>'],
+            name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>> [[[original]]]',
+            values: ['35 (((specification-Id))) <<<pt-BR>>> [[[original]]]'],
           },
         ],
       })
@@ -357,12 +357,12 @@ describe('tests related to product resolver', () => {
 
       expect(result).toMatchObject([
         {
-          name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>>',
-          values: ['35 (((specification-Id))) <<<pt-BR>>>'],
+          name: 'Numero do calçado (((specification-Id))) <<<pt-BR>>> [[[original]]]',
+          values: ['35 (((specification-Id))) <<<pt-BR>>> [[[original]]]'],
         },
         {
-          name: 'testeName (((teste-id))) <<<pt-BR>>>',
-          values: ['teste value (((teste-id))) <<<pt-BR>>>'],
+          name: 'testeName (((teste-id))) <<<pt-BR>>> [[[original]]]',
+          values: ['teste value (((teste-id))) <<<pt-BR>>> [[[original]]]'],
         },
       ])
     })

--- a/node/resolvers/search/productSearch.test.ts
+++ b/node/resolvers/search/productSearch.test.ts
@@ -18,7 +18,7 @@ describe('tests related to the searchMetadata query', () => {
 
     expect(result.titleTag).toBe('department/category-title')
     expect(result.metaTagDescription).toBe(
-      'department/category-metaTagDescription (((1))) <<<pt-BR>>>'
+      'department/category-metaTagDescription (((1))) <<<pt-BR>>> [[[original]]]'
     )
     expect(mockContext.clients.search.pageType).toBeCalledTimes(1)
   })
@@ -30,7 +30,7 @@ describe('tests related to the searchMetadata query', () => {
 
     expect(result.titleTag).toBe('Brand-title')
     expect(result.metaTagDescription).toBe(
-      'Brand-metaTagDescription (((1))) <<<pt-BR>>>'
+      'Brand-metaTagDescription (((1))) <<<pt-BR>>> [[[original]]]'
     )
     expect(mockContext.clients.search.pageType).toBeCalledTimes(1)
   })
@@ -62,7 +62,7 @@ describe('tests related to the searchMetadata query', () => {
 
     expect(result.titleTag).toBe('brand - department/category-title')
     expect(result.metaTagDescription).toBe(
-      'department/category-metaTagDescription (((1))) <<<pt-BR>>>'
+      'department/category-metaTagDescription (((1))) <<<pt-BR>>> [[[original]]]'
     )
     expect(mockContext.clients.search.pageType).toBeCalledTimes(2)
   })
@@ -74,7 +74,7 @@ describe('tests related to the searchMetadata query', () => {
 
     expect(result.titleTag).toBe('department/category - Brand-title')
     expect(result.metaTagDescription).toBe(
-      'Brand-metaTagDescription (((1))) <<<pt-BR>>>'
+      'Brand-metaTagDescription (((1))) <<<pt-BR>>> [[[original]]]'
     )
     expect(mockContext.clients.search.pageType).toBeCalledTimes(2)
   })
@@ -89,7 +89,7 @@ describe('tests related to the searchMetadata query', () => {
 
     expect(result.titleTag).toBe('Large - brand - department/category-title')
     expect(result.metaTagDescription).toBe(
-      'department/category-metaTagDescription (((1))) <<<pt-BR>>>'
+      'department/category-metaTagDescription (((1))) <<<pt-BR>>> [[[original]]]'
     )
     expect(mockContext.clients.search.pageType).toBeCalledTimes(2)
   })
@@ -106,7 +106,7 @@ describe('tests related to the searchMetadata query', () => {
       'brand - department/category/subcategory-title'
     )
     expect(result.metaTagDescription).toBe(
-      'department/category/subcategory-metaTagDescription (((1))) <<<pt-BR>>>'
+      'department/category/subcategory-metaTagDescription (((1))) <<<pt-BR>>> [[[original]]]'
     )
     expect(mockContext.clients.search.pageType).toBeCalledTimes(2)
   })
@@ -159,12 +159,41 @@ describe('tests related to the searchMetadata query', () => {
 
     expect(result.titleTag).toBe('department/category-title-es-ES')
     expect(result.metaTagDescription).toBe(
-      'department/category-metaTagDescription (((1))) <<<fr-FR>>>'
+      'department/category-metaTagDescription (((1))) <<<fr-FR>>> [[[original]]]'
     )
     expect(mockContext.clients.search.pageType).toBeCalledTimes(1)
     expect(mockContext.state.messagesBindingLanguage.loadMany).toBeCalledTimes(
       1
     )
+  })
+
+  it('get search metadata from pageType for category with translated flag true', async () => {
+    const args = { query: 'Department/Category', map: 'c,c' }
+
+    mockContext.translated = true
+
+    const result = await queries.searchMetadata({}, args, mockContext as any)
+
+    expect(result.titleTag).toBe('department/category-title')
+    expect(result.metaTagDescription).toBe(
+      'department/category-metaTagDescription (((1))) <<<pt-BR>>> [[[translated]]]'
+    )
+    expect(result.metaTagDescription).not.toContain('[[[original]]]')
+    expect(mockContext.clients.search.pageType).toBeCalledTimes(1)
+  })
+
+  it('get search metadata from pageType for category with translated flag false', async () => {
+    const args = { query: 'Department/Category', map: 'c,c' }
+
+    mockContext.translated = false
+
+    const result = await queries.searchMetadata({}, args, mockContext as any)
+
+    expect(result.titleTag).toBe('department/category-title')
+    expect(result.metaTagDescription).toBe(
+      'department/category-metaTagDescription (((1))) <<<pt-BR>>> [[[original]]]'
+    )
+    expect(mockContext.clients.search.pageType).toBeCalledTimes(1)
   })
 })
 

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -1,5 +1,5 @@
-import { fetchAppSettings } from './settings'
 import type { SegmentData } from '../typings/Search'
+import { fetchAppSettings } from './settings'
 
 export type ProductIdentifier = {
   field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'
@@ -144,6 +144,7 @@ export async function fetchProduct(
 
   // Check if current account should skip comparison and use intsch directly
   if (shouldUseNewPDPEndpoint) {
+    ctx.translated = true
     return fetchProductFromIntsch(ctx, args)
   }
 

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -1,18 +1,22 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import {
   createMessagesLoader,
   formatTranslatableStringV2,
   parseTranslatableStringV2,
 } from '@vtex/api'
+
 import { logDegradedSearchError } from '../resolvers/search/utils'
 
-export const formatTranslatableProp = <R, P extends keyof R, I extends keyof R>(prop: P, idProp: I) =>
-  (root: R, _: unknown, ctx: Context) => addContextToTranslatableString(
-    {
-      content: root[prop] as unknown as string,
-      context: root[idProp] as unknown as string
-    },
-    ctx
-  )
+export const formatTranslatableProp =
+  <R, P extends keyof R, I extends keyof R>(prop: P, idProp: I) =>
+  (root: R, _: unknown, ctx: Context) =>
+    addContextToTranslatableString(
+      {
+        content: root[prop] as unknown as string,
+        context: root[idProp] as unknown as string,
+      },
+      ctx
+    )
 
 interface BaseMessage {
   content: string
@@ -27,8 +31,15 @@ export interface Message extends BaseMessage {
   context?: string
 }
 
-export const addContextToTranslatableString = (message: Message, ctx: Context) => {
-  const { vtex: { tenant }, translated } = ctx
+export const addContextToTranslatableString = (
+  message: Message,
+  ctx: Context
+) => {
+  const {
+    vtex: { tenant },
+    translated,
+  } = ctx
+
   const { locale } = tenant!
 
   if (!message.content) {
@@ -37,16 +48,16 @@ export const addContextToTranslatableString = (message: Message, ctx: Context) =
 
   const state = translated ? 'translated' : 'original'
 
-
   try {
     const {
       content,
       context: originalContext,
-      from: originalFrom
+      from: originalFrom,
     } = parseTranslatableStringV2(message.content)
 
     const context = (originalContext || message.context)?.toString()
     const from = originalFrom || message.from || locale
+
     return formatTranslatableStringV2({ content, context, from, state })
   } catch (e) {
     logDegradedSearchError(ctx.vtex.logger, {
@@ -54,14 +65,26 @@ export const addContextToTranslatableString = (message: Message, ctx: Context) =
       error: 'Error when trying to add context to translatable string',
       errorStack: e,
     })
+
     return message.content
   }
 }
 
-export const translateToCurrentLanguage = (message: MessageWithContext, ctx: Context) => {
-  const { state, clients, vtex: { binding, tenant, locale } } = ctx
+export const translateToCurrentLanguage = (
+  message: MessageWithContext,
+  ctx: Context
+) => {
+  const {
+    state,
+    clients,
+    vtex: { binding, tenant, locale },
+  } = ctx
+
   if (!state.messagesBindingLanguage) {
-    state.messagesBindingLanguage = createMessagesLoader(clients, locale ?? binding!.locale)
+    state.messagesBindingLanguage = createMessagesLoader(
+      clients,
+      locale ?? binding!.locale
+    )
   }
 
   return state.messagesBindingLanguage!.load({
@@ -71,23 +94,44 @@ export const translateToCurrentLanguage = (message: MessageWithContext, ctx: Con
   })
 }
 
-export const translateManyToCurrentLanguage = (messages: Message[], ctx: Context) => {
-  const { state, clients, vtex: { binding, tenant, locale } } = ctx
+export const translateManyToCurrentLanguage = (
+  messages: Message[],
+  ctx: Context
+) => {
+  const {
+    state,
+    clients,
+    vtex: { binding, tenant, locale },
+  } = ctx
+
   if (!state.messagesBindingLanguage) {
-    state.messagesBindingLanguage = createMessagesLoader(clients, locale ?? binding!.locale)
+    state.messagesBindingLanguage = createMessagesLoader(
+      clients,
+      locale ?? binding!.locale
+    )
   }
 
-  return state.messagesBindingLanguage!.loadMany(messages.map(message => ({
-    content: message.content,
-    context: message.context,
-    from: message.from ?? tenant!.locale,
-  })))
+  return state.messagesBindingLanguage!.loadMany(
+    messages.map((message) => ({
+      content: message.content,
+      context: message.context,
+      from: message.from ?? tenant!.locale,
+    }))
+  )
 }
 
-export const shouldTranslateToUserLocale = ({ vtex: { tenant, locale } }: Context) => tenant?.locale !== locale
+export const shouldTranslateToUserLocale = ({
+  vtex: { tenant, locale },
+}: Context) => tenant?.locale !== locale
 
-export const shouldTranslateToBinding = ({ translated, vtex: { binding, tenant } }: Context, ignoreIndexedTranslation?: boolean) =>
-  binding && binding?.locale !== tenant?.locale && (!translated || ignoreIndexedTranslation)
+export const shouldTranslateToBinding = (
+  { translated, vtex: { binding, tenant } }: Context,
+  ignoreIndexedTranslation?: boolean
+) =>
+  binding &&
+  binding?.locale !== tenant?.locale &&
+  (!translated || ignoreIndexedTranslation)
 
-export const shouldTranslateToTenantLocale = ({ vtex: { locale, tenant } }: Context) =>
-  Boolean(tenant?.locale && locale && tenant.locale !== locale)
+export const shouldTranslateToTenantLocale = ({
+  vtex: { locale, tenant },
+}: Context) => Boolean(tenant?.locale && locale && tenant.locale !== locale)

--- a/node/utils/i18n.ts
+++ b/node/utils/i18n.ts
@@ -1,7 +1,7 @@
 import {
+  createMessagesLoader,
   formatTranslatableStringV2,
   parseTranslatableStringV2,
-  createMessagesLoader,
 } from '@vtex/api'
 import { logDegradedSearchError } from '../resolvers/search/utils'
 
@@ -28,12 +28,14 @@ export interface Message extends BaseMessage {
 }
 
 export const addContextToTranslatableString = (message: Message, ctx: Context) => {
-  const { vtex: { tenant } } = ctx
+  const { vtex: { tenant }, translated } = ctx
   const { locale } = tenant!
 
   if (!message.content) {
     return message.content
   }
+
+  const state = translated ? 'translated' : 'original'
 
 
   try {
@@ -45,7 +47,7 @@ export const addContextToTranslatableString = (message: Message, ctx: Context) =
 
     const context = (originalContext || message.context)?.toString()
     const from = originalFrom || message.from || locale
-    return formatTranslatableStringV2({ content, context, from })
+    return formatTranslatableStringV2({ content, context, from, state })
   } catch (e) {
     logDegradedSearchError(ctx.vtex.logger, {
       service: 'node-vtex-api translation',

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1290,10 +1290,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@^7.0.0":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-7.2.1.tgz#0dd23f00deb37ba2ce40ba6855a90ca64da0a17a"
-  integrity sha512-ZJQttor2CismFbJZSG94o3TYUb66D1pQYew2Pr1o87j6v+YfyyIA5qPFrLX6Ax/755gUPwwi8Izko7cVijlDIw==
+"@vtex/api@^7.2.7":
+  version "7.2.7"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-7.2.7.tgz#c22dc034a36fc9b586a450345cfd95d764325d14"
+  integrity sha512-MIrTNRr5ijTVRsXQAxLkkp3M6P1afpLIds+LLcMqxq4H8rXqLsHC0G8Wr3G5QVTN6kbTtE+WbriFdHe396h8lQ==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/host-metrics" "0.35.5"
@@ -1302,6 +1302,7 @@
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
     "@vtex/diagnostics-nodejs" "0.1.0-io-beta.20"
+    "@vtex/diagnostics-semconv" "^1.1.2"
     "@vtex/node-error-report" "^0.0.3"
     "@wry/equality" "^0.1.9"
     agentkeepalive "^4.0.2"
@@ -1376,6 +1377,11 @@
   version "0.1.0-beta.11"
   resolved "https://registry.yarnpkg.com/@vtex/diagnostics-semconv/-/diagnostics-semconv-0.1.0-beta.11.tgz#2ddfff7dffdc1c052d23b335f914de91653d9659"
   integrity sha512-H3KM5fYAFmcxhlA4wT5iPgWJtgKsumFqGkkxjcA/BSwC5tgSWezN82sZDKvBsVo24EoZxVGgLlsjNw1tsp9U3Q==
+
+"@vtex/diagnostics-semconv@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@vtex/diagnostics-semconv/-/diagnostics-semconv-1.1.2.tgz#ed58b4c0f403cf5d9ff5e3d487e959ff9c1802e2"
+  integrity sha512-CUz58FTeYHC6z5n0qJKcHesJK00ykwDAFKXUaBKjzI166lm/LqMkdPJA8KE2h4RWGDdSaPDIUDdkueSD76oUfw==
 
 "@vtex/node-error-report@^0.0.3":
   version "0.0.3"
@@ -3991,7 +3997,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
This pull request introduces improvements to translation handling by adding a `translated` flag to the context, which helps distinguish between translated and original content.

* Added a `translated` property to the `ctx` object in the product fetching logic to indicate when translated content should be used. This property is now considered in the `addContextToTranslatableString` utility, and a new `state` parameter is passed to `formatTranslatableStringV2` to differentiate between translated and original strings. It will be read [here](https://github.com/vtex/node-vtex-api/pull/615).

#### How should this be manually tested?

- Clone the [vtex-node-api project](https://github.com/vtex/node-vtex-api/pull/615)
- Go to the `poc/l10n-bypass` branch
- `yarn && yarn build && yarn link`
- Open the search-resolver project
- `cd node && yarn link @vtex/api && cd ..`

OBS:  After linking the new vtex-node-api version, a typing incompatibility occurs on this parameter above. To unblock this, we can add the `// @ts-expect-error` directive to skip (it is not related to any changes here)
<img width="631" height="360" alt="image" src="https://github.com/user-attachments/assets/ca9d26fa-4dc4-4d73-acc8-2f5eb347a77e" />

- Log in to an account with Multilanguage settled
- Move to development workspace `vtex use [WORKSPACE_NAME]`
- `vtex link`
- Open a PDP
- For testing purposes, move the `ctx.translated` line above like this:
<img width="760" height="307" alt="image" src="https://github.com/user-attachments/assets/4714e904-9ef2-4f2e-9719-9764c43c1fce" />

- The product request should not translate the ProductName and ProductDescription, or any other product with the [@translatableV2 directive added here](https://github.com/vtex-apps/search-graphql/blob/master/graphql/types/Product.graphql)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

<img width="1675" height="957" alt="image" src="https://github.com/user-attachments/assets/46c3d444-987b-4359-8237-3a32f2043d3d" />


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

- During the tests, the new version of `@vtex/api ` linked has a type problem on the `node/index.ts` file at `Ln 83, Col 5`
