### PR TITLE
Add feature flag to call the new Facets and Search endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Make productSearch and facets send a % of the traffic to our routes on intsch.
 
+### Fixed
+
+- Make the productIdentifier call the intsch when the feature flag is on.
+
 ## [1.86.0] - 2025-10-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Feature flag to call the productSearch and facets using the intsch api.
+
+### Changed 
+
+- Make productSearch and facets send a % of the traffic to our routes on intsch.
+
 ## [1.86.0] - 2025-10-21
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,11 @@
         "title": "Feature flag to use the new PDP endpoint",
         "type": "boolean",
         "default": false
+      },
+      "shouldUseNewPLPEndpoint": {
+        "title": "Feature flag to use the new PLP endpoint",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -15,7 +15,7 @@ import type {
 } from './intsch/types'
 import type { Options, SearchResultArgs } from '../typings/Search'
 
-const isPathTraversal = (str: string) => str.indexOf('..') >= 0
+export const isPathTraversal = (str: string) => str.indexOf('..') >= 0
 
 interface CorrectionParams {
   query: string
@@ -47,7 +47,7 @@ interface FacetsArgs {
   regionId?: string | null
 }
 
-const decodeQuery = (query: string) => {
+export const decodeQuery = (query: string) => {
   try {
     return decodeURIComponent(query)
   } catch (e) {

--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -29,7 +29,7 @@ interface AutocompleteSearchSuggestionsParams {
   query: string
 }
 
-interface FacetsArgs {
+export type FacetsArgs = {
   query?: string
   page?: number
   count?: number

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -14,11 +14,15 @@ import type {
   FetchProductArgs,
   FetchProductResponse,
   IIntelligentSearchClient,
+  ProductSearchResponse,
   SearchSuggestionsArgs,
   SearchSuggestionsArgsV1,
   SearchSuggestionsResponse,
   TopSearchesResponse,
 } from './types'
+import type { SearchResultArgs } from '../../typings/Search'
+import { decodeQuery, isPathTraversal } from '../intelligent-search-api'
+import { parseState } from '../../utils/searchState'
 
 export class Intsch extends JanusClient implements IIntelligentSearchClient {
   private locale: string | undefined
@@ -131,6 +135,32 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     return this.http.get(`/api/intelligent-search/v1/banners/${args.path}`, {
       params: { query: args.query, locale: args.locale },
       metric: 'banners-new-v1',
+    })
+  }
+
+  public productSearch(
+    params: SearchResultArgs,
+    path: string,
+    shippingHeader?: string[]
+  ): Promise<ProductSearchResponse> {
+    const { query, leap, searchState } = params
+
+    if (isPathTraversal(path)) {
+      throw new Error('Malformed URL')
+    }
+
+    return this.http.get(`/api/intelligent-search/v0/product-search/${path}`, {
+      params: {
+        query: query && decodeQuery(query),
+        locale: this.locale,
+        bgy_leap: leap ? true : undefined,
+        ...parseState(searchState),
+        ...params,
+      },
+      metric: 'product-search-new',
+      headers: {
+        'x-vtex-shipping-options': shippingHeader ?? '',
+      },
     })
   }
 }

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -8,6 +8,7 @@ import type {
   CorrectionArgs,
   CorrectionArgsV1,
   CorrectionResponse,
+  FacetsResponse,
   FetchBannersArgs,
   FetchBannersArgsV1,
   FetchBannersResponse,
@@ -21,6 +22,7 @@ import type {
   TopSearchesResponse,
 } from './types'
 import type { SearchResultArgs } from '../../typings/Search'
+import type { FacetsArgs } from '../intelligent-search-api'
 import { decodeQuery, isPathTraversal } from '../intelligent-search-api'
 import { parseState } from '../../utils/searchState'
 
@@ -158,6 +160,32 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
         ...params,
       },
       metric: 'product-search-new',
+      headers: {
+        'x-vtex-shipping-options': shippingHeader ?? '',
+      },
+    })
+  }
+
+  public facets(
+    params: FacetsArgs,
+    path: string,
+    shippingHeader?: string[]
+  ): Promise<FacetsResponse> {
+    if (isPathTraversal(path)) {
+      throw new Error('Malformed URL')
+    }
+
+    const { query, leap, searchState } = params
+
+    return this.http.get(`/api/intelligent-search/v0/facets/${path}`, {
+      params: {
+        ...params,
+        query: query && decodeQuery(query),
+        locale: this.locale,
+        bgy_leap: leap ? true : undefined,
+        ...parseState(searchState),
+      },
+      metric: 'facets-new',
       headers: {
         'x-vtex-shipping-options': shippingHeader ?? '',
       },

--- a/node/clients/intsch/types.ts
+++ b/node/clients/intsch/types.ts
@@ -1,3 +1,5 @@
+import type { SearchResultArgs } from '../../typings/Search'
+
 export type AutocompleteSuggestionsArgs = {
   query: string
 }
@@ -91,6 +93,10 @@ export type FetchProductArgs = {
 
 export type FetchProductResponse = SearchProduct
 
+export type ProductSearchResponse = {
+  products: SearchProduct[]
+}
+
 export interface IIntelligentSearchClient {
   fetchAutocompleteSuggestions(
     args: AutocompleteSuggestionsArgs
@@ -111,4 +117,9 @@ export interface IIntelligentSearchClient {
   ): Promise<SearchSuggestionsResponse>
   fetchCorrectionV1(args: CorrectionArgsV1): Promise<CorrectionResponse>
   fetchBannersV1(args: FetchBannersArgsV1): Promise<FetchBannersResponse>
+  productSearch(
+    args: SearchResultArgs,
+    path: string,
+    shippingHeader?: string[]
+  ): Promise<ProductSearchResponse>
 }

--- a/node/clients/intsch/types.ts
+++ b/node/clients/intsch/types.ts
@@ -1,4 +1,5 @@
 import type { SearchResultArgs } from '../../typings/Search'
+import type { FacetsArgs } from '../intelligent-search-api'
 
 export type AutocompleteSuggestionsArgs = {
   query: string
@@ -97,6 +98,8 @@ export type ProductSearchResponse = {
   products: SearchProduct[]
 }
 
+export type FacetsResponse = any
+
 export interface IIntelligentSearchClient {
   fetchAutocompleteSuggestions(
     args: AutocompleteSuggestionsArgs
@@ -122,4 +125,9 @@ export interface IIntelligentSearchClient {
     path: string,
     shippingHeader?: string[]
   ): Promise<ProductSearchResponse>
+  facets(
+    params: FacetsArgs,
+    path: string,
+    shippingHeader?: string[]
+  ): Promise<FacetsResponse>
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -21,12 +21,14 @@ const searchCache = new LRUCache<string, Cached>({ max: 3000 })
 const messagesCache = new LRUCache<string, Cached>({ max: 3000 })
 const vbaseCache = new LRUCache<string, Cached>({ max: 3000 })
 const appsCache = new LRUCache<string, Cached>({ max: 1500 })
+const intschCache = new LRUCache<string, Cached>({ max: 3000 })
 
 metrics.trackCache('segment', segmentCache)
 metrics.trackCache('search', searchCache)
 metrics.trackCache('messages', messagesCache)
 metrics.trackCache('vbase', vbaseCache)
 metrics.trackCache('apps', appsCache)
+metrics.trackCache('intsch', intschCache)
 
 export default new Service<Clients, RecorderState, CustomContext>({
   clients: {

--- a/node/mocks/contextFactory.ts
+++ b/node/mocks/contextFactory.ts
@@ -57,6 +57,9 @@ export function createContext<Ctx = Context>({
       apps: {
         getAppSettings: jest.fn().mockReturnValue(appSettings ?? {}),
       },
+      vbase: {
+        getJSON: jest.fn().mockResolvedValue({}),
+      }
     },
     vtex: {
       production: production ?? false,

--- a/node/mocks/intsch.ts
+++ b/node/mocks/intsch.ts
@@ -6,6 +6,8 @@ import type {
   CorrectionResponse,
   FetchBannersResponse,
   FetchProductResponse,
+  ProductSearchResponse,
+  FacetsResponse,
 } from '../clients/intsch/types'
 
 export class MockedIntschClient implements IIntelligentSearchClient {
@@ -91,6 +93,18 @@ export class MockedIntschClient implements IIntelligentSearchClient {
     } else {
       this.fetchBannersV1.mockResolvedValue(args?.fetchBannersV1 ?? null)
     }
+
+    if (args?.productSearch instanceof Error) {
+      this.productSearch.mockRejectedValue(args.productSearch)
+    } else {
+      this.productSearch.mockResolvedValue(args?.productSearch ?? null)
+    }
+
+    if (args?.facets instanceof Error) {
+      this.facets.mockRejectedValue(args.facets)
+    } else {
+      this.facets.mockResolvedValue(args?.facets ?? null)
+    }
   }
 
   public fetchAutocompleteSuggestions = jest.fn()
@@ -104,6 +118,8 @@ export class MockedIntschClient implements IIntelligentSearchClient {
   public fetchSearchSuggestionsV1 = jest.fn()
   public fetchCorrectionV1 = jest.fn()
   public fetchBannersV1 = jest.fn()
+  public productSearch = jest.fn()
+  public facets = jest.fn()
 }
 
 export type IntelligentSearchClientArgs = {
@@ -118,4 +134,6 @@ export type IntelligentSearchClientArgs = {
   fetchSearchSuggestionsV1?: SearchSuggestionsResponse | Error
   fetchCorrectionV1?: CorrectionResponse | Error
   fetchBannersV1?: FetchBannersResponse | Error
+  productSearch?: ProductSearchResponse | Error
+  facets?: FacetsResponse | Error
 }

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -47,6 +47,8 @@ import {
   fetchCorrection,
 } from '../../services/autocomplete'
 import { fetchBanners } from '../../services/banners'
+import { fetchFacets } from '../../services/facets'
+import { fetchProductSearch } from '../../services/productSearch'
 import { AdvertisementOptions, FacetsInput, ProductSearchInput, ProductsInput, SuggestionProductsArgs } from '../../typings/Search'
 
 enum CrossSellingInput {
@@ -347,28 +349,7 @@ export const queries = {
 
     let { selectedFacets } = args
 
-    const {
-      clients: { intelligentSearchApi },
-    } = ctx
-
-    const biggyArgs: { [key: string]: any } = {
-      ...args,
-    }
-
-    // unnecessary field. It's is an object and breaks the @vtex/api cache
-    delete biggyArgs.selectedFacets
-
-    const result = await intelligentSearchApi.facets(
-      { ...biggyArgs, query: args.fullText },
-      buildAttributePath(selectedFacets),
-      shippingOptions
-    )
-
-    if (ctx.vtex.tenant) {
-      ctx.translated = result.translated
-    }
-
-    return result
+    return fetchFacets(ctx, args, selectedFacets, shippingOptions)
   },
 
   product: async (_: any, rawArgs: ProductArgs, ctx: Context) => {
@@ -464,41 +445,9 @@ export const queries = {
       })
     }
 
-    const { intelligentSearchApi } = ctx.clients
-    const {
-      selectedFacets,
-      fullText,
-      advertisementOptions = defaultAdvertisementOptions,
-    } = args
+    const { selectedFacets } = args
 
-    const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
-
-    const biggyArgs: { [key: string]: any } = {
-      ...advertisementOptions,
-      ...args,
-      query: fullText,
-      sort: convertOrderBy(args.orderBy),
-      ...args.options,
-      ...workspaceSearchParams,
-    }
-
-    // unnecessary field. It's is an object and breaks the @vtex/api cache
-    delete biggyArgs.selectedFacets
-
-    const result = await intelligentSearchApi.productSearch(
-      { ...biggyArgs },
-      buildAttributePath(selectedFacets),
-      shippingOptions
-    )
-
-    if (ctx.vtex.tenant && !args.productOriginVtex) {
-      ctx.translated = result.translated
-    }
-
-    return {
-      searchState: args.searchState,
-      ...result,
-    }
+    return fetchProductSearch(ctx, args, selectedFacets, shippingOptions)
   },
 
   sponsoredProducts: async (_: any, args: ProductSearchInput, ctx: any) => {

--- a/node/services/facets.test.ts
+++ b/node/services/facets.test.ts
@@ -1,0 +1,110 @@
+import { fetchFacets } from './facets'
+import { createContext } from '../mocks/contextFactory'
+import type { FacetsInput } from '../typings/Search'
+
+describe('fetchFacets service', () => {
+  const mockFacetsResponse = {
+    facets: [
+      {
+        name: 'Category',
+        values: [
+          { name: 'Electronics', quantity: 10 },
+          { name: 'Clothing', quantity: 5 },
+        ],
+      },
+    ],
+    translated: false,
+  }
+
+  const mockArgs: FacetsInput = {
+    fullText: 'test query',
+    query: 'test',
+    map: 'ft',
+    selectedFacets: [],
+    removeHiddenFacets: false,
+    hideUnavailableItems: false,
+    categoryTreeBehavior: 'default',
+  }
+
+  const mockSelectedFacets: SelectedFacet[] = []
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should use intelligentSearchApi when shouldUseNewPLPEndpoint is false', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        facets: mockFacetsResponse,
+      },
+    })
+
+    const result = await fetchFacets(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.clients.intelligentSearchApi.facets).toHaveBeenCalled()
+    expect(ctx.clients.intsch.facets).not.toHaveBeenCalled()
+    expect(result).toEqual(mockFacetsResponse)
+  })
+
+  it('should use intsch when shouldUseNewPLPEndpoint is true', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: true,
+      },
+      intschSettings: {
+        facets: mockFacetsResponse,
+      },
+    })
+
+    const result = await fetchFacets(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.clients.intsch.facets).toHaveBeenCalled()
+    expect(ctx.clients.intelligentSearchApi.facets).not.toHaveBeenCalled()
+    expect(result).toEqual(mockFacetsResponse)
+  })
+
+  it('should handle shipping options correctly', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        facets: mockFacetsResponse,
+      },
+    })
+
+    const shippingOptions = ['delivery', 'pickup']
+
+    await fetchFacets(ctx, mockArgs, mockSelectedFacets, shippingOptions)
+
+    expect(ctx.clients.intelligentSearchApi.facets).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'test query' }),
+      expect.any(String),
+      shippingOptions
+    )
+  })
+
+  it('should set translated flag in context when tenant is present', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        facets: { ...mockFacetsResponse, translated: true },
+      },
+      tenantLocale: 'en-US',
+    })
+
+    await fetchFacets(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.translated).toBe(true)
+  })
+})
+

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -1,0 +1,90 @@
+import { buildAttributePath } from '../commons/compatibility-layer'
+import { fetchAppSettings } from './settings'
+import type { FacetsInput } from '../typings/Search'
+
+/**
+ * Fetches facets using the intelligentSearchApi client (Biggy)
+ */
+async function fetchFacetsFromBiggy(
+  ctx: Context,
+  args: FacetsInput,
+  selectedFacets: SelectedFacet[],
+  shippingOptions?: string[]
+) {
+  const {
+    clients: { intelligentSearchApi },
+  } = ctx
+
+  const biggyArgs: { [key: string]: any } = {
+    ...args,
+  }
+
+  // unnecessary field. It's is an object and breaks the @vtex/api cache
+  delete biggyArgs.selectedFacets
+
+  const result: any = await intelligentSearchApi.facets(
+    { ...biggyArgs, query: args.fullText },
+    buildAttributePath(selectedFacets),
+    shippingOptions
+  )
+
+  if (ctx.vtex.tenant) {
+    ctx.translated = result.translated
+  }
+
+  return result
+}
+
+/**
+ * Fetches facets using the intsch client (Intelligent Search)
+ */
+async function fetchFacetsFromIntsch(
+  ctx: Context,
+  args: FacetsInput,
+  selectedFacets: SelectedFacet[],
+  shippingOptions?: string[]
+) {
+  const {
+    clients: { intsch },
+  } = ctx
+
+  const intschArgs: { [key: string]: any } = {
+    ...args,
+  }
+
+  // unnecessary field. It's is an object and breaks the @vtex/api cache
+  delete intschArgs.selectedFacets
+
+  const result: any = await intsch.facets(
+    { ...intschArgs, query: args.fullText },
+    buildAttributePath(selectedFacets),
+    shippingOptions
+  )
+
+  if (ctx.vtex.tenant) {
+    ctx.translated = result.translated
+  }
+
+  return result
+}
+
+/**
+ * Facets service that extracts facets fetching logic and implements flag-based routing
+ * using intelligentSearchApi as primary and intsch as alternative based on shouldUseNewPLPEndpoint flag
+ */
+export async function fetchFacets(
+  ctx: Context,
+  args: FacetsInput,
+  selectedFacets: SelectedFacet[],
+  shippingOptions?: string[]
+) {
+  const { shouldUseNewPLPEndpoint } = await fetchAppSettings(ctx)
+
+  // Check if current account should use intsch directly
+  if (shouldUseNewPLPEndpoint) {
+    return fetchFacetsFromIntsch(ctx, args, selectedFacets, shippingOptions)
+  }
+
+  return fetchFacetsFromBiggy(ctx, args, selectedFacets, shippingOptions)
+}
+

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -69,7 +69,7 @@ async function fetchProductFromIntsch(
   const { field, value } = identifier
 
   // Get locale from context (fallback)
-  const defaultLocale = ctx.vtex.tenant?.locale || ctx.vtex.locale
+  const defaultLocale = ctx.vtex.tenant?.locale ?? ctx.vtex.locale
 
   // Default salesChannel from args
   let finalSalesChannel = salesChannel ? `${salesChannel}` : undefined
@@ -170,9 +170,9 @@ export async function resolveProduct(
   const args =
     rawArgs && isValidProductIdentifier(rawArgs.identifier)
       ? rawArgs
-      : { identifier: { field: 'slug', value: rawArgs.slug! } }
+      : { identifier: { field: 'slug', value: rawArgs.slug ?? '' } }
 
-  if (!args.identifier) {
+  if (!args.identifier?.value) {
     throw new Error('No product identifier provided')
   }
 
@@ -205,7 +205,7 @@ export async function resolveProduct(
       return null
     }
 
-    const product = products[0]
+    const [product] = products
 
     return product
   } catch (error) {
@@ -266,7 +266,7 @@ async function fetchProductsByIdentifierFromIntsch(
   const { field, values, salesChannel, regionId } = args
 
   // Get locale from context (fallback)
-  const defaultLocale = ctx.vtex.tenant?.locale || ctx.vtex.locale
+  const defaultLocale = ctx.vtex.tenant?.locale ?? ctx.vtex.locale
 
   // Default salesChannel from args
   let finalSalesChannel = salesChannel ? `${salesChannel}` : undefined
@@ -334,12 +334,20 @@ export async function resolveProductsByIdentifier(
 
     // Check if current account should use intsch directly
     if (shouldUseNewPDPEndpoint) {
-      products = await fetchProductsByIdentifierFromIntsch(ctx, args, vtexSegment)
+      products = await fetchProductsByIdentifierFromIntsch(
+        ctx,
+        args,
+        vtexSegment
+      )
     } else {
-      products = await fetchProductsByIdentifierFromSearch(ctx, args, vtexSegment)
+      products = await fetchProductsByIdentifierFromSearch(
+        ctx,
+        args,
+        vtexSegment
+      )
     }
 
-    return products 
+    return products
   } catch (error) {
     ctx.vtex.logger.error({
       message: 'Error fetching products by identifier',

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -217,3 +217,135 @@ export async function resolveProduct(
     throw error
   }
 }
+
+export type ProductsByIdentifierArgs = {
+  field: 'id' | 'ean' | 'reference' | 'sku'
+  values: string[]
+  salesChannel?: string | null
+  regionId?: string | null
+}
+
+/**
+ * Fetches multiple products by identifier using the search client
+ */
+async function fetchProductsByIdentifierFromSearch(
+  ctx: Context,
+  args: ProductsByIdentifierArgs,
+  vtexSegment?: string
+): Promise<SearchProduct[]> {
+  const { search } = ctx.clients
+  const { field, values, salesChannel } = args
+
+  switch (field) {
+    case 'id':
+      return search.productsById(values, vtexSegment, salesChannel)
+
+    case 'ean':
+      return search.productsByEan(values, vtexSegment, salesChannel)
+
+    case 'reference':
+      return search.productsByReference(values, vtexSegment, salesChannel)
+
+    case 'sku':
+      return search.productsBySku(values, vtexSegment, salesChannel)
+
+    default:
+      throw new Error(`Unsupported product identifier field: ${field}`)
+  }
+}
+
+/**
+ * Fetches multiple products by identifier using the intsch client
+ */
+async function fetchProductsByIdentifierFromIntsch(
+  ctx: Context,
+  args: ProductsByIdentifierArgs,
+  vtexSegment?: string
+): Promise<SearchProduct[]> {
+  const { intsch } = ctx.clients
+  const { field, values, salesChannel, regionId } = args
+
+  // Get locale from context (fallback)
+  const defaultLocale = ctx.vtex.tenant?.locale || ctx.vtex.locale
+
+  // Default salesChannel from args
+  let finalSalesChannel = salesChannel ? `${salesChannel}` : undefined
+  let finalLocale = defaultLocale
+
+  // Parse vtexSegment if available to extract locale and salesChannel
+  if (vtexSegment) {
+    try {
+      const segmentData: SegmentData = JSON.parse(
+        Buffer.from(vtexSegment, 'base64').toString()
+      )
+
+      // Use segment's salesChannel if available, otherwise use the provided one
+      if (segmentData.channel) {
+        finalSalesChannel = segmentData.channel
+      }
+
+      // Use segment's locale (cultureInfo) if available, otherwise use default
+      if (segmentData.cultureInfo) {
+        finalLocale = segmentData.cultureInfo
+      }
+    } catch (error) {
+      // If parsing fails, continue with defaults
+      ctx.vtex.logger.warn({
+        message: 'Failed to parse vtexSegment token, using defaults',
+        error: error.message,
+        vtexSegment,
+      })
+    }
+  }
+
+  // Fetch all products in parallel
+  const productPromises = values.map((value) =>
+    intsch.fetchProduct({
+      field,
+      value,
+      salesChannel: finalSalesChannel?.toString(),
+      regionId: regionId ?? undefined,
+      locale: finalLocale,
+    })
+  )
+
+  const products = await Promise.all(productPromises)
+
+  return products as SearchProduct[]
+}
+
+export async function resolveProductsByIdentifier(
+  ctx: Context,
+  args: ProductsByIdentifierArgs
+): Promise<SearchProduct[]> {
+  const vtexSegment =
+    !ctx.vtex.segment || (!ctx.vtex.segment?.regionId && args.regionId)
+      ? buildVtexSegment({
+          vtexSegment: ctx.vtex.segment as SegmentData | undefined,
+          salesChannel: args.salesChannel?.toString(),
+          regionId: args.regionId ?? undefined,
+        })
+      : ctx.vtex.segmentToken
+
+  const { shouldUseNewPDPEndpoint } = await fetchAppSettings(ctx)
+
+  try {
+    let products: SearchProduct[]
+
+    // Check if current account should use intsch directly
+    if (shouldUseNewPDPEndpoint) {
+      products = await fetchProductsByIdentifierFromIntsch(ctx, args, vtexSegment)
+    } else {
+      products = await fetchProductsByIdentifierFromSearch(ctx, args, vtexSegment)
+    }
+
+    return products 
+  } catch (error) {
+    ctx.vtex.logger.error({
+      message: 'Error fetching products by identifier',
+      error: error.message,
+      args,
+    })
+    throw error
+  }
+}

--- a/node/services/productSearch.test.ts
+++ b/node/services/productSearch.test.ts
@@ -1,0 +1,203 @@
+import { fetchProductSearch } from './productSearch'
+import { createContext } from '../mocks/contextFactory'
+import type { ProductSearchInput } from '../typings/Search'
+
+describe('fetchProductSearch service', () => {
+  const mockProductSearchResponse = {
+    products: [] as any,
+    recordsFiltered: 2,
+  }
+
+  const mockArgs: ProductSearchInput = {
+    fullText: 'test query',
+    query: 'test',
+    map: 'ft',
+    selectedFacets: [],
+    orderBy: 'OrderByTopSaleDESC',
+    from: 0,
+    to: 10,
+    fuzzy: '0',
+    operator: 'and',
+    productOriginVtex: false,
+    simulationBehavior: 'default',
+    hideUnavailableItems: false,
+  }
+
+  const mockSelectedFacets: SelectedFacet[] = []
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should use intelligentSearchApi when shouldUseNewPLPEndpoint is false', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    const result = await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.clients.intelligentSearchApi.productSearch).toHaveBeenCalled()
+    expect(ctx.clients.intsch.productSearch).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      searchState: undefined,
+      ...mockProductSearchResponse,
+    })
+  })
+
+  it('should use intsch when shouldUseNewPLPEndpoint is true', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: true,
+      },
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    const result = await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.clients.intsch.productSearch).toHaveBeenCalled()
+    expect(ctx.clients.intelligentSearchApi.productSearch).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      searchState: undefined,
+      ...mockProductSearchResponse,
+    })
+  })
+
+  it('should handle shipping options correctly', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    const shippingOptions = ['delivery', 'pickup']
+
+    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets, shippingOptions)
+
+    expect(ctx.clients.intelligentSearchApi.productSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'test query' }),
+      expect.any(String),
+      shippingOptions
+    )
+  })
+
+  it('should preserve searchState in response', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    const argsWithSearchState = {
+      ...mockArgs,
+      searchState: 'test-search-state',
+    }
+
+    const result = await fetchProductSearch(
+      ctx,
+      argsWithSearchState,
+      mockSelectedFacets
+    )
+
+    expect(result.searchState).toBe('test-search-state')
+  })
+
+  it('should set translated flag in context when tenant is present and productOriginVtex is false', async () => {
+    const mockResponseWithTranslated = {
+      ...mockProductSearchResponse,
+      translated: true,
+    } as any
+
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockResponseWithTranslated,
+      },
+      tenantLocale: 'en-US',
+    })
+
+    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.translated).toBe(true)
+  })
+
+  it('should not set translated flag when productOriginVtex is true', async () => {
+    const mockResponseWithTranslated = {
+      ...mockProductSearchResponse,
+      translated: true,
+    } as any
+
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockResponseWithTranslated,
+      },
+      tenantLocale: 'en-US',
+    })
+
+    const argsWithProductOriginVtex = {
+      ...mockArgs,
+      productOriginVtex: true,
+    }
+
+    await fetchProductSearch(ctx, argsWithProductOriginVtex, mockSelectedFacets)
+
+    expect(ctx.translated).toBeUndefined()
+  })
+
+  it('should include advertisement options in the request', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    const argsWithAdOptions = {
+      ...mockArgs,
+      advertisementOptions: {
+        showSponsored: true,
+        sponsoredCount: 5,
+        repeatSponsoredProducts: false,
+      },
+    }
+
+    await fetchProductSearch(ctx, argsWithAdOptions, mockSelectedFacets)
+
+    expect(ctx.clients.intelligentSearchApi.productSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showSponsored: true,
+        sponsoredCount: 5,
+        repeatSponsoredProducts: false,
+      }),
+      expect.any(String),
+      undefined
+    )
+  })
+})
+

--- a/node/services/productSearch.test.ts
+++ b/node/services/productSearch.test.ts
@@ -1,6 +1,7 @@
 import { fetchProductSearch } from './productSearch'
 import { createContext } from '../mocks/contextFactory'
 import type { ProductSearchInput } from '../typings/Search'
+import * as compareResultsModule from '../utils/compareResults'
 
 describe('fetchProductSearch service', () => {
   const mockProductSearchResponse = {
@@ -29,27 +30,6 @@ describe('fetchProductSearch service', () => {
     jest.clearAllMocks()
   })
 
-  it('should use intelligentSearchApi when shouldUseNewPLPEndpoint is false', async () => {
-    const ctx = createContext({
-      accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-    })
-
-    const result = await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
-
-    expect(ctx.clients.intelligentSearchApi.productSearch).toHaveBeenCalled()
-    expect(ctx.clients.intsch.productSearch).not.toHaveBeenCalled()
-    expect(result).toEqual({
-      searchState: undefined,
-      ...mockProductSearchResponse,
-    })
-  })
-
   it('should use intsch when shouldUseNewPLPEndpoint is true', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
@@ -64,11 +44,44 @@ describe('fetchProductSearch service', () => {
     const result = await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
 
     expect(ctx.clients.intsch.productSearch).toHaveBeenCalled()
-    expect(ctx.clients.intelligentSearchApi.productSearch).not.toHaveBeenCalled()
+    expect(
+      ctx.clients.intelligentSearchApi.productSearch
+    ).not.toHaveBeenCalled()
     expect(result).toEqual({
       searchState: undefined,
       ...mockProductSearchResponse,
     })
+  })
+
+  it('should compare both APIs when shouldUseNewPLPEndpoint is undefined', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: undefined,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    const mockResult = {
+      searchState: undefined,
+      ...mockProductSearchResponse,
+    }
+
+    const compareApiResultsSpy = jest
+      .spyOn(compareResultsModule, 'compareApiResults')
+      .mockResolvedValue(mockResult)
+
+    const result = await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    expect(compareApiResultsSpy).toHaveBeenCalled()
+    expect(result).toEqual(mockResult)
+
+    compareApiResultsSpy.mockRestore()
   })
 
   it('should handle shipping options correctly', async () => {
@@ -200,4 +213,3 @@ describe('fetchProductSearch service', () => {
     )
   })
 })
-

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -1,0 +1,121 @@
+import { buildAttributePath, convertOrderBy } from '../commons/compatibility-layer'
+import { getWorkspaceSearchParamsFromStorage } from '../routes/workspaceSearchParams'
+import { fetchAppSettings } from './settings'
+import type { ProductSearchInput } from '../typings/Search'
+
+const defaultAdvertisementOptions = {
+  showSponsored: false,
+  sponsoredCount: 3,
+  repeatSponsoredProducts: true,
+}
+
+/**
+ * Fetches product search results using the intelligentSearchApi client (Biggy)
+ */
+async function fetchProductSearchFromBiggy(
+  ctx: Context,
+  args: ProductSearchInput,
+  selectedFacets: SelectedFacet[],
+  shippingOptions?: string[]
+) {
+  const { intelligentSearchApi } = ctx.clients
+  const {
+    fullText,
+    advertisementOptions = defaultAdvertisementOptions,
+  } = args
+
+  const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
+
+  const biggyArgs: { [key: string]: any } = {
+    ...advertisementOptions,
+    ...args,
+    query: fullText,
+    sort: convertOrderBy(args.orderBy),
+    ...args.options,
+    ...workspaceSearchParams,
+  }
+
+  // unnecessary field. It's is an object and breaks the @vtex/api cache
+  delete biggyArgs.selectedFacets
+
+  const result: any = await intelligentSearchApi.productSearch(
+    { ...biggyArgs },
+    buildAttributePath(selectedFacets),
+    shippingOptions
+  )
+
+  if (ctx.vtex.tenant && !args.productOriginVtex) {
+    ctx.translated = result.translated
+  }
+
+  return {
+    searchState: args.searchState,
+    ...result,
+  }
+}
+
+/**
+ * Fetches product search results using the intsch client (Intelligent Search)
+ */
+async function fetchProductSearchFromIntsch(
+  ctx: Context,
+  args: ProductSearchInput,
+  selectedFacets: SelectedFacet[],
+  shippingOptions?: string[]
+) {
+  const { intsch } = ctx.clients
+  const {
+    fullText,
+    advertisementOptions = defaultAdvertisementOptions,
+  } = args
+
+  const workspaceSearchParams = await getWorkspaceSearchParamsFromStorage(ctx)
+
+  const intschArgs: { [key: string]: any } = {
+    ...advertisementOptions,
+    ...args,
+    query: fullText,
+    sort: convertOrderBy(args.orderBy),
+    ...args.options,
+    ...workspaceSearchParams,
+  }
+
+  // unnecessary field. It's is an object and breaks the @vtex/api cache
+  delete intschArgs.selectedFacets
+
+  const result: any = await intsch.productSearch(
+    { ...intschArgs },
+    buildAttributePath(selectedFacets),
+    shippingOptions
+  )
+
+  if (ctx.vtex.tenant && !args.productOriginVtex) {
+    ctx.translated = result.translated
+  }
+
+  return {
+    searchState: args.searchState,
+    ...result,
+  }
+}
+
+/**
+ * ProductSearch service that extracts product search fetching logic and implements flag-based routing
+ * using intelligentSearchApi as primary and intsch as alternative based on shouldUseNewPLPEndpoint flag
+ */
+export async function fetchProductSearch(
+  ctx: Context,
+  args: ProductSearchInput,
+  selectedFacets: SelectedFacet[],
+  shippingOptions?: string[]
+) {
+  const { shouldUseNewPLPEndpoint } = await fetchAppSettings(ctx)
+
+  // Check if current account should use intsch directly
+  if (shouldUseNewPLPEndpoint) {
+    return fetchProductSearchFromIntsch(ctx, args, selectedFacets, shippingOptions)
+  }
+
+  return fetchProductSearchFromBiggy(ctx, args, selectedFacets, shippingOptions)
+}
+

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -16,6 +16,7 @@ const defaultAdvertisementOptions = {
 /**
  * Fetches product search results using the intelligentSearchApi client (Biggy)
  */
+// eslint-disable-next-line max-params
 async function fetchProductSearchFromBiggy(
   ctx: Context,
   args: ProductSearchInput,
@@ -58,6 +59,7 @@ async function fetchProductSearchFromBiggy(
 /**
  * Fetches product search results using the intsch client (Intelligent Search)
  */
+// eslint-disable-next-line max-params
 async function fetchProductSearchFromIntsch(
   ctx: Context,
   args: ProductSearchInput,
@@ -100,6 +102,7 @@ async function fetchProductSearchFromIntsch(
 /**
  * ProductSearch service that extracts product search fetching logic and implements comparison or flag-based routing
  */
+// eslint-disable-next-line max-params
 export async function fetchProductSearch(
   ctx: Context,
   args: ProductSearchInput,

--- a/node/services/settings.ts
+++ b/node/services/settings.ts
@@ -1,5 +1,6 @@
 type AppSettings = {
   shouldUseNewPDPEndpoint: boolean
+  shouldUseNewPLPEndpoint: boolean
 }
 
 export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
@@ -8,12 +9,12 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
   } = ctx
 
   try {
-    const { shouldUseNewPDPEndpoint }: AppSettings = await apps.getAppSettings(
-      'vtex.search-resolver@1.x'
-    )
+    const { shouldUseNewPDPEndpoint, shouldUseNewPLPEndpoint }: AppSettings =
+      await apps.getAppSettings('vtex.search-resolver@1.x')
 
     return {
       shouldUseNewPDPEndpoint,
+      shouldUseNewPLPEndpoint,
     }
   } catch (error) {
     ctx.vtex.logger.error({
@@ -23,6 +24,7 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
 
     return {
       shouldUseNewPDPEndpoint: false,
+      shouldUseNewPLPEndpoint: false,
     }
   }
 }

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -40,7 +40,7 @@ export interface SearchResultArgs extends AdvertisementOptions {
   showSponsored?: boolean
 }
 
-interface RegionSeller {
+export type RegionSeller = {
   id: string
   name: string
 }


### PR DESCRIPTION
#### What problem is this solving?

- Added the new endpoints for intsch (facets and product-search) and a feature-flag to trigger it.
- Changed the productByIdentifier to also trigger the intsch flow when the PDP flag is on.
- Start sending some shadow traffic to test the facets and Search endpoints.

#### How should this be manually tested?

[Workspace](https://felipe--cea.myvtex.com/search/camiseta%20feminina%20algod%C3%A3o%20peruano)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
