### PR TITLE
Add log to detect categoryTree mount for non vtex accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added log to `productCategoriesToCategoryTree` fallback return if the platform is not `vtex` to detect if it is used
+
 ## [1.82.0] - 2025-10-01
 
 ### Changed

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -1,4 +1,4 @@
-import { compose, last, omit, pathOr, split, flatten } from 'ramda'
+import { compose, flatten, last, omit, pathOr, split } from 'ramda'
 
 import {
   addContextToTranslatableString,
@@ -123,7 +123,7 @@ const findMainTree = (categoriesIds: string[], prodCategoryId: string) => {
 const productCategoriesToCategoryTree = async (
   { categories, categoriesIds, categoryId: prodCategoryId }: SearchProduct,
   _: any,
-  { clients: { search }, vtex: { platform } }: Context
+  { clients: { search }, vtex: { platform, logger } }: Context
 ) => {
   if (!categories || !categoriesIds) {
     return []
@@ -134,6 +134,8 @@ const productCategoriesToCategoryTree = async (
   if (platform === 'vtex') {
     return mainTreeIds.map(categoryId => search.category(Number(categoryId)))
   }
+
+  logger.info({ message: 'productCategoriesToCategoryTree: not vtex platform', platform })
   const categoriesTree = await search.categories(mainTreeIds.length)
   const categoryMap = buildCategoryMap(categoriesTree)
   const mappedCategories = mainTreeIds


### PR DESCRIPTION
#### What problem is this solving?

We want to identify if this category tree mount strategy is being used for some accounts.
* Added a log statement using the `logger` object to record when the resolver is executed on a non-VTEX platform, including the platform name for easier debugging.

#### How should this be manually tested?

-

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
