### PR TITLE
Route traffic to intsch instead of the IO version. For: correction, banners, suggestions and top-searches routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Route traffic to intsch instead of the IO version. For: correction, banners, suggestions and top-searches routes.
+
 ## [1.89.0] - 2025-12-08
 
 ### Added

--- a/node/services/autocomplete.ts
+++ b/node/services/autocomplete.ts
@@ -1,85 +1,45 @@
-import { compareApiResults, NO_TRAFFIC } from '../utils/compareResults'
-
 export function fetchAutocompleteSuggestions(ctx: Context, query: string) {
-  const { intelligentSearchApi, intsch } = ctx.clients
+  const { intsch } = ctx.clients
 
   const args = { query }
 
-  const locale = (ctx.vtex.segment?.cultureInfo ||
-    ctx.vtex.tenant?.locale ||
+  const locale = (ctx.vtex.segment?.cultureInfo ??
+    ctx.vtex.tenant?.locale ??
     ctx.vtex.locale) as string
 
-  return compareApiResults(
-    () => intelligentSearchApi.fetchAutocompleteSuggestions(args),
-    () => intsch.fetchAutocompleteSuggestionsV1({ ...args, locale }),
-    ctx.vtex.production ? NO_TRAFFIC : 100,
-    ctx.vtex.logger,
-    {
-      logPrefix: 'Autocomplete Suggestions',
-      args: { ...args, locale },
-    }
-  )
+  return intsch.fetchAutocompleteSuggestionsV1({ ...args, locale })
 }
 
 export function fetchTopSearches(ctx: Context) {
-  const { intelligentSearchApi, intsch } = ctx.clients
+  const { intsch } = ctx.clients
 
-  const locale = (ctx.vtex.segment?.cultureInfo ||
-    ctx.vtex.tenant?.locale ||
+  const locale = (ctx.vtex.segment?.cultureInfo ??
+    ctx.vtex.tenant?.locale ??
     ctx.vtex.locale) as string
 
-  return compareApiResults(
-    () => intelligentSearchApi.fetchTopSearches(),
-    () => intsch.fetchTopSearchesV1(locale),
-    ctx.vtex.production ? NO_TRAFFIC : 100,
-    ctx.vtex.logger,
-    {
-      logPrefix: 'Top Searches',
-      args: {
-        locale,
-      },
-    }
-  )
+  return intsch.fetchTopSearchesV1(locale)
 }
 
 export function fetchSearchSuggestions(ctx: Context, query: string) {
-  const { intelligentSearchApi, intsch } = ctx.clients
+  const { intsch } = ctx.clients
 
   const args = { query }
 
-  const locale = (ctx.vtex.segment?.cultureInfo ||
-    ctx.vtex.tenant?.locale ||
+  const locale = (ctx.vtex.segment?.cultureInfo ??
+    ctx.vtex.tenant?.locale ??
     ctx.vtex.locale) as string
 
-  return compareApiResults(
-    () => intelligentSearchApi.fetchSearchSuggestions(args),
-    () => intsch.fetchSearchSuggestionsV1({ ...args, locale }),
-    ctx.vtex.production ? NO_TRAFFIC : 100,
-    ctx.vtex.logger,
-    {
-      logPrefix: 'Search Suggestions',
-      args: { ...args, locale },
-    }
-  )
+  return intsch.fetchSearchSuggestionsV1({ ...args, locale })
 }
 
 export function fetchCorrection(ctx: Context, query: string) {
-  const { intelligentSearchApi, intsch } = ctx.clients
+  const { intsch } = ctx.clients
 
   const args = { query }
 
-  const locale = (ctx.vtex.segment?.cultureInfo ||
-    ctx.vtex.tenant?.locale ||
+  const locale = (ctx.vtex.segment?.cultureInfo ??
+    ctx.vtex.tenant?.locale ??
     ctx.vtex.locale) as string
 
-  return compareApiResults(
-    () => intelligentSearchApi.fetchCorrection(args),
-    () => intsch.fetchCorrectionV1({ ...args, locale }),
-    ctx.vtex.production ? NO_TRAFFIC : 100,
-    ctx.vtex.logger,
-    {
-      logPrefix: 'Correction',
-      args: { ...args, locale },
-    }
-  )
+  return intsch.fetchCorrectionV1({ ...args, locale })
 }

--- a/node/services/banners.ts
+++ b/node/services/banners.ts
@@ -1,11 +1,10 @@
-import { compareApiResults, NO_TRAFFIC } from '../utils/compareResults'
 import { buildAttributePath } from '../commons/compatibility-layer'
 
 export async function fetchBanners(
   ctx: Context,
   args: { fullText: string; selectedFacets: SelectedFacet[] }
 ) {
-  const { intelligentSearchApi, intsch } = ctx.clients
+  const { intsch } = ctx.clients
 
   const argumentsToFetchBanners = {
     query: args.fullText,
@@ -16,14 +15,5 @@ export async function fetchBanners(
     ctx.vtex.tenant?.locale ||
     ctx.vtex.locale) as string
 
-  return compareApiResults(
-    () => intelligentSearchApi.fetchBanners(argumentsToFetchBanners),
-    () => intsch.fetchBannersV1({ ...argumentsToFetchBanners, locale }),
-    ctx.vtex.production ? NO_TRAFFIC : 100,
-    ctx.vtex.logger,
-    {
-      logPrefix: 'Banners',
-      args: argumentsToFetchBanners,
-    }
-  )
+  return intsch.fetchBannersV1({ ...argumentsToFetchBanners, locale })
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -3997,7 +3997,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

- Continuing the migration to our new api...