### PR TITLE
Testing 1% of the facets and product search traffic to intsch service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Enhanced comparisson logs for Facets and Product Search
+- Sending 1% of production traffict to test both search and facets endpoint.
+
 ## [1.90.0] - 2025-12-09
 
 ### Changed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -363,7 +363,7 @@ export const queries = {
 
     const { selectedFacets } = args
 
-    return fetchFacets(ctx, args, selectedFacets, shippingOptions)
+    return fetchFacets(ctx, { args, selectedFacets, shippingOptions })
   },
 
   product: async (_: any, rawArgs: ProductArgs, ctx: Context) => {

--- a/node/services/facets.test.ts
+++ b/node/services/facets.test.ts
@@ -44,7 +44,10 @@ describe('fetchFacets service', () => {
       },
     })
 
-    const result = await fetchFacets(ctx, mockArgs, mockSelectedFacets)
+    const result = await fetchFacets(ctx, {
+      args: mockArgs,
+      selectedFacets: mockSelectedFacets,
+    })
 
     expect(ctx.clients.intsch.facets).toHaveBeenCalled()
     expect(ctx.clients.intelligentSearchApi.facets).not.toHaveBeenCalled()
@@ -69,7 +72,10 @@ describe('fetchFacets service', () => {
       .spyOn(compareResultsModule, 'compareApiResults')
       .mockResolvedValue(mockFacetsResponse)
 
-    const result = await fetchFacets(ctx, mockArgs, mockSelectedFacets)
+    const result = await fetchFacets(ctx, {
+      args: mockArgs,
+      selectedFacets: mockSelectedFacets,
+    })
 
     expect(compareApiResultsSpy).toHaveBeenCalled()
     expect(result).toEqual(mockFacetsResponse)
@@ -90,7 +96,11 @@ describe('fetchFacets service', () => {
 
     const shippingOptions = ['delivery', 'pickup']
 
-    await fetchFacets(ctx, mockArgs, mockSelectedFacets, shippingOptions)
+    await fetchFacets(ctx, {
+      args: mockArgs,
+      selectedFacets: mockSelectedFacets,
+      shippingOptions,
+    })
 
     expect(ctx.clients.intelligentSearchApi.facets).toHaveBeenCalledWith(
       expect.objectContaining({ query: 'test query' }),
@@ -111,7 +121,10 @@ describe('fetchFacets service', () => {
       tenantLocale: 'en-US',
     })
 
-    await fetchFacets(ctx, mockArgs, mockSelectedFacets)
+    await fetchFacets(ctx, {
+      args: mockArgs,
+      selectedFacets: mockSelectedFacets,
+    })
 
     expect(ctx.translated).toBe(true)
   })

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -1,5 +1,5 @@
 import { buildAttributePath } from '../commons/compatibility-layer'
-import { compareApiResults, NO_TRAFFIC } from '../utils/compareResults'
+import { compareApiResults } from '../utils/compareResults'
 import { fetchAppSettings } from './settings'
 import type { FacetsInput } from '../typings/Search'
 import { decodeQuery } from '../clients/intelligent-search-api'
@@ -148,7 +148,7 @@ export async function fetchFacets(ctx: Context, options: FetchFacetsOptions) {
   return compareApiResults(
     () => fetchFacetsFromBiggy(ctx, options),
     () => fetchFacetsFromIntsch(ctx, options),
-    ctx.vtex.production ? NO_TRAFFIC : 100,
+    ctx.vtex.production ? 1 : 100,
     ctx.vtex.logger,
     {
       logPrefix: 'Facets',

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -35,6 +35,7 @@ function buildCurlCommands(
 ): { biggyCurl: string; intschCurl: string } {
   const { workspace, account } = ctx.vtex
   const queryString = buildQueryString(params)
+
   const shippingHeader = shippingOptions?.length
     ? ` -H "x-vtex-shipping-options: ${shippingOptions.join(',')}"`
     : ''
@@ -77,6 +78,7 @@ async function fetchProductSearchFromBiggy(
 
   // unnecessary field. It's is an object and breaks the @vtex/api cache
   delete biggyArgs.selectedFacets
+  delete biggyArgs.advertisementOptions
 
   const result: any = await intelligentSearchApi.productSearch(
     { ...biggyArgs },
@@ -120,6 +122,7 @@ async function fetchProductSearchFromIntsch(
 
   // unnecessary field. It's is an object and breaks the @vtex/api cache
   delete intschArgs.selectedFacets
+  delete intschArgs.advertisementOptions
 
   const result: any = await intsch.productSearch(
     { ...intschArgs },
@@ -173,6 +176,7 @@ export async function fetchProductSearch(
   }
 
   delete clientArgs.selectedFacets
+  delete clientArgs.advertisementOptions
 
   const { leap, searchState } = args as { leap?: boolean; searchState?: string }
 

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -3,7 +3,7 @@ import {
   convertOrderBy,
 } from '../commons/compatibility-layer'
 import { getWorkspaceSearchParamsFromStorage } from '../routes/workspaceSearchParams'
-import { compareApiResults, NO_TRAFFIC } from '../utils/compareResults'
+import { compareApiResults } from '../utils/compareResults'
 import { fetchAppSettings } from './settings'
 import type { ProductSearchInput } from '../typings/Search'
 import { decodeQuery } from '../clients/intelligent-search-api'
@@ -196,7 +196,7 @@ export async function fetchProductSearch(
       fetchProductSearchFromBiggy(ctx, args, selectedFacets, shippingOptions),
     () =>
       fetchProductSearchFromIntsch(ctx, args, selectedFacets, shippingOptions),
-    ctx.vtex.production ? NO_TRAFFIC : 100,
+    ctx.vtex.production ? 1 : 100,
     ctx.vtex.logger,
     {
       logPrefix: 'ProductSearch',

--- a/node/utils/compareResults.ts
+++ b/node/utils/compareResults.ts
@@ -1,7 +1,5 @@
 import type { Logger } from '@vtex/api'
 
-export const NO_TRAFFIC = 0
-
 /**
  * Utility to compare the results of two functions in parallel
  * Used primarily for comparing the results of two API implementations


### PR DESCRIPTION
`{
  app: 'vtex.search-resolver@1.90.0',
  account: 'biggy',
  workspace: 'felipe',
  production: false,
  data: {
    message: 'ProductSearch: Results differ',
    params: '{"biggyCurl":"curl \\"https://felipe--biggy.myvtex.com/_v/api/intelligent-search/product_search/?query=camisa&locale=pt-BR&showSponsored=true&sponsoredCount=3&repeatSponsoredProducts=true&advertisementPlacement=top_search&fullText=camisa&map=ft&orderBy=OrderByScoreDESC&from=0&to=9&hideUnavailableItems=false&simulationBehavior=skip&productOriginVtex=false&operator=and&fuzzy=0&a=1&c=1\\"","intschCurl":"curl \\"https://biggy.myvtex.com/api/intelligent-search/v0/product-search/?query=camisa&locale=pt-BR&showSponsored=true&sponsoredCount=3&repeatSponsoredProducts=true&advertisementPlacement=top_search&fullText=camisa&map=ft&orderBy=OrderByScoreDESC&from=0&to=9&hideUnavailableItems=false&simulationBehavior=skip&productOriginVtex=false&operator=and&fuzzy=0&a=1&c=1\\""}',
    differences: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    differenceCount: 454,
    totalDifferences: 454,
    ignoredDifferences: 0
  },
  level: 'error',
  operationId: 'ad49842c-2cd5-4a5a-8ab1-cb71a7ef3482',
  requestId: 'ace68d293f8443a1ad88b9fafd660f9c'
}`