### PR TITLE
Forward the segment in the headers for facets and search request to intsch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Enhanced comparisson logs for Facets and Product Search by including the vtex-segment  in the curl.
+- Forward the segment in the headers for facets and search request to intsch.
+
 ## [1.91.0] - 2025-12-15
 
 ### Changed

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -172,6 +172,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
       },
       metric: 'product-search-new',
       headers: {
+        'x-vtex-segment': this.context.segmentToken,
         'x-vtex-shipping-options': shippingHeader ?? '',
         ...(authToken ? { VtexIdclientAutCookie: authToken } : {}),
       },
@@ -203,6 +204,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
       },
       metric: 'facets-new',
       headers: {
+        'x-vtex-segment': this.context.segmentToken,
         'x-vtex-shipping-options': shippingHeader ?? '',
         ...(authToken ? { VtexIdclientAutCookie: authToken } : {}),
       },

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -23,20 +23,25 @@ function buildQueryString(params: Record<string, any>): string {
 /**
  * Builds curl commands for debugging API requests
  */
+// eslint-disable-next-line max-params
 function buildCurlCommands(
   ctx: Context,
   path: string,
   params: Record<string, any>,
   shippingOptions?: string[]
 ): { biggyCurl: string; intschCurl: string } {
-  const { workspace, account } = ctx.vtex
+  const { account } = ctx.vtex
   const queryString = buildQueryString(params)
   const shippingHeader = shippingOptions?.length
     ? ` -H "x-vtex-shipping-options: ${shippingOptions.join(',')}"`
     : ''
 
-  const biggyCurl = `curl "https://${workspace}--${account}.myvtex.com/_v/api/intelligent-search/facets/${path}?${queryString}"${shippingHeader}`
-  const intschCurl = `curl "https://${account}.myvtex.com/api/intelligent-search/v0/facets/${path}?${queryString}"${shippingHeader}`
+  const segmentHeader = ctx.vtex.segmentToken
+    ? ` -H "x-vtex-segment: ${ctx.vtex.segmentToken}"`
+    : ''
+
+  const biggyCurl = `curl "https://${account}.myvtex.com/_v/api/intelligent-search/facets/${path}?${queryString}"${shippingHeader}${segmentHeader}`
+  const intschCurl = `curl "https://${account}.myvtex.com/api/intelligent-search/v0/facets/${path}?${queryString}"${shippingHeader}${segmentHeader}`
 
   return { biggyCurl, intschCurl }
 }

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -27,21 +27,26 @@ function buildQueryString(params: Record<string, any>): string {
 /**
  * Builds curl commands for debugging API requests
  */
+// eslint-disable-next-line max-params
 function buildCurlCommands(
   ctx: Context,
   path: string,
   params: Record<string, any>,
   shippingOptions?: string[]
 ): { biggyCurl: string; intschCurl: string } {
-  const { workspace, account } = ctx.vtex
+  const { account } = ctx.vtex
   const queryString = buildQueryString(params)
 
   const shippingHeader = shippingOptions?.length
     ? ` -H "x-vtex-shipping-options: ${shippingOptions.join(',')}"`
     : ''
 
-  const biggyCurl = `curl "https://${workspace}--${account}.myvtex.com/_v/api/intelligent-search/product_search/${path}?${queryString}"${shippingHeader}`
-  const intschCurl = `curl "https://${account}.myvtex.com/api/intelligent-search/v0/product-search/${path}?${queryString}"${shippingHeader}`
+  const segmentHeader = ctx.vtex.segmentToken
+    ? ` -H "x-vtex-segment: ${ctx.vtex.segmentToken}"`
+    : ''
+
+  const biggyCurl = `curl "https://${account}.myvtex.com/_v/api/intelligent-search/product_search/${path}?${queryString}"${shippingHeader}${segmentHeader}`
+  const intschCurl = `curl "https://${account}.myvtex.com/api/intelligent-search/v0/product-search/${path}?${queryString}"${shippingHeader}${segmentHeader}`
 
   return { biggyCurl, intschCurl }
 }


### PR DESCRIPTION
We noticed differences in some requests and we were not quite understanding why until we realized that the SalesChannel is only present in the segment and we weren't forwarding the segment to the new API, for store with different sales channel...