### PR TITLE
Add shadow migration strategy with dk flags

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -90,6 +90,13 @@
     },
     {
       "name": "vtex.messages:graphql-translate-messages"
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "flags.vtex.com",
+        "path": "/*"
+      }
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/index.ts
+++ b/node/index.ts
@@ -4,6 +4,7 @@ import schema from 'vtex.search-graphql/graphql'
 
 import { Clients } from './clients'
 import { schemaDirectives } from './directives'
+import { initFeatureHub } from './services/featurehub'
 import { resolvers } from './resolvers'
 import {
   getWorkspaceSearchParams,
@@ -29,6 +30,9 @@ metrics.trackCache('messages', messagesCache)
 metrics.trackCache('vbase', vbaseCache)
 metrics.trackCache('apps', appsCache)
 metrics.trackCache('intsch', intschCache)
+
+// FeatureHub SSE connection ready before first requests
+initFeatureHub().catch(() => {})
 
 export default new Service<Clients, RecorderState, CustomContext>({
   clients: {

--- a/node/package.json
+++ b/node/package.json
@@ -5,6 +5,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "featurehub-javascript-node-sdk": "1.3.3",
     "@gocommerce/utils": "^0.6.11",
     "camelcase": "^5.0.0",
     "co-body": "^6.2.0",
@@ -36,5 +37,8 @@
     "vtex.messages": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.64.0/public/@types/vtex.messages",
     "vtex.rewriter": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.53.4/public/@types/vtex.rewriter"
   },
-  "version": "1.92.0"
+  "version": "1.92.0",
+  "resolutions": {
+    "featurehub-javascript-client-sdk": "1.4.0"
+  }
 }

--- a/node/services/featurehub.ts
+++ b/node/services/featurehub.ts
@@ -3,7 +3,8 @@ import { EdgeFeatureHubConfig } from 'featurehub-javascript-node-sdk'
 
 const FEATUREHUB_EDGE_URL = 'https://flags.vtex.com/'
 
-const FEATUREHUB_CLIENT_API_KEY = ''
+const FEATUREHUB_CLIENT_API_KEY =
+  '6729a5cb-284e-4f0f-8727-11c28dc76ea9/jO21O8Z7lSlDGHMMuU8ueZvj1uQcnt*SQ40zD7Jpq0vtQafBCTe'
 
 let fhConfig: EdgeFeatureHubConfig | null = null
 let ready = false

--- a/node/services/featurehub.ts
+++ b/node/services/featurehub.ts
@@ -1,0 +1,114 @@
+import type { ClientContext } from 'featurehub-javascript-node-sdk'
+import { EdgeFeatureHubConfig } from 'featurehub-javascript-node-sdk'
+
+const FEATUREHUB_EDGE_URL = 'https://flags.vtex.com/'
+
+const FEATUREHUB_CLIENT_API_KEY =
+  '1a066a06-65c2-481a-b6f5-bc0c5bb3a565/Jxzg2n5WRLGbrVN8UrqD0jz4wOV6ln*FnKz6GX1TV16NAL2Jzmj'
+
+let fhConfig: EdgeFeatureHubConfig | null = null
+let ready = false
+
+export async function initFeatureHub(): Promise<void> {
+  if (fhConfig) {
+    return
+  }
+
+  fhConfig = new EdgeFeatureHubConfig(
+    FEATUREHUB_EDGE_URL,
+    FEATUREHUB_CLIENT_API_KEY
+  )
+
+  // SSE (Server Sent Events) is the default for featurehub-javascript-node-sdk
+  // It provides near real-time updates without polling
+  fhConfig.init()
+
+  await new Promise<void>((resolve) => {
+    if (!fhConfig) return
+
+    fhConfig.addReadynessListener(
+      (_readiness: unknown, firstTimeReady: boolean) => {
+        if (firstTimeReady) {
+          ready = true
+          resolve()
+        }
+      }
+    )
+  })
+}
+
+export async function evaluateBooleanFlag(
+  flagKey: string,
+  defaultValue: boolean,
+  context?: Record<string, string>
+): Promise<{ value: boolean; flagFound: boolean }> {
+  if (!fhConfig || !ready) {
+    return { value: defaultValue, flagFound: false }
+  }
+
+  const clientContext = await buildContext(context)
+
+  if (!clientContext.isSet(flagKey)) {
+    return { value: defaultValue, flagFound: false }
+  }
+
+  const value = clientContext.getBoolean(flagKey)
+
+  if (value === null || value === undefined) {
+    return { value: defaultValue, flagFound: false }
+  }
+
+  return { value, flagFound: true }
+}
+
+export async function evaluateStringFlag(
+  flagKey: string,
+  defaultValue: string,
+  context?: Record<string, string>
+): Promise<{ value: string; flagFound: boolean }> {
+  if (!fhConfig || !ready) {
+    return { value: defaultValue, flagFound: false }
+  }
+
+  const clientContext = await buildContext(context)
+
+  if (!clientContext.isSet(flagKey)) {
+    return { value: defaultValue, flagFound: false }
+  }
+
+  const value = clientContext.getString(flagKey)
+
+  if (value === null || value === undefined) {
+    return { value: defaultValue, flagFound: false }
+  }
+
+  return { value, flagFound: true }
+}
+
+async function buildContext(
+  attrs?: Record<string, string>
+): Promise<ClientContext> {
+  if (!fhConfig) {
+    throw new Error('FeatureHub not initialized')
+  }
+
+  let ctx = fhConfig.newContext()
+
+  if (attrs) {
+    for (const [key, val] of Object.entries(attrs)) {
+      if (key === 'userKey' || key === 'targetingKey') {
+        ctx = ctx.userKey(val)
+      } else if (key === 'sessionKey') {
+        ctx = ctx.sessionKey(val)
+      } else if (key === 'version') {
+        ctx = ctx.version(val)
+      } else {
+        ctx = ctx.attributeValue(key, val)
+      }
+    }
+  }
+
+  ctx = await ctx.build()
+
+  return ctx
+}

--- a/node/services/product.test.ts
+++ b/node/services/product.test.ts
@@ -1,12 +1,13 @@
 import { fetchProduct, buildVtexSegment } from './product'
 import { createContext } from '../mocks/contextFactory'
 
-jest.mock('./featurehub', () => ({
-  evaluateBooleanFlag: jest.fn(),
-}))
+const mockGetBoolean = jest.fn()
 
-const { evaluateBooleanFlag } = jest.requireMock('./featurehub')
-const mockEvaluateBooleanFlag = evaluateBooleanFlag as jest.Mock
+jest.mock('./featurehub', () => ({
+  createEvaluator: jest.fn(() =>
+    Promise.resolve({ getBoolean: mockGetBoolean })
+  ),
+}))
 
 describe('fetchProduct service', () => {
   const mockProduct = {
@@ -17,11 +18,7 @@ describe('fetchProduct service', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    // Default: legacy only (no shadow, no migration complete)
-    mockEvaluateBooleanFlag.mockResolvedValue({
-      value: false,
-      flagFound: true,
-    })
+    mockGetBoolean.mockResolvedValue(false)
   })
 
   it('should build vtex segment correctly', () => {
@@ -63,10 +60,10 @@ describe('fetchProduct service', () => {
   })
 
   it('should use intsch when FeatureHub migrationComplete is true', async () => {
-    mockEvaluateBooleanFlag
-      .mockResolvedValueOnce({ value: true, flagFound: true })
-      .mockResolvedValueOnce({ value: false, flagFound: true })
-      .mockResolvedValueOnce({ value: false, flagFound: true })
+    mockGetBoolean
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
 
     const ctx = createContext({ accountName: 'b2bstoreqa' })
 

--- a/node/shadow/README.md
+++ b/node/shadow/README.md
@@ -19,7 +19,7 @@ The consumer calls `ShadowMigration.execute(legacyFn, nextFn, ctx)`, where:
 
 In **shadow** mode, the comparison runs in the background: both payloads are normalized and go through a structural diff. **Logging**:
 - **No diffs**: `logger.info` with a message indicating no structural differences.
-- **Diffs found**: `logger.warn` with the diff count, summary, and the first differences.
+- **Diffs found**: `logger.error` with the diff count, summary, and the first differences.
 
 ### Diagram: flag-based decision
 
@@ -51,7 +51,7 @@ flowchart LR
     NormL[normalize]
     NormN[normalize]
     Diff[structuralCompare]
-    Log[diffs > 0: logger.warn / else: logger.info]
+    Log[diffs > 0: logger.error / else: logger.info]
   end
   L --> NormL
   N --> NormN
@@ -95,6 +95,6 @@ The diff is **structural**: it compares keys, types, lengths, and presence (empt
 | `type_mismatch` | Different types at the same path (e.g. string vs number) |
 | `presence_mismatch` | One value “empty” and the other not (e.g. `''` vs `'x'`, `null` vs object) |
 
-When there are diffs, the warning log includes the first differences and a **summary** by category (`legacy_has_more`, `new_has_more`, `both_different`). When there are no diffs, an **info** log is emitted to indicate a successful structural match.
+When there are diffs, the error log includes the first differences and a **summary** by category (`legacy_has_more`, `new_has_more`, `both_different`). When there are no diffs, an **info** log is emitted to indicate a successful structural match.
 
 **Limits**: The comparison caps tree depth and the number of elements compared in each array (see constants in `structuralCompare.ts`) to avoid excessive cost.

--- a/node/shadow/README.md
+++ b/node/shadow/README.md
@@ -1,0 +1,42 @@
+# Shadow migration
+
+Pasta com a lógica de **shadow compare**: rodar em paralelo duas fontes de dados (ex.: API legada vs nova) e comparar o resultado de forma estrutural para validar migrações sem mudar o comportamento em produção.
+
+## Fluxo
+
+1. **Execute**: o consumidor chama `ShadowMigration.execute(legacy, next, ctx)`.
+2. **Feature flags** (FeatureHub) definem:
+   - `migrationComplete`: se `true`, só a fonte nova é usada e seu resultado é retornado.
+   - `shadow`: se `true`, as duas fontes são chamadas; o resultado retornado depende de `returnNew`.
+   - `returnNew`: em modo shadow, define se a resposta ao cliente vem da fonte nova (`true`) ou legada (`false`).
+3. **Comparação**: em background, os dois payloads são normalizados e passam por um diff estrutural. Diferenças são logadas como warning.
+
+## Arquivos principais
+
+| Arquivo | Responsabilidade |
+|--------|-------------------|
+| **ShadowMigration.ts** | Orquestra a execução (legacy/next), avalia flags e agenda a comparação. |
+| **structuralCompare.ts** | Diff estrutural entre dois valores: chaves, tipos, tamanhos de array, presença (não compara valores literais). |
+| **normalizers/** | Funções que projetam o payload de cada fonte para um shape comparável (ex.: alinhado à tipagem `SearchProduct[]`). |
+
+## Normalizer de product
+
+O normalizer de product **não** executa resolvers. Uma única função garante que ambos os payloads (legacy e new) são projetados para o **mesmo shape**, alinhado à tipagem `SearchProduct[]`: mesmo conjunto de chaves (com defaults para ausentes), para que o diff estrutural reflita apenas as diferenças relevantes. O `structuralCompare` continua a reportar os tipos de diferença documentados abaixo (missing_key, extra_key, array_length_mismatch, type_mismatch, presence_mismatch).
+
+## Como adicionar outra migração shadow
+
+1. Criar um normalizer em `normalizers/` que receba o payload e retorne um shape comparável (sync ou async), por exemplo projetando para uma tipagem comum (como no product: `SearchProduct[]`).
+2. Instanciar `ShadowMigration` com:
+   - `normalize`: sua função de normalização
+   - `name`: identificador da migração (entra nos logs)
+   - `flags`: nomes das flags no FeatureHub (`migrationComplete`, `shadow`, `returnNew`)
+3. No serviço, chamar `migration.execute(legacyFn, newFn, ctx)` e usar `result.result` e `result.source`.
+
+## Tipos de diferença (structuralCompare)
+
+- `missing_key` / `extra_key`: chave presente só em um dos lados
+- `array_length_mismatch`: arrays com tamanhos diferentes
+- `type_mismatch`: tipos diferentes no mesmo caminho
+- `presence_mismatch`: um valor “vazio” e outro não (ex.: `''` vs `'x'`)
+
+A comparação limita profundidade e quantidade de elementos em arrays para evitar custo excessivo.

--- a/node/shadow/README.md
+++ b/node/shadow/README.md
@@ -1,42 +1,100 @@
 # Shadow migration
 
-Pasta com a lógica de **shadow compare**: rodar em paralelo duas fontes de dados (ex.: API legada vs nova) e comparar o resultado de forma estrutural para validar migrações sem mudar o comportamento em produção.
+This folder contains the **shadow compare** logic: run two data sources in parallel (e.g. legacy API vs new API) and compare the results structurally to validate migrations without changing production behavior.
 
-## Fluxo
+## Flow
 
-1. **Execute**: o consumidor chama `ShadowMigration.execute(legacy, next, ctx)`.
-2. **Feature flags** (FeatureHub) definem:
-   - `migrationComplete`: se `true`, só a fonte nova é usada e seu resultado é retornado.
-   - `shadow`: se `true`, as duas fontes são chamadas; o resultado retornado depende de `returnNew`.
-   - `returnNew`: em modo shadow, define se a resposta ao cliente vem da fonte nova (`true`) ou legada (`false`).
-3. **Comparação**: em background, os dois payloads são normalizados e passam por um diff estrutural. Diferenças são logadas como warning.
+The consumer calls `ShadowMigration.execute(legacyFn, nextFn, ctx)`, where:
 
-## Arquivos principais
+- **`legacyFn`** and **`nextFn`** are functions that return `Promise<T>` (e.g. calls to the legacy and new APIs). `execute` invokes them according to the feature flags.
+- **`ctx`** is the request context (with `ctx.vtex.account` and `ctx.vtex.logger` for logging).
 
-| Arquivo | Responsabilidade |
-|--------|-------------------|
-| **ShadowMigration.ts** | Orquestra a execução (legacy/next), avalia flags e agenda a comparação. |
-| **structuralCompare.ts** | Diff estrutural entre dois valores: chaves, tipos, tamanhos de array, presença (não compara valores literais). |
-| **normalizers/** | Funções que projetam o payload de cada fonte para um shape comparável (ex.: alinhado à tipagem `SearchProduct[]`). |
+**Feature flags** (FeatureHub) control the behavior. If evaluating the flags fails (e.g. FeatureHub unavailable), the fallback is to use **only the legacy source**.
 
-## Normalizer de product
+| Flag | Effect |
+|------|--------|
+| `migrationComplete` | If `true`, only the new source is used and its result is returned. |
+| `shadow` | If `true`, both sources are called in parallel; the returned result depends on `returnNew`. |
+| `returnNew` | In shadow mode, controls whether the response to the client comes from the new source (`true`) or legacy (`false`). |
 
-O normalizer de product **não** executa resolvers. Uma única função garante que ambos os payloads (legacy e new) são projetados para o **mesmo shape**, alinhado à tipagem `SearchProduct[]`: mesmo conjunto de chaves (com defaults para ausentes), para que o diff estrutural reflita apenas as diferenças relevantes. O `structuralCompare` continua a reportar os tipos de diferença documentados abaixo (missing_key, extra_key, array_length_mismatch, type_mismatch, presence_mismatch).
+In **shadow** mode, the comparison runs in the background: both payloads are normalized and go through a structural diff. **Logging**:
+- **No diffs**: `logger.info` with a message indicating no structural differences.
+- **Diffs found**: `logger.warn` with the diff count, summary, and the first differences.
 
-## Como adicionar outra migração shadow
+### Diagram: flag-based decision
 
-1. Criar um normalizer em `normalizers/` que receba o payload e retorne um shape comparável (sync ou async), por exemplo projetando para uma tipagem comum (como no product: `SearchProduct[]`).
-2. Instanciar `ShadowMigration` com:
-   - `normalize`: sua função de normalização
-   - `name`: identificador da migração (entra nos logs)
-   - `flags`: nomes das flags no FeatureHub (`migrationComplete`, `shadow`, `returnNew`)
-3. No serviço, chamar `migration.execute(legacyFn, newFn, ctx)` e usar `result.result` e `result.source`.
+```mermaid
+flowchart TD
+  Start([execute legacyFn, nextFn, ctx]) --> Eval[Evaluate flags in FeatureHub]
+  Eval --> Fallback{Failure?}
+  Fallback -->|Yes| LegacyOnly[Use legacy only]
+  Fallback -->|No| Complete{migrationComplete?}
+  Complete -->|Yes| NewOnly[Call nextFn → return new result]
+  Complete -->|No| Shadow{shadow?}
+  Shadow -->|No| LegacyOnly
+  Shadow -->|Yes| Parallel[Call legacyFn and nextFn in parallel]
+  Parallel --> Compare[Background: normalize + structuralCompare + log]
+  Compare --> ReturnNew{returnNew?}
+  ReturnNew -->|Yes| ReturnNewResult[Return result from new source]
+  ReturnNew -->|No| ReturnLegacyResult[Return result from legacy source]
+```
 
-## Tipos de diferença (structuralCompare)
+### Diagram: comparison pipeline (shadow mode)
 
-- `missing_key` / `extra_key`: chave presente só em um dos lados
-- `array_length_mismatch`: arrays com tamanhos diferentes
-- `type_mismatch`: tipos diferentes no mesmo caminho
-- `presence_mismatch`: um valor “vazio” e outro não (ex.: `''` vs `'x'`)
+```mermaid
+flowchart LR
+  subgraph inputs [Payloads]
+    L[legacy result]
+    N[new result]
+  end
+  subgraph background [Background]
+    NormL[normalize]
+    NormN[normalize]
+    Diff[structuralCompare]
+    Log[diffs > 0: logger.warn / else: logger.info]
+  end
+  L --> NormL
+  N --> NormN
+  NormL --> Diff
+  NormN --> Diff
+  Diff --> Log
+```
 
-A comparação limita profundidade e quantidade de elementos em arrays para evitar custo excessivo.
+## Main files
+
+| File | Responsibility |
+|------|----------------|
+| **ShadowMigration.ts** | Orchestrates execution (legacy/next), evaluates flags, and schedules the comparison. |
+| **structuralCompare.ts** | Structural diff between two values: keys, types, array lengths, presence (does not compare literal values). |
+| **normalizers/** | Functions that project each source’s payload to a comparable shape (e.g. aligned to `SearchProduct[]`). |
+
+## Product normalizer
+
+The product normalizer **does not** run resolvers. A single function ensures both payloads (legacy and new) are projected to the **same shape** aligned to the `SearchProduct[]` type: same set of keys (with defaults for missing ones), so the structural diff reflects only relevant differences. `structuralCompare` reports the difference types documented below (missing_key, extra_key, array_length_mismatch, type_mismatch, presence_mismatch).
+
+## Adding another shadow migration
+
+1. Create a **normalizer** in `normalizers/` that takes the payload and returns a comparable shape. The function must be **synchronous** (`(data: T) => unknown`), e.g. projecting to a common type (like `SearchProduct[]` for product).
+2. Instantiate `ShadowMigration` with:
+   - **`normalize`**: your normalization function (synchronous)
+   - **`name`**: migration identifier (used in logs)
+   - **`flags`**: object with the FeatureHub flag names: `{ migrationComplete, shadow, returnNew }`
+3. In the service, call `migration.execute(legacyFn, newFn, ctx)`. The return type is `ExecuteResult<T>`:
+   - **`result`**: the payload returned to the client
+   - **`source`**: `'legacy'` or `'new'`, indicating which source was used
+
+## Difference types (structuralCompare)
+
+The diff is **structural**: it compares keys, types, lengths, and presence (empty vs non-empty), **not** literal values.
+
+| Type | Description |
+|------|-------------|
+| `missing_key` | Key present only in the legacy payload |
+| `extra_key` | Key present only in the new payload |
+| `array_length_mismatch` | Arrays with different lengths at the same path |
+| `type_mismatch` | Different types at the same path (e.g. string vs number) |
+| `presence_mismatch` | One value “empty” and the other not (e.g. `''` vs `'x'`, `null` vs object) |
+
+When there are diffs, the warning log includes the first differences and a **summary** by category (`legacy_has_more`, `new_has_more`, `both_different`). When there are no diffs, an **info** log is emitted to indicate a successful structural match.
+
+**Limits**: The comparison caps tree depth and the number of elements compared in each array (see constants in `structuralCompare.ts`) to avoid excessive cost.

--- a/node/shadow/ShadowMigration.test.ts
+++ b/node/shadow/ShadowMigration.test.ts
@@ -129,7 +129,7 @@ describe('ShadowMigration', () => {
       setImmediate(() => resolve())
     })
 
-    expect(ctx.vtex.logger.warn).toHaveBeenCalledWith(
+    expect(ctx.vtex.logger.error).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'ShadowMigration diff-test structural differences',
         name: 'diff-test',
@@ -168,7 +168,7 @@ describe('ShadowMigration', () => {
       setImmediate(() => resolve())
     })
 
-    expect(ctx.vtex.logger.warn).toHaveBeenCalledWith(
+    expect(ctx.vtex.logger.error).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'ShadowMigration throw-test compare failed',
         name: 'throw-test',

--- a/node/shadow/ShadowMigration.test.ts
+++ b/node/shadow/ShadowMigration.test.ts
@@ -1,0 +1,183 @@
+import { ShadowMigration } from './ShadowMigration'
+
+jest.mock('../services/featurehub', () => ({
+  evaluateBooleanFlag: jest.fn(),
+}))
+
+const { evaluateBooleanFlag } = jest.requireMock('../services/featurehub')
+const mockEvaluateBooleanFlag = evaluateBooleanFlag as jest.Mock
+
+function createCtx(account = 'test') {
+  return {
+    vtex: {
+      account,
+      logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+    },
+  } as unknown as Context
+}
+
+describe('ShadowMigration', () => {
+  const migration = new ShadowMigration<number>({
+    name: 'test',
+    normalize: (x) => x,
+    flags: {
+      migrationComplete: 'complete',
+      shadow: 'shadow',
+      returnNew: 'returnNew',
+    },
+  })
+
+  const legacy = jest.fn().mockResolvedValue(1)
+  const next = jest.fn().mockResolvedValue(2)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEvaluateBooleanFlag.mockImplementation(() =>
+      Promise.resolve({
+        value: false,
+        flagFound: true,
+      })
+    )
+  })
+
+  it('when migrationComplete=true calls only next() and returns new', async () => {
+    mockEvaluateBooleanFlag
+      .mockResolvedValueOnce({ value: true, flagFound: true })
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+
+    const ctx = createCtx()
+    const { result, source } = await migration.execute(legacy, next, ctx)
+
+    expect(result).toBe(2)
+    expect(source).toBe('new')
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(legacy).not.toHaveBeenCalled()
+  })
+
+  it('when shadow=false calls only legacy() and returns legacy', async () => {
+    const ctx = createCtx()
+    const { result, source } = await migration.execute(legacy, next, ctx)
+
+    expect(result).toBe(1)
+    expect(source).toBe('legacy')
+    expect(legacy).toHaveBeenCalledTimes(1)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('when shadow=true returnNew=false calls both, returns legacy', async () => {
+    mockEvaluateBooleanFlag
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+      .mockResolvedValueOnce({ value: true, flagFound: true })
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+
+    const ctx = createCtx()
+    const { result, source } = await migration.execute(legacy, next, ctx)
+
+    expect(result).toBe(1)
+    expect(source).toBe('legacy')
+    expect(legacy).toHaveBeenCalledTimes(1)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('when shadow=true returnNew=true calls both, returns new', async () => {
+    mockEvaluateBooleanFlag
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+      .mockResolvedValueOnce({ value: true, flagFound: true })
+      .mockResolvedValueOnce({ value: true, flagFound: true })
+
+    const ctx = createCtx()
+    const { result, source } = await migration.execute(legacy, next, ctx)
+
+    expect(result).toBe(2)
+    expect(source).toBe('new')
+    expect(legacy).toHaveBeenCalledTimes(1)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('on flag evaluation error falls back to legacy only', async () => {
+    mockEvaluateBooleanFlag.mockRejectedValue(new Error('fh down'))
+
+    const ctx = createCtx()
+    const { result, source } = await migration.execute(legacy, next, ctx)
+
+    expect(result).toBe(1)
+    expect(source).toBe('legacy')
+    expect(legacy).toHaveBeenCalledTimes(1)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('when shadow=true logs structural differences when legacy and new differ', async () => {
+    mockEvaluateBooleanFlag
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+      .mockResolvedValueOnce({ value: true, flagFound: true })
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+
+    const legacyFn = jest.fn().mockResolvedValue({ a: 1, b: 2 })
+    const nextFn = jest.fn().mockResolvedValue({ a: 1 })
+
+    const migrationWithNormalize = new ShadowMigration<Record<string, number>>({
+      name: 'diff-test',
+      normalize: (x) => x,
+      flags: {
+        migrationComplete: 'complete',
+        shadow: 'shadow',
+        returnNew: 'returnNew',
+      },
+    })
+
+    const ctx = createCtx()
+
+    await migrationWithNormalize.execute(legacyFn, nextFn, ctx)
+    await new Promise<void>((resolve) => {
+      setImmediate(() => resolve())
+    })
+
+    expect(ctx.vtex.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'ShadowMigration diff-test structural differences',
+        name: 'diff-test',
+        diffCount: 1,
+        diffSummary: expect.any(Array),
+        differences: expect.any(Array),
+      })
+    )
+  })
+
+  it('when shadow=true logs compare failed when normalize throws', async () => {
+    mockEvaluateBooleanFlag
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+      .mockResolvedValueOnce({ value: true, flagFound: true })
+      .mockResolvedValueOnce({ value: false, flagFound: true })
+
+    const legacyFn = jest.fn().mockResolvedValue(1)
+    const nextFn = jest.fn().mockResolvedValue(2)
+
+    const migrationThrowing = new ShadowMigration<number>({
+      name: 'throw-test',
+      normalize: () => {
+        throw new Error('normalize boom')
+      },
+      flags: {
+        migrationComplete: 'complete',
+        shadow: 'shadow',
+        returnNew: 'returnNew',
+      },
+    })
+
+    const ctx = createCtx()
+
+    await migrationThrowing.execute(legacyFn, nextFn, ctx)
+    await new Promise<void>((resolve) => {
+      setImmediate(() => resolve())
+    })
+
+    expect(ctx.vtex.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'ShadowMigration throw-test compare failed',
+        name: 'throw-test',
+        error: 'normalize boom',
+      })
+    )
+  })
+})

--- a/node/shadow/ShadowMigration.ts
+++ b/node/shadow/ShadowMigration.ts
@@ -86,6 +86,11 @@ export class ShadowMigration<T> {
             diffSummary: summary,
             differences: diffs.slice(0, 20),
           })
+        } else {
+          ctx.vtex?.logger?.info?.({
+            message: `ShadowMigration ${this.config.name} no structural differences`,
+            name: this.config.name,
+          })
         }
       })
       .catch((err) => {

--- a/node/shadow/ShadowMigration.ts
+++ b/node/shadow/ShadowMigration.ts
@@ -79,7 +79,7 @@ export class ShadowMigration<T> {
         const { diffs, summary } = structuralCompare(normLegacy, normNew)
 
         if (diffs.length > 0) {
-          ctx.vtex?.logger?.warn?.({
+          ctx.vtex?.logger?.error?.({
             message: `ShadowMigration ${this.config.name} structural differences`,
             name: this.config.name,
             diffCount: diffs.length,
@@ -94,7 +94,7 @@ export class ShadowMigration<T> {
         }
       })
       .catch((err) => {
-        ctx.vtex?.logger?.warn?.({
+        ctx.vtex?.logger?.error?.({
           message: `ShadowMigration ${this.config.name} compare failed`,
           name: this.config.name,
           error: err instanceof Error ? err.message : String(err),

--- a/node/shadow/ShadowMigration.ts
+++ b/node/shadow/ShadowMigration.ts
@@ -1,0 +1,100 @@
+import { evaluateBooleanFlag } from '../services/featurehub'
+import { structuralCompare } from './structuralCompare'
+
+export interface ShadowMigrationConfig<T> {
+  /** Synchronous; projects data to a comparable shape for structural diff. */
+  normalize: (data: T) => unknown
+  name: string
+  flags: {
+    migrationComplete: string
+    shadow: string
+    returnNew: string
+  }
+}
+
+export interface ExecuteResult<T> {
+  result: T
+  source: 'legacy' | 'new'
+}
+
+export class ShadowMigration<T> {
+  constructor(private config: ShadowMigrationConfig<T>) {}
+
+  public async execute(
+    legacy: () => Promise<T>,
+    next: () => Promise<T>,
+    ctx: Context
+  ): Promise<ExecuteResult<T>> {
+    const account = ctx.vtex?.account ?? ''
+
+    let migrationComplete = false
+    let shadow = false
+    let returnNew = false
+
+    try {
+      const [migrationCompleteRes, shadowRes, returnNewRes] = await Promise.all(
+        [
+          evaluateBooleanFlag(this.config.flags.migrationComplete, false, {
+            account,
+          }),
+          evaluateBooleanFlag(this.config.flags.shadow, false, { account }),
+          evaluateBooleanFlag(this.config.flags.returnNew, false, { account }),
+        ]
+      )
+
+      migrationComplete = migrationCompleteRes.value
+      shadow = shadowRes.value
+      returnNew = returnNewRes.value
+    } catch {
+      // Fallback: all false -> legacy only
+    }
+
+    if (migrationComplete) {
+      const result = await next()
+
+      return { result, source: 'new' }
+    }
+
+    if (!shadow) {
+      const result = await legacy()
+
+      return { result, source: 'legacy' }
+    }
+
+    const [legacyResult, newResult] = await Promise.all([legacy(), next()])
+
+    this.scheduleCompare(legacyResult, newResult, ctx)
+
+    if (returnNew) {
+      return { result: newResult, source: 'new' }
+    }
+
+    return { result: legacyResult, source: 'legacy' }
+  }
+
+  private scheduleCompare(legacyData: T, newData: T, ctx: Context): void {
+    Promise.resolve()
+      .then(() => {
+        const normLegacy = this.config.normalize(legacyData)
+        const normNew = this.config.normalize(newData)
+        const { diffs, summary } = structuralCompare(normLegacy, normNew)
+
+        if (diffs.length > 0) {
+          ctx.vtex?.logger?.warn?.({
+            message: `ShadowMigration ${this.config.name} structural differences`,
+            name: this.config.name,
+            diffCount: diffs.length,
+            diffSummary: summary,
+            differences: diffs.slice(0, 20),
+          })
+        }
+      })
+      .catch((err) => {
+        ctx.vtex?.logger?.warn?.({
+          message: `ShadowMigration ${this.config.name} compare failed`,
+          name: this.config.name,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+  }
+}

--- a/node/shadow/normalizers/product.test.ts
+++ b/node/shadow/normalizers/product.test.ts
@@ -1,0 +1,117 @@
+import { normalizeProduct } from './product'
+
+describe('normalizeProduct', () => {
+  it('returns _type non-array for non-array input', () => {
+    expect(normalizeProduct(null as unknown as SearchProduct[])).toEqual({
+      _type: 'non-array',
+    })
+  })
+
+  it('returns empty array for empty input array', () => {
+    const out = normalizeProduct([] as SearchProduct[]) as unknown[]
+
+    expect(out).toEqual([])
+  })
+
+  it('returns array of objects with exactly SearchProduct keys', () => {
+    const products = [
+      {
+        productId: 'p1',
+        linkText: 'link',
+        productName: 'Product 1',
+        items: [],
+      },
+    ] as unknown as SearchProduct[]
+
+    const out = normalizeProduct(products) as Array<Record<string, unknown>>
+
+    expect(out).toHaveLength(1)
+    const keys = Object.keys(out[0]).sort((a, b) => a.localeCompare(b))
+
+    expect(keys).toEqual(
+      [
+        'origin',
+        'productId',
+        'productName',
+        'brand',
+        'brandId',
+        'linkText',
+        'productReference',
+        'categoryId',
+        'productTitle',
+        'metaTagDescription',
+        'clusterHighlights',
+        'productClusters',
+        'searchableClusters',
+        'categories',
+        'categoriesIds',
+        'link',
+        'description',
+        'items',
+        'itemMetadata',
+        'titleTag',
+        'Specifications',
+        'allSpecifications',
+        'allSpecificationsGroups',
+        'completeSpecifications',
+        'skuSpecifications',
+        'specificationGroups',
+        'properties',
+      ].sort((a, b) => a.localeCompare(b))
+    )
+    expect(out[0].productId).toBe('p1')
+    expect(out[0].linkText).toBe('link')
+    expect(out[0].productName).toBe('Product 1')
+    expect(out[0].items).toEqual([])
+    expect(out[0].origin).toBeUndefined()
+    expect(out[0].brand).toBe('')
+    expect(out[0].itemMetadata).toEqual({ items: [] })
+  })
+
+  it('copies existing values and uses defaults for missing keys', () => {
+    const products = [
+      {
+        productId: 'p99',
+        categories: ['cat1'],
+        clusterHighlights: { h: 'x' },
+        extraKey: 'ignored',
+      },
+    ] as unknown as SearchProduct[]
+
+    const out = normalizeProduct(products) as Array<Record<string, unknown>>
+
+    expect(out[0].productId).toBe('p99')
+    expect(out[0].categories).toEqual(['cat1'])
+    expect(out[0].clusterHighlights).toEqual({ h: 'x' })
+    expect(out[0]).not.toHaveProperty('extraKey')
+    expect(out[0].link).toBe('')
+    expect(out[0].categoriesIds).toEqual([])
+  })
+
+  it('two payloads with different key sets get same keys after normalization', () => {
+    const legacy = [
+      { productId: 'a', linkText: 'a-link' },
+    ] as unknown as SearchProduct[]
+
+    const newPayload = [
+      { productId: 'a', linkText: 'a-link', onlyInNew: true },
+    ] as unknown as SearchProduct[]
+
+    const normLegacy = normalizeProduct(legacy) as Array<
+      Record<string, unknown>
+    >
+
+    const normNew = normalizeProduct(newPayload) as Array<
+      Record<string, unknown>
+    >
+
+    const keysLegacy = Object.keys(normLegacy[0]).sort((a, b) =>
+      a.localeCompare(b)
+    )
+
+    const keysNew = Object.keys(normNew[0]).sort((a, b) => a.localeCompare(b))
+
+    expect(keysLegacy).toEqual(keysNew)
+    expect(normNew[0]).not.toHaveProperty('onlyInNew')
+  })
+})

--- a/node/shadow/normalizers/product.ts
+++ b/node/shadow/normalizers/product.ts
@@ -1,0 +1,103 @@
+/**
+ * Normalizes SearchProduct[] to a canonical shape aligned to the SearchProduct type.
+ * Ensures both legacy and new payloads have the same set of keys (with defaults for
+ * missing ones) so structuralCompare only reports meaningful diffs: missing_key,
+ * extra_key, array_length_mismatch, type_mismatch, presence_mismatch.
+ * Does not run resolvers.
+ */
+
+const SEARCH_PRODUCT_KEYS = [
+  'origin',
+  'productId',
+  'productName',
+  'brand',
+  'brandId',
+  'linkText',
+  'productReference',
+  'categoryId',
+  'productTitle',
+  'metaTagDescription',
+  'clusterHighlights',
+  'productClusters',
+  'searchableClusters',
+  'categories',
+  'categoriesIds',
+  'link',
+  'description',
+  'items',
+  'itemMetadata',
+  'titleTag',
+  'Specifications',
+  'allSpecifications',
+  'allSpecificationsGroups',
+  'completeSpecifications',
+  'skuSpecifications',
+  'specificationGroups',
+  'properties',
+] as const
+
+const DEFAULT_BY_KEY: Record<string, unknown> = {
+  origin: undefined,
+  brandId: undefined,
+  clusterHighlights: {},
+  productClusters: {},
+  searchableClusters: {},
+  categories: [],
+  categoriesIds: [],
+  Specifications: [],
+  allSpecifications: [],
+  allSpecificationsGroups: [],
+  items: [],
+  completeSpecifications: [],
+  skuSpecifications: [],
+  specificationGroups: [],
+  properties: [],
+  itemMetadata: { items: [] },
+  productId: '',
+  productName: '',
+  brand: '',
+  linkText: '',
+  productReference: '',
+  categoryId: '',
+  productTitle: '',
+  metaTagDescription: '',
+  link: '',
+  description: '',
+  titleTag: '',
+}
+
+function defaultForKey(key: string): unknown {
+  return key in DEFAULT_BY_KEY ? DEFAULT_BY_KEY[key] : undefined
+}
+
+/**
+ * Projects a single product-like object to the canonical SearchProduct shape:
+ * exactly the keys of SearchProduct, with values from the payload or defaults.
+ */
+function projectToSearchProductShape(
+  item: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+
+  for (const key of SEARCH_PRODUCT_KEYS) {
+    out[key] = item[key] !== undefined ? item[key] : defaultForKey(key)
+  }
+
+  return out
+}
+
+/**
+ * Ensures the payload is normalized to a comparable SearchProduct[] shape.
+ * Both legacy and new responses should be passed through this so structuralCompare
+ * sees the same key set and only reports the four diff types (missing_key, extra_key,
+ * array_length_mismatch, type_mismatch, presence_mismatch).
+ */
+export function normalizeProduct(products: SearchProduct[]): unknown {
+  if (!Array.isArray(products)) {
+    return { _type: 'non-array' }
+  }
+
+  return products.map((p) =>
+    projectToSearchProductShape(p as unknown as Record<string, unknown>)
+  )
+}

--- a/node/shadow/structuralCompare.test.ts
+++ b/node/shadow/structuralCompare.test.ts
@@ -1,0 +1,214 @@
+import { structuralCompare } from './structuralCompare'
+
+describe('structuralCompare', () => {
+  it('returns no diffs for equal structure (same keys, same array lengths)', () => {
+    const a = { x: 1, arr: [1, 2] }
+    const b = { x: 99, arr: [3, 4] }
+    const result = structuralCompare(a, b)
+
+    expect(result.diffs).toEqual([])
+    expect(result.summary).toEqual([])
+  })
+
+  it('reports missing_key when legacy has key new does not (new has less)', () => {
+    const a = { a: 1, b: 2 }
+    const b = { a: 1 }
+    const { diffs } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(1)
+    expect(diffs[0].type).toBe('missing_key')
+    expect(diffs[0].path).toBe('b')
+    expect(diffs[0].valueA).toBe(2)
+    expect(diffs[0].valueB).toBeUndefined()
+    expect(structuralCompare(a, b).summary).toEqual(['legacy_has_more'])
+  })
+
+  it('reports extra_key when new has key legacy does not (new has more)', () => {
+    const a = { a: 1 }
+    const b = { a: 1, b: 2 }
+    const { diffs } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(1)
+    expect(diffs[0].type).toBe('extra_key')
+    expect(diffs[0].path).toBe('b')
+    expect(diffs[0].valueA).toBeUndefined()
+    expect(diffs[0].valueB).toBe(2)
+    expect(structuralCompare(a, b).summary).toEqual(['new_has_more'])
+  })
+
+  it('reports array_length_mismatch with valueA/valueB as lengths', () => {
+    const a = { arr: [1, 2] }
+    const b = { arr: [1] }
+    const { diffs, summary } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(1)
+    expect(diffs[0].type).toBe('array_length_mismatch')
+    expect(diffs[0].valueA).toBe(2)
+    expect(diffs[0].valueB).toBe(1)
+    expect(summary).toEqual(['both_different'])
+  })
+
+  it('reports type_mismatch with valueA and valueB', () => {
+    const a = { x: 'str' }
+    const b = { x: 123 }
+    const { diffs } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(1)
+    expect(diffs[0].type).toBe('type_mismatch')
+    expect(diffs[0].valueA).toBe('str')
+    expect(diffs[0].valueB).toBe(123)
+  })
+
+  it('reports presence_mismatch with valueA and valueB', () => {
+    const a = { x: '' }
+    const b = { x: 'hello' }
+    const { diffs } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(1)
+    expect(diffs[0].type).toBe('presence_mismatch')
+    expect(diffs[0].valueA).toBe('')
+    expect(diffs[0].valueB).toBe('hello')
+  })
+
+  it('stops at depth limit', () => {
+    let a: unknown = 1
+    let b: unknown = 1
+
+    for (let i = 0; i < 12; i++) {
+      a = { v: a }
+      b = { v: b }
+    }
+
+    const { diffs } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(0)
+  })
+
+  it('compares at most 10 elements per array (does not recurse past index 9)', () => {
+    const a = Array.from({ length: 15 }, (_, i) =>
+      i === 12 ? { x: [1, 2] } : { x: [1] }
+    )
+
+    const b = Array.from({ length: 15 }, (_, i) =>
+      i === 12 ? { x: [1] } : { x: [1] }
+    )
+
+    const { diffs } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(0)
+  })
+
+  it('reports diffs only within first 10 array elements', () => {
+    const a = Array.from({ length: 20 }, (_, i) => ({
+      v: i === 3 ? [1, 2] : [1],
+    }))
+
+    const b = Array.from({ length: 20 }, (_, i) => ({
+      v: i === 3 ? [1] : [1],
+    }))
+
+    const { diffs } = structuralCompare(a, b)
+
+    expect(diffs).toHaveLength(1)
+    expect(diffs[0].type).toBe('array_length_mismatch')
+    expect(diffs[0].path).toBe('[3].v')
+  })
+
+  it('reports array_length_mismatch for product-like arrays when properties[].values length differs', () => {
+    const legacy = [
+      {
+        productId: '2',
+        linkText: 'camisa-masculina',
+        cacheId: 'camisa-masculina',
+        clusterHighlights: [],
+        productClusters: [
+          { id: '138', name: 'all' },
+          { id: '139', name: 'Testezada' },
+          { id: '1139', name: 'camisas' },
+          { id: '1141', name: 'Teste Agendado' },
+          { id: '1142', name: 'Teste Alê' },
+        ],
+        properties: [
+          { name: 'Material', values: [] },
+          { name: 'Fabric', values: [] },
+        ],
+        itemMetadataPresent: false,
+        itemsLength: 2,
+        items: [
+          {
+            itemId: '2',
+            name: 'Green',
+            sellersLength: 1,
+            skuSpecifications: [],
+          },
+          {
+            itemId: '33',
+            name: 'Red',
+            sellersLength: 1,
+            skuSpecifications: [],
+          },
+        ],
+      },
+    ]
+
+    const shadow = [
+      {
+        productId: '2',
+        linkText: 'classic-blue-tshirt',
+        cacheId: 'sp-2',
+        clusterHighlights: [],
+        productClusters: [
+          { id: '138', name: 'all' },
+          { id: '139', name: 'Testezada' },
+          { id: '1139', name: 'Summer Collection 2024' },
+          { id: '1141', name: 'Teste Agendado' },
+          { id: '1142', name: 'Teste Alê' },
+        ],
+        properties: [
+          { name: 'Material', values: ['soft'] },
+          { name: 'Fabric', values: ['Fabric'] },
+        ],
+        itemMetadataPresent: false,
+        itemsLength: 2,
+        items: [
+          {
+            itemId: '2',
+            name: 'Green',
+            sellersLength: 1,
+            skuSpecifications: [],
+          },
+          {
+            itemId: '33',
+            name: "Men's Red T-Shirt",
+            sellersLength: 1,
+            skuSpecifications: [],
+          },
+        ],
+      },
+    ]
+
+    const { diffs, summary } = structuralCompare(legacy, shadow)
+
+    expect(diffs).toHaveLength(2)
+    expect(diffs.every((d) => d.type === 'array_length_mismatch')).toBe(true)
+    expect(diffs.map((d) => d.path).sort((x, y) => x.localeCompare(y))).toEqual(
+      ['[0].properties[0].values', '[0].properties[1].values'].sort((x, y) =>
+        x.localeCompare(y)
+      )
+    )
+    expect(diffs.every((d) => d.valueA === 0 && d.valueB === 1)).toBe(true)
+    expect(summary).toEqual(['both_different'])
+  })
+
+  it('summary contains all categories when diffs are mixed', () => {
+    const legacy = { a: 1, b: 2, c: [1, 2] }
+    const newObj = { a: 1, x: 99, c: [1] }
+    const { diffs, summary } = structuralCompare(legacy, newObj)
+
+    expect(diffs.length).toBeGreaterThanOrEqual(2)
+    expect(summary).toContain('legacy_has_more')
+    expect(summary).toContain('new_has_more')
+    expect(summary).toContain('both_different')
+    expect(summary).toHaveLength(3)
+  })
+})

--- a/node/shadow/structuralCompare.ts
+++ b/node/shadow/structuralCompare.ts
@@ -1,0 +1,184 @@
+const MAX_DEPTH = 10
+const MAX_ARRAY_ELEMENTS = 10
+
+export type DiffCategory = 'legacy_has_more' | 'new_has_more' | 'both_different'
+
+export interface StructuralDifference {
+  path: string
+  type:
+    | 'missing_key'
+    | 'extra_key'
+    | 'array_length_mismatch'
+    | 'presence_mismatch'
+    | 'type_mismatch'
+  valueA?: unknown
+  valueB?: unknown
+}
+
+export interface StructuralCompareResult {
+  diffs: StructuralDifference[]
+  summary: DiffCategory[]
+}
+
+function typeToCategory(type: StructuralDifference['type']): DiffCategory {
+  if (type === 'extra_key') return 'new_has_more'
+
+  if (type === 'missing_key') return 'legacy_has_more'
+
+  return 'both_different'
+}
+
+function isEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) return true
+
+  if (typeof value === 'string' && value === '') return true
+
+  if (Array.isArray(value) && value.length === 0) return true
+
+  return false
+}
+
+function getKeys(value: unknown): string[] {
+  if (value === null || value === undefined) return []
+
+  if (typeof value !== 'object') return []
+
+  return Object.keys(value as object)
+}
+
+interface CompareRecParams {
+  a: unknown
+  b: unknown
+  path: string
+  currentDepth: number
+}
+
+function compareRec(params: CompareRecParams): StructuralDifference[] {
+  const { a, b, path, currentDepth } = params
+  const diffs: StructuralDifference[] = []
+
+  if (currentDepth > MAX_DEPTH) {
+    return diffs
+  }
+
+  const typeA = Array.isArray(a) ? 'array' : typeof a
+  const typeB = Array.isArray(b) ? 'array' : typeof b
+
+  if (typeA !== typeB) {
+    diffs.push({
+      path: path || '(root)',
+      type: 'type_mismatch',
+      valueA: a,
+      valueB: b,
+    })
+
+    return diffs
+  }
+
+  if (typeof a !== 'object' || a === null) {
+    const emptyA = isEmpty(a)
+    const emptyB = isEmpty(b)
+
+    if (emptyA !== emptyB) {
+      diffs.push({
+        path: path || '(root)',
+        type: 'presence_mismatch',
+        valueA: a,
+        valueB: b,
+      })
+    }
+
+    return diffs
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      diffs.push({
+        path: path || '(root)',
+        type: 'array_length_mismatch',
+        valueA: a.length,
+        valueB: b.length,
+      })
+
+      return diffs
+    }
+
+    const arrPath = path || '(root)'
+    const elementsToCompare = Math.min(a.length, MAX_ARRAY_ELEMENTS)
+
+    for (let i = 0; i < elementsToCompare; i++) {
+      const elPath = arrPath === '(root)' ? `[${i}]` : `${arrPath}[${i}]`
+
+      diffs.push(
+        ...compareRec({
+          a: (a as unknown[])[i],
+          b: (b as unknown[])[i],
+          path: elPath,
+          currentDepth: currentDepth + 1,
+        })
+      )
+    }
+
+    return diffs
+  }
+
+  const keysA = getKeys(a) as string[]
+  const keysB = getKeys(b) as string[]
+  const setB = new Set(keysB)
+
+  for (const key of keysA) {
+    const keyPath = path ? `${path}.${key}` : key
+
+    if (!setB.has(key)) {
+      diffs.push({
+        path: keyPath,
+        type: 'missing_key',
+        valueA: (a as Record<string, unknown>)[key],
+        valueB: undefined,
+      })
+
+      continue
+    }
+
+    const childA = (a as Record<string, unknown>)[key]
+    const childB = (b as Record<string, unknown>)[key]
+
+    diffs.push(
+      ...compareRec({
+        a: childA,
+        b: childB,
+        path: keyPath,
+        currentDepth: currentDepth + 1,
+      })
+    )
+  }
+
+  for (const key of keysB) {
+    if (!keysA.includes(key)) {
+      diffs.push({
+        path: path ? `${path}.${key}` : key,
+        type: 'extra_key',
+        valueA: undefined,
+        valueB: (b as Record<string, unknown>)[key],
+      })
+    }
+  }
+
+  return diffs
+}
+
+export function structuralCompare(
+  a: unknown,
+  b: unknown
+): StructuralCompareResult {
+  const diffs = compareRec({ a, b, path: '', currentDepth: 0 })
+  const categorySet = new Set<DiffCategory>()
+
+  for (const d of diffs) {
+    categorySet.add(typeToCategory(d.type))
+  }
+
+  const summary = Array.from(categorySet)
+
+  return { diffs, summary }
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -598,6 +598,11 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
+"@juanelas/base64@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@juanelas/base64/-/base64-1.1.5.tgz#d43b3c78e32e609d9b17a15e4f1b6342c9ca1238"
+  integrity sha512-mjAF27LzwfYobdwqnxZgeucbKT5wRRNvILg3h5OvCWK+3F7mw/A1tnjHnNiTYtLmTvT/bM1jA5AX7eQawDGs1w==
+
 "@opentelemetry/api-logs@0.57.2":
   version "0.57.2"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz#d4001b9aa3580367b40fe889f3540014f766cc87"
@@ -1684,6 +1689,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 bintrees@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
@@ -1769,6 +1779,14 @@ buffer@^5.1.0:
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
+
+buffer@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bufrw@^1.3.0:
   version "1.3.0"
@@ -2041,6 +2059,13 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+cross-sha256@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/cross-sha256/-/cross-sha256-1.2.0.tgz#d7b941d17920a1781b8d2d03a1e55700c75b2082"
+  integrity sha512-KViLNMDZKV7jwFqjFx+rNhG26amnFYYQ0S+VaFlVvpk8tM+2XbFia/don/SjGHg9WQxnFVi6z64CGPuF3T+nNw==
+  dependencies:
+    buffer "^5.6.0"
+
 cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -2294,6 +2319,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventsource@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
+  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -2341,6 +2371,25 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
+
+featurehub-javascript-client-sdk@1.4.0, featurehub-javascript-client-sdk@^1.3.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/featurehub-javascript-client-sdk/-/featurehub-javascript-client-sdk-1.4.0.tgz#c10b5589e6d2d4bfd0ccf9d323591c02b7395d34"
+  integrity sha512-AlUV5xOQTv5g2aXTUhZBa41OAbiB6DhEy7VUkF1/XmI/W1Y5vQChBvAB7ftF2fWTQ3lFUqTKoB3mTAUkwDYg7A==
+  dependencies:
+    "@juanelas/base64" "^1.1.5"
+    cross-sha256 "^1.2.0"
+    murmurhash "^2.0.1"
+    netmask "^2.0.2"
+    semver-compare "^1.0.0"
+
+featurehub-javascript-node-sdk@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/featurehub-javascript-node-sdk/-/featurehub-javascript-node-sdk-1.3.3.tgz#0278c95f3986cbc824ccfe821f1563a5caab28be"
+  integrity sha512-L4jVpl2+lvPlNKW9ILtlLmDuwon5ayOFna200aYus+13RL8PYVyXykaqPN+Aa3gj669lidsWqdHRY7IhsYqUvw==
+  dependencies:
+    eventsource "^2.0.2"
+    featurehub-javascript-client-sdk "^1.3.2"
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -2620,6 +2669,11 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ieee754@^1.1.4:
   version "1.1.13"
@@ -3530,6 +3584,11 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+murmurhash@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/murmurhash/-/murmurhash-2.0.1.tgz#4097720e08cf978872194ad84ea5be2dec9b610f"
+  integrity sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -3539,6 +3598,11 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+netmask@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
+  integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3894,6 +3958,11 @@ safe-buffer@~5.2.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
 semver@^5.5.1:
   version "5.7.1"


### PR DESCRIPTION
#### What problem is this solving?

- Use a shadow request structure to validate sensitive API migration. To support this architecture, [DK flags](https://flags.vtex.com/dashboard) was integrated. Using the flag values, the ShadowMigration class can decide which requests make, and which one will be the response, while log diff if it exists.
- This new structure was integrated with the fetchProduct request used to resolve the query `product`

Complete flow with flags
```mermaid
flowchart TD
  Start([execute legacyFn, nextFn, ctx]) --> Eval[Evaluate flags in FeatureHub]
  Eval --> Fallback{Failure?}
  Fallback -->|Yes| LegacyOnly[Use legacy only]
  Fallback -->|No| Complete{migrationComplete?}
  Complete -->|Yes| NewOnly[Call nextFn → return new result]
  Complete -->|No| Shadow{shadow?}
  Shadow -->|No| LegacyOnly
  Shadow -->|Yes| Parallel[Call legacyFn and nextFn in parallel]
  Parallel --> Compare[Background: normalize + structuralCompare + log]
  Compare --> ReturnNew{returnNew?}
  ReturnNew -->|Yes| ReturnNewResult[Return result from new source]
  ReturnNew -->|No| ReturnLegacyResult[Return result from legacy source]
```

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
