### PR TITLE
Improve compare for ProductSearch and add compare to PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Improve compare configs for ProductSearch
+- Start comparing traffic for PDP by calling the Intsch with productOriginVtex true.
+
 ## [1.95.0] - 2026-03-17
 
 ### Changed

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -52,6 +52,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
         sc: args.salesChannel ?? 1,
         regionId: args.regionId,
         locale: args.locale,
+        productOriginVtex: args.productOriginVtex
       },
       metric: 'search-product-new',
       headers: {

--- a/node/clients/intsch/types.ts
+++ b/node/clients/intsch/types.ts
@@ -91,6 +91,7 @@ export type FetchProductArgs = {
   salesChannel?: string
   regionId?: string
   locale?: string
+  productOriginVtex?: boolean
 }
 
 export type FetchProductResponse = SearchProduct

--- a/node/services/pdpConfig.ts
+++ b/node/services/pdpConfig.ts
@@ -1,0 +1,40 @@
+import type {
+  ExistenceComparePattern,
+  IgnoredDifference,
+} from '../utils/compareResults'
+
+/**
+ * Known expected differences when comparing PDP (productOriginVtex=true) vs catalog/portal search.
+ * Populate as differences are discovered.
+ */
+export const CATALOG_IGNORED_DIFFERENCES: IgnoredDifference[] = [
+  // Actual
+  { path: 'skuSpecifications[*].field.type', type: 'missing_key' },
+  { path: 'origin', type: 'extra_key' },
+  // productReference: catalog data plane does not always carry the product-level refId
+  { path: 'productReference', type: 'different_value' },
+  // PriceToken: generated internally by the catalog search API, not available in simulation
+  {
+    path: 'items[*].sellers[*].commertialOffer.PriceToken',
+    type: 'missing_key',
+  },
+  // PriceValidUntil: timezone differences between simulation and catalog search snapshots
+  {
+    path: 'items[*].sellers[*].commertialOffer.PriceValidUntil',
+    type: 'different_value',
+  },
+  {
+    path: 'items[*].sellers[*].commertialOffer.PaymentOptions.paymentSystems[*].dueDate',
+    type: 'different_value',
+  },
+]
+
+/**
+ * Existence-based comparison for catalog comparison. Populate as needed.
+ */
+export const CATALOG_EXISTENCE_COMPARE_FIELDS: ExistenceComparePattern[] = [
+  'allSpecifications',
+  { path: 'completeSpecifications', key: 'Name' },
+  { path: 'skuSpecifications', key: 'field.name' },
+  { path: 'items[*].sellers[*].commertialOffer.PaymentOptions.paymentSystems', key: 'id' },
+]

--- a/node/services/pdpConfig.ts
+++ b/node/services/pdpConfig.ts
@@ -33,7 +33,9 @@ export const CATALOG_IGNORED_DIFFERENCES: IgnoredDifference[] = [
  * Existence-based comparison for catalog comparison. Populate as needed.
  */
 export const CATALOG_EXISTENCE_COMPARE_FIELDS: ExistenceComparePattern[] = [
-  'allSpecifications',
+  "categories",
+  "categoriesIds",
+  "allSpecifications",
   { path: 'completeSpecifications', key: 'Name' },
   { path: 'skuSpecifications', key: 'field.name' },
   { path: 'items[*].sellers[*].commertialOffer.PaymentOptions.paymentSystems', key: 'id' },

--- a/node/services/product.test.ts
+++ b/node/services/product.test.ts
@@ -1,4 +1,4 @@
-import { fetchProduct, buildVtexSegment } from './product'
+import { fetchProduct } from './product'
 import { createContext } from '../mocks/contextFactory'
 
 describe('fetchProduct service', () => {
@@ -10,44 +10,6 @@ describe('fetchProduct service', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-  })
-
-  it('should build vtex segment correctly', () => {
-    const vtexSegment = buildVtexSegment({
-      vtexSegment: {
-        campaigns: null,
-        channel: '1',
-        priceTables: null,
-        regionId: 'U1cjMQ==',
-        utm_campaign: null,
-        utm_source: null,
-        utmi_campaign: null,
-        currencyCode: 'ARS',
-        currencySymbol: '$',
-        countryCode: 'ARG',
-        cultureInfo: 'es-AR',
-        admin_cultureInfo: 'es-AR',
-        channelPrivacy: 'public',
-      },
-      salesChannel: '2',
-      regionId: '3',
-    })
-
-    const result = JSON.parse(Buffer.from(vtexSegment, 'base64').toString())
-
-    expect(result.regionId).toBe('3')
-    expect(result.countryCode).toBe('ARG')
-    expect(result.currencySymbol).toBe('$')
-    expect(result.currencyCode).toBe('ARS')
-    expect(result.channel).toBe('2')
-    expect(result.cultureInfo).toBe('es-AR')
-    expect(result.admin_cultureInfo).toBe('es-AR')
-    expect(result.channelPrivacy).toBe('public')
-    expect(result.campaigns).toBeNull()
-    expect(result.priceTables).toBeNull()
-    expect(result.utm_campaign).toBeNull()
-    expect(result.utm_source).toBeNull()
-    expect(result.utmi_campaign).toBeNull()
   })
 
   it('should use intsch directly for b2bstoreqa account', async () => {

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -1,5 +1,10 @@
 import type { SegmentData } from '../typings/Search'
+import { compareApiResults } from '../utils/compareResults'
 import { fetchAppSettings } from './settings'
+import {
+  CATALOG_IGNORED_DIFFERENCES,
+  CATALOG_EXISTENCE_COMPARE_FIELDS,
+} from './pdpConfig'
 
 export type ProductIdentifier = {
   field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'
@@ -18,6 +23,7 @@ interface FetchProductArgs {
   salesChannel?: number | null
   regionId?: string
   vtexSegment?: string
+  productOriginVtex?: boolean
 }
 
 /**
@@ -148,7 +154,24 @@ export async function fetchProduct(
     return fetchProductFromIntsch(ctx, args)
   }
 
-  return fetchProductFromSearch(ctx, args)
+  const existenceCompareFields = CATALOG_EXISTENCE_COMPARE_FIELDS
+  const ignoredDifferences =  CATALOG_IGNORED_DIFFERENCES
+
+  return compareApiResults(
+    () => fetchProductFromSearch(ctx, args),
+    () => fetchProductFromIntsch(ctx, args),
+    ctx.vtex.production ? 1 : 100,
+    ctx.vtex.logger,
+    {
+      logPrefix: 'Product',
+      args: {
+        field: args.identifier.field,
+        value: args.identifier.value,
+      },
+      existenceCompareFields,
+      ignoredDifferences,
+    }
+  )
 }
 
 /**

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -1,5 +1,5 @@
-import type { SegmentData } from '../typings/Search'
 import { compareApiResults } from '../utils/compareResults'
+import { extractSegmentData, getOrCreateSegment } from '../utils/segment'
 import { fetchAppSettings } from './settings'
 import {
   CATALOG_IGNORED_DIFFERENCES,
@@ -22,8 +22,6 @@ interface FetchProductArgs {
   identifier: ProductIdentifier
   salesChannel?: number | null
   regionId?: string
-  vtexSegment?: string
-  productOriginVtex?: boolean
 }
 
 /**
@@ -39,8 +37,9 @@ async function fetchProductFromSearch(
   args: FetchProductArgs
 ): Promise<SearchProduct[]> {
   const { search } = ctx.clients
-  const { identifier, salesChannel, vtexSegment } = args
+  const { identifier, salesChannel } = args
   const { field, value } = identifier
+  const vtexSegment = ctx.vtex.segmentToken
 
   switch (field) {
     case 'id':
@@ -68,10 +67,11 @@ async function fetchProductFromSearch(
  */
 async function fetchProductFromIntsch(
   ctx: Context,
-  args: FetchProductArgs
+  args: FetchProductArgs,
+  segmentData: ReturnType<typeof extractSegmentData>
 ): Promise<SearchProduct[]> {
   const { intsch } = ctx.clients
-  const { identifier, salesChannel, regionId, vtexSegment } = args
+  const { identifier, salesChannel, regionId } = args
   const { field, value } = identifier
 
   // Get locale from context (fallback)
@@ -81,29 +81,13 @@ async function fetchProductFromIntsch(
   let finalSalesChannel = salesChannel ? `${salesChannel}` : undefined
   let finalLocale = defaultLocale
 
-  // Parse vtexSegment if available to extract locale and salesChannel
-  if (vtexSegment) {
-    try {
-      const segmentData: SegmentData = JSON.parse(
-        Buffer.from(vtexSegment, 'base64').toString()
-      )
-
-      // Use segment's salesChannel if available, otherwise use the provided one
-      if (segmentData.channel) {
-        finalSalesChannel = segmentData.channel
-      }
-
-      // Use segment's locale (cultureInfo) if available, otherwise use default
-      if (segmentData.cultureInfo) {
-        finalLocale = segmentData.cultureInfo
-      }
-    } catch (error) {
-      // If parsing fails, continue with defaults
-      ctx.vtex.logger.warn({
-        message: 'Failed to parse vtexSegment token, using defaults',
-        error: error.message,
-        vtexSegment,
-      })
+  // Extract locale and salesChannel from segment data
+  if (segmentData.segmentParams) {
+    if (segmentData.segmentParams.sc) {
+      finalSalesChannel = String(segmentData.segmentParams.sc)
+    }
+    if (segmentData.segmentParams.locale) {
+      finalLocale = segmentData.segmentParams.locale
     }
   }
 
@@ -113,6 +97,7 @@ async function fetchProductFromIntsch(
     salesChannel: finalSalesChannel?.toString(),
     regionId,
     locale: finalLocale,
+    productOriginVtex: true,
   })
 
   // intsch.fetchProduct returns a single SearchProduct, but we need to return an array
@@ -124,34 +109,20 @@ async function fetchProductFromIntsch(
  * Builds vtex segment token for product fetching
  */
 
-export function buildVtexSegment({
-  vtexSegment,
-  salesChannel,
-  regionId,
-}: {
-  vtexSegment?: SegmentData
-  salesChannel?: string
-  regionId?: string
-}): string {
-  const cookie = {
-    ...vtexSegment,
-    regionId: regionId ?? vtexSegment?.regionId,
-    channel: salesChannel ?? vtexSegment?.channel,
-  }
-
-  return Buffer.from(JSON.stringify(cookie)).toString('base64')
-}
-
 export async function fetchProduct(
   ctx: Context,
   args: FetchProductArgs
 ): Promise<SearchProduct[]> {
   const { shouldUseNewPDPEndpoint } = await fetchAppSettings(ctx)
 
+  // Get and create segment before calling intsch
+  const segment = await getOrCreateSegment(ctx)
+  const segmentData = extractSegmentData(segment)
+
   // Check if current account should skip comparison and use intsch directly
   if (shouldUseNewPDPEndpoint) {
     ctx.translated = true
-    return fetchProductFromIntsch(ctx, args)
+    return fetchProductFromIntsch(ctx, args, segmentData)
   }
 
   const existenceCompareFields = CATALOG_EXISTENCE_COMPARE_FIELDS
@@ -159,7 +130,7 @@ export async function fetchProduct(
 
   return compareApiResults(
     () => fetchProductFromSearch(ctx, args),
-    () => fetchProductFromIntsch(ctx, args),
+    () => fetchProductFromIntsch(ctx, args, segmentData),
     ctx.vtex.production ? 1 : 100,
     ctx.vtex.logger,
     {
@@ -200,26 +171,12 @@ export async function resolveProduct(
     throw new Error('No product identifier provided')
   }
 
-  const cookie: SegmentData | undefined = ctx.vtex.segment as
-    | SegmentData
-    | undefined
-
   const { salesChannel } = rawArgs
-
-  const vtexSegment =
-    !cookie || (!cookie?.regionId && rawArgs.regionId)
-      ? buildVtexSegment({
-          vtexSegment: ctx.vtex.segment as SegmentData | undefined,
-          salesChannel: rawArgs.salesChannel?.toString(),
-          regionId: rawArgs.regionId,
-        })
-      : ctx.vtex.segmentToken
 
   const fetchArgs: FetchProductArgs = {
     identifier: args.identifier as ProductIdentifier,
     salesChannel,
     regionId: rawArgs.regionId,
-    vtexSegment,
   }
 
   try {
@@ -254,11 +211,11 @@ export type ProductsByIdentifierArgs = {
  */
 async function fetchProductsByIdentifierFromSearch(
   ctx: Context,
-  args: ProductsByIdentifierArgs,
-  vtexSegment?: string
+  args: ProductsByIdentifierArgs
 ): Promise<SearchProduct[]> {
   const { search } = ctx.clients
   const { field, values, salesChannel } = args
+  const vtexSegment = ctx.vtex.segmentToken
 
   switch (field) {
     case 'id':
@@ -284,7 +241,7 @@ async function fetchProductsByIdentifierFromSearch(
 async function fetchProductsByIdentifierFromIntsch(
   ctx: Context,
   args: ProductsByIdentifierArgs,
-  vtexSegment?: string
+  segmentData: ReturnType<typeof extractSegmentData>
 ): Promise<SearchProduct[]> {
   const { intsch } = ctx.clients
   const { field, values, salesChannel, regionId } = args
@@ -296,29 +253,13 @@ async function fetchProductsByIdentifierFromIntsch(
   let finalSalesChannel = salesChannel ? `${salesChannel}` : undefined
   let finalLocale = defaultLocale
 
-  // Parse vtexSegment if available to extract locale and salesChannel
-  if (vtexSegment) {
-    try {
-      const segmentData: SegmentData = JSON.parse(
-        Buffer.from(vtexSegment, 'base64').toString()
-      )
-
-      // Use segment's salesChannel if available, otherwise use the provided one
-      if (segmentData.channel) {
-        finalSalesChannel = segmentData.channel
-      }
-
-      // Use segment's locale (cultureInfo) if available, otherwise use default
-      if (segmentData.cultureInfo) {
-        finalLocale = segmentData.cultureInfo
-      }
-    } catch (error) {
-      // If parsing fails, continue with defaults
-      ctx.vtex.logger.warn({
-        message: 'Failed to parse vtexSegment token, using defaults',
-        error: error.message,
-        vtexSegment,
-      })
+  // Extract locale and salesChannel from segment data
+  if (segmentData.segmentParams) {
+    if (segmentData.segmentParams.sc) {
+      finalSalesChannel = String(segmentData.segmentParams.sc)
+    }
+    if (segmentData.segmentParams.locale) {
+      finalLocale = segmentData.segmentParams.locale
     }
   }
 
@@ -330,6 +271,7 @@ async function fetchProductsByIdentifierFromIntsch(
       salesChannel: finalSalesChannel?.toString(),
       regionId: regionId ?? undefined,
       locale: finalLocale,
+      productOriginVtex: true,
     })
   )
 
@@ -342,16 +284,11 @@ export async function resolveProductsByIdentifier(
   ctx: Context,
   args: ProductsByIdentifierArgs
 ): Promise<SearchProduct[]> {
-  const vtexSegment =
-    !ctx.vtex.segment || (!ctx.vtex.segment?.regionId && args.regionId)
-      ? buildVtexSegment({
-          vtexSegment: ctx.vtex.segment as SegmentData | undefined,
-          salesChannel: args.salesChannel?.toString(),
-          regionId: args.regionId ?? undefined,
-        })
-      : ctx.vtex.segmentToken
-
   const { shouldUseNewPDPEndpoint } = await fetchAppSettings(ctx)
+
+  // Get and create segment before calling intsch
+  const segment = await getOrCreateSegment(ctx)
+  const segmentData = extractSegmentData(segment)
 
   try {
     let products: SearchProduct[]
@@ -361,13 +298,12 @@ export async function resolveProductsByIdentifier(
       products = await fetchProductsByIdentifierFromIntsch(
         ctx,
         args,
-        vtexSegment
+        segmentData
       )
     } else {
       products = await fetchProductsByIdentifierFromSearch(
         ctx,
-        args,
-        vtexSegment
+        args
       )
     }
 

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -119,6 +119,44 @@ export const PRODUCT_SEARCH_IGNORED_DIFFERENCES: IgnoredDifference[] = [
 ]
 
 /**
+ * Known expected differences to ignore when comparing productOriginVtex=true (catalog/portal) responses.
+ * These are based on CATALOG_IGNORED_DIFFERENCES from intelligent-search tests, with paths prefixed for product_search context.
+ */
+export const CATALOG_PRODUCT_SEARCH_IGNORED_DIFFERENCES: IgnoredDifference[] = [
+  // skuSpecifications[*].field.type: present in intsch but not in catalog
+  { path: 'products[*].skuSpecifications[*].field.type', type: 'missing_key' },
+  // origin: intsch sends this but catalog doesn't
+  { path: 'products[*].origin', type: 'extra_key' },
+  // productReference: catalog data plane does not always carry the product-level refId
+  { path: 'products[*].productReference', type: 'different_value' },
+  // PriceToken: generated internally by the catalog search API, not available in simulation
+  {
+    path: 'products[*].items[*].sellers[*].commertialOffer.PriceToken',
+    type: 'missing_key',
+  },
+  // PriceValidUntil: timezone differences between simulation and catalog search snapshots
+  {
+    path: 'products[*].items[*].sellers[*].commertialOffer.PriceValidUntil',
+    type: 'different_value',
+  },
+  {
+    path: 'products[*].items[*].sellers[*].commertialOffer.PaymentOptions.paymentSystems[*].dueDate',
+    type: 'different_value',
+  },
+]
+
+/**
+ * Existence-based comparison fields for productOriginVtex=true (catalog/portal) responses.
+ * These are based on CATALOG_EXISTENCE_COMPARE_FIELDS from intelligent-search tests, with paths prefixed for product_search context.
+ */
+export const CATALOG_PRODUCT_SEARCH_EXISTENCE_COMPARE_FIELDS: ExistenceComparePattern[] = [
+  'products[*].allSpecifications',
+  { path: 'products[*].completeSpecifications', key: 'Name' },
+  { path: 'products[*].skuSpecifications', key: 'field.name' },
+  { path: 'products[*].items[*].sellers[*].commertialOffer.PaymentOptions.paymentSystems', key: 'id' },
+]
+
+/**
  * Builds a query string from an object of params, filtering out undefined/null values
  */
 function buildQueryString(params: Record<string, any>): string {
@@ -302,27 +340,22 @@ export async function fetchProductSearch(
     ...clientArgs,
   }
 
-  if (args.productOriginVtex) {
-    // This uses the portal search reather than biggy, so the diff is guaranteed to be different and not useful. We can remove the comparison and just log the request params for debugging.
-    ctx.vtex.logger.info({
-      message:
-        'Product search with productOriginVtex=true, skipping comparison and using Intelligent Search endpoint directly',
-    })
-
-    return fetchProductSearchFromBiggy(
-      ctx,
-      args,
-      selectedFacets,
-      shippingOptions
-    )
-  }
-
   const { biggyCurl, intschCurl } = buildCurlCommands(
     ctx,
     path,
     requestParams,
     shippingOptions
   )
+
+  // Use catalog-specific comparison configs when productOriginVtex is enabled
+  // since the response format differs (uses catalog data plane)
+  const isProductOriginVtex = args.productOriginVtex ?? false
+  const existenceCompareFields = isProductOriginVtex
+    ? CATALOG_PRODUCT_SEARCH_EXISTENCE_COMPARE_FIELDS
+    : PRODUCT_SEARCH_EXISTENCE_COMPARE_FIELDS
+  const ignoredDifferences = isProductOriginVtex
+    ? CATALOG_PRODUCT_SEARCH_IGNORED_DIFFERENCES
+    : PRODUCT_SEARCH_IGNORED_DIFFERENCES
 
   return compareApiResults(
     () =>
@@ -336,9 +369,10 @@ export async function fetchProductSearch(
       args: {
         biggyCurl,
         intschCurl,
+        productOriginVtex: isProductOriginVtex,
       },
-      existenceCompareFields: PRODUCT_SEARCH_EXISTENCE_COMPARE_FIELDS,
-      ignoredDifferences: PRODUCT_SEARCH_IGNORED_DIFFERENCES,
+      existenceCompareFields,
+      ignoredDifferences,
     }
   )
 }

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -60,19 +60,24 @@ export const PRODUCT_SEARCH_IGNORED_DIFFERENCES: IgnoredDifference[] = [
   { path: 'pagination.last.proxyUrl', type: 'different_value' },
   { path: 'pagination.current.proxyUrl', type: 'different_value' },
   { path: 'pagination.previous.proxyUrl', type: 'different_value' },
-  { path: 'products[*].items[*].kitItems', type: 'missing_key' },
-  { path: 'products[*].items[*].estimatedDateArrival', type: 'missing_key' },
-  { path: 'products[*].items[*].manufacturerCode', type: 'missing_key' },
   // cacheId differs because of sponsored products middleware on node
   { path: 'products[*].cacheId', type: 'different_value' },
   // productReference: intsch sends this but biggy always returns ""
+  // searchId is always different
+  { path: 'searchId', type: 'different_value' },
+  // PDP differences (from intelligent-search/tests), mapped under `products[*].*`
+  // New data that intsch sends and production doesn't (extra in local)
+  { path: 'products[*].items[*].kitItems', type: 'extra_key' },
+  { path: 'products[*].items[*].estimatedDateArrival', type: 'extra_key' },
+  { path: 'products[*].items[*].manufacturerCode', type: 'extra_key' },
+  // productReference: intsch sends this but production always returns ""
   { path: 'products[*].productReference', type: 'different_value' },
-  { path: 'products[*].productReference', type: 'missing_key' },
-  // metaTagDescription: intsch sends this but biggy always returns ""
+  { path: 'products[*].productReference', type: 'extra_key' },
+  // metaTagDescription: intsch sends this but production always returns ""
   { path: 'products[*].metaTagDescription', type: 'different_value' },
-  // isKit: intsch sends this but biggy always returns "false"
+  // isKit: intsch sends this but production always returns "false"
   { path: 'products[*].items[*].isKit', type: 'different_value' },
-  // modalType: intsch sends this but biggy always returns ""
+  // modalType: intsch sends this but production always returns ""
   { path: 'products[*].items[*].modalType', type: 'different_value' },
   // PriceValidUntil changes with each request
   {
@@ -84,39 +89,32 @@ export const PRODUCT_SEARCH_IGNORED_DIFFERENCES: IgnoredDifference[] = [
     path: 'products[*].items[*].sellers[*].commertialOffer.PriceValidUntil',
     type: 'null_mismatch',
   },
-  {
-    path: 'products[*].items[*].sellers[*].commertialOffer.RewardValue',
-    type: 'different_value',
-  },
-  // imageText: intsch sends this but biggy always returns ""
+  // imageText: intsch sends this but production always returns ""
   { path: 'products[*].items[*].images[*].imageText', type: 'different_value' },
-  // attachments: intsch sends this but biggy always returns an empty array
-  {
-    path: 'products[*].items[*].attachments',
-    type: 'array_length_mismatch',
-  },
-  { path: 'products[*].items[*].attachments[*]', type: 'missing_key' },
-  // sellerId in specificationGroups/properties: no longer sent by intsch
+  // attachments: intsch sends this but production always returns an empty array
+  { path: 'products[*].items[*].attachments', type: 'array_length_mismatch' },
+  { path: 'products[*].items[*].attachments[*]', type: 'extra_key' },
+  // sellerId in specificationGroups/properties: no longer sent by intsch (missing from local)
   {
     path: 'products[*].specificationGroups[name:allSpecifications].specifications[name:sellerId]',
-    type: 'extra_key',
+    type: 'missing_key',
   },
-  { path: 'products[*].properties[name:sellerId]', type: 'extra_key' },
-  // productTitle: no longer sent by intsch because it is always empty
-  { path: 'products[*].productTitle', type: 'extra_key' },
-  // description: differs because intsch gets the raw value from catalog without cropping
-  { path: 'products[*].description', type: 'different_value' },
-  // taxPercentage: biggy sends 0 or null, intsch always sends 0
+  { path: 'products[*].properties[name:sellerId]', type: 'missing_key' },
+  // taxPercentage: production sends 0 or null, intsch always sends 0
   {
     path: 'products[*].items[*].sellers[*].commertialOffer.taxPercentage',
     type: 'null_mismatch',
   },
-  // searchId is always different
-  { path: 'searchId', type: 'different_value' },
-  // allSpecifications group can be missing when product has no specs (biggy always returns sellerId there)
+  // cacheId differs because of sponsored products middleware on node
+  { path: 'products[*].cacheId', type: 'different_value' },
+  // productTitle: no longer sent because it is always empty (missing from local)
+  { path: 'products[*].productTitle', type: 'missing_key' },
+  // description: differs because intsch gets the raw value from catalog without cropping
+  { path: 'products[*].description', type: 'different_value' },
+  // allSpecifications group can be missing when product has no specs (missing from local)
   {
     path: 'products[*].specificationGroups[name:allSpecifications]',
-    type: 'extra_key',
+    type: 'missing_key',
   },
 ]
 

--- a/node/utils/compareResults.test.ts
+++ b/node/utils/compareResults.test.ts
@@ -335,12 +335,12 @@ describe('isDeepEqual', () => {
         expect.arrayContaining([
           {
             path: 'age',
-            type: 'extra_key',
+            type: 'missing_key',
             expected: 25,
           },
           {
             path: 'email',
-            type: 'missing_key',
+            type: 'extra_key',
             actual: 'john@example.com',
           },
         ])
@@ -446,7 +446,7 @@ describe('findDifferences', () => {
         },
         {
           path: 'c',
-          type: 'missing_key',
+          type: 'extra_key',
           actual: 4,
         },
       ])
@@ -601,11 +601,11 @@ describe('existence-based array comparison', () => {
       expect.arrayContaining([
         expect.objectContaining({
           path: 'skuSpecifications[name:Colour]',
-          type: 'missing_key',
+          type: 'extra_key',
         }),
         expect.objectContaining({
           path: 'skuSpecifications[name:Size]',
-          type: 'extra_key',
+          type: 'missing_key',
         }),
       ])
     )
@@ -731,11 +731,11 @@ describe('existence-based array comparison', () => {
       expect.arrayContaining([
         expect.objectContaining({
           path: 'categories[name:/Electronics/TVs/]',
-          type: 'missing_key',
+          type: 'extra_key',
         }),
         expect.objectContaining({
           path: 'categories[name:/Electronics/Tablets/]',
-          type: 'extra_key',
+          type: 'missing_key',
         }),
       ])
     )
@@ -823,7 +823,7 @@ describe('nested existence-based comparison with ignore patterns', () => {
     expect(result.differences).toEqual([
       {
         path: 'products[0].specificationGroups[name:allSpecifications].specifications[name:sellerId]',
-        type: 'extra_key',
+        type: 'missing_key',
         expected: {
           originalName: 'sellerId',
           name: 'sellerId',
@@ -832,7 +832,7 @@ describe('nested existence-based comparison with ignore patterns', () => {
       },
       {
         path: 'products[0].properties[name:sellerId]',
-        type: 'extra_key',
+        type: 'missing_key',
         expected: {
           originalName: 'sellerId',
           name: 'sellerId',
@@ -888,15 +888,15 @@ describe('nested existence-based comparison with ignore patterns', () => {
     const ignoredDifferences: IgnoredDifference[] = [
       {
         path: 'products[*].specificationGroups[name:allSpecifications].specifications[name:sellerId]',
-        type: 'extra_key',
+        type: 'missing_key',
       },
-      { path: 'products[*].properties[name:sellerId]', type: 'extra_key' },
+      { path: 'products[*].properties[name:sellerId]', type: 'missing_key' },
     ]
 
     const filtered = filterIgnoredDifferences(
       result.differences,
       ignoredDifferences
-    )
+    ).filtered
 
     expect(filtered).toEqual([])
   })
@@ -915,7 +915,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'age', type: 'extra_key', expected: 25 },
       ]
 
-      const result = filterIgnoredDifferences(differences, [])
+      const result = filterIgnoredDifferences(differences, []).filtered
 
       expect(result).toEqual(differences)
     })
@@ -931,7 +931,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'age', type: 'extra_key', expected: 25 },
       ]
 
-      const result = filterIgnoredDifferences(differences)
+      const result = filterIgnoredDifferences(differences).filtered
 
       expect(result).toEqual(differences)
     })
@@ -953,7 +953,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'email', type: 'missing_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([
         {
@@ -985,7 +985,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'value', type: 'different_value' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([
         {
@@ -1007,7 +1007,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'name', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([{ path: 'age', type: 'extra_key', expected: 25 }])
     })
@@ -1031,7 +1031,7 @@ describe('filterIgnoredDifferences', () => {
         { path: '[0].brandImageUrl', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([
         {
@@ -1058,7 +1058,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'data[0].items[2].specs', type: 'missing_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([
         {
@@ -1097,7 +1097,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'user.settings.notifications', type: 'missing_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([
         {
@@ -1142,7 +1142,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'array', type: 'array_length_mismatch' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([
         {
@@ -1162,7 +1162,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'any', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([])
     })
@@ -1177,7 +1177,7 @@ describe('filterIgnoredDifferences', () => {
         },
       ]
 
-      const result = filterIgnoredDifferences(differences, [])
+      const result = filterIgnoredDifferences(differences, []).filtered
 
       expect(result).toEqual(differences)
     })
@@ -1198,7 +1198,7 @@ describe('filterIgnoredDifferences', () => {
         { path: 'age', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
       expect(result).toEqual([])
     })
@@ -1237,7 +1237,7 @@ describe('shouldIgnoreDifference', () => {
           path: 'products[*].cacheId',
           type: 'different_value',
         })
-      ).toBe(false)
+      ).toBe(true)
     })
 
     it('should match multiple [*] wildcards', () => {
@@ -1428,7 +1428,7 @@ describe('filterIgnoredDifferences with wildcards', () => {
       { path: 'products[*].cacheId', type: 'different_value' },
     ]
 
-    const result = filterIgnoredDifferences(differences, ignoredDifferences)
+    const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
     expect(result).toEqual([
       {
@@ -1457,7 +1457,7 @@ describe('filterIgnoredDifferences with wildcards', () => {
 
     const result = filterIgnoredDifferences(differences, [
       'products[*].cacheId',
-    ])
+    ]).filtered
 
     expect(result).toEqual([])
   })
@@ -1487,7 +1487,7 @@ describe('filterIgnoredDifferences with wildcards', () => {
       },
     ]
 
-    const result = filterIgnoredDifferences(differences, ignoredDifferences)
+    const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
 
     expect(result).toEqual([
       {
@@ -1673,7 +1673,7 @@ describe('compareApiResults', () => {
       const ignoredDifferences: IgnoredDifference[] = [
         { path: 'name', type: 'different_value' },
         { path: 'age', type: 'different_value' },
-        { path: 'extra', type: 'extra_key' },
+        { path: 'extra', type: 'missing_key' },
       ]
 
       const result = await compareApiResults(func1, func2, 100, mockLogger, {
@@ -1709,8 +1709,8 @@ describe('compareApiResults', () => {
       ])
 
       const ignoredDifferences: IgnoredDifference[] = [
-        { path: '[0].productReferenceCode', type: 'extra_key' },
-        { path: '[0].brandImageUrl', type: 'extra_key' },
+        { path: '[0].productReferenceCode', type: 'missing_key' },
+        { path: '[0].brandImageUrl', type: 'missing_key' },
       ]
 
       const result = await compareApiResults(func1, func2, 100, mockLogger, {
@@ -1781,9 +1781,9 @@ describe('compareApiResults', () => {
       ])
 
       const ignoredDifferences: IgnoredDifference[] = [
-        { path: '[0].productReferenceCode', type: 'extra_key' },
-        { path: '[0].brandImageUrl', type: 'extra_key' },
-        { path: '[0].searchableClusters', type: 'extra_key' },
+        { path: '[0].productReferenceCode', type: 'missing_key' },
+        { path: '[0].brandImageUrl', type: 'missing_key' },
+        { path: '[0].searchableClusters', type: 'missing_key' },
         { path: '[0].releaseDate', type: 'different_type' },
         { path: '[0].clusterHighlights', type: 'different_type' },
         { path: '[0].productClusters', type: 'different_type' },
@@ -1849,10 +1849,10 @@ describe('compareApiResults', () => {
       })
 
       const ignoredDifferences: IgnoredDifference[] = [
-        { path: 'user.avatar', type: 'extra_key' },
-        { path: 'user.settings.notifications', type: 'missing_key' },
+        { path: 'user.avatar', type: 'missing_key' },
+        { path: 'user.settings.notifications', type: 'extra_key' },
         { path: 'items', type: 'array_length_mismatch' },
-        { path: 'items[2]', type: 'extra_key' },
+        { path: 'items[2]', type: 'missing_key' },
       ]
 
       const result = await compareApiResults(func1, func2, 100, mockLogger, {

--- a/node/utils/compareResults.ts
+++ b/node/utils/compareResults.ts
@@ -176,13 +176,13 @@ function compareArraysByExistence(
     if (i >= noKey1.length) {
       differences.push({
         path: currentPath,
-        type: 'missing_key',
+        type: 'extra_key',
         actual: noKey2[i],
       })
     } else if (i >= noKey2.length) {
       differences.push({
         path: currentPath,
-        type: 'extra_key',
+        type: 'missing_key',
         expected: noKey1[i],
       })
     } else {
@@ -198,27 +198,27 @@ function compareArraysByExistence(
     }
   }
 
-  // Find elements in arr2 not in arr1 (missing from expected)
+  // Find elements in arr2 not in arr1 (extra in local/actual)
   for (const [key, item] of map2) {
     if (!map1.has(key)) {
       const currentPath = path ? `${path}[name:${key}]` : `[name:${key}]`
 
       differences.push({
         path: currentPath,
-        type: 'missing_key',
+        type: 'extra_key',
         actual: item,
       })
     }
   }
 
-  // Find elements in arr1 not in arr2 (extra in expected)
+  // Find elements in arr1 not in arr2 (missing from local/actual)
   for (const [key, item] of map1) {
     if (!map2.has(key)) {
       const currentPath = path ? `${path}[name:${key}]` : `[name:${key}]`
 
       differences.push({
         path: currentPath,
-        type: 'extra_key',
+        type: 'missing_key',
         expected: item,
       })
     }
@@ -240,9 +240,12 @@ function compareArraysByExistence(
 }
 
 /**
- * Finds differences between two values recursively
- * @param a First value to compare
- * @param b Second value to compare
+ * Finds differences between two values recursively.
+ * Types are from local (b) perspective: extra_key = present only in local,
+ * missing_key = present only in production (missing from local).
+ *
+ * @param a First value to compare (production / expected)
+ * @param b Second value to compare (local / actual)
  * @param path Current path in the object (for tracking location of differences)
  * @param options Comparison options (maxDepth, existenceCompareFields)
  * @param currentDepth Current recursion depth (internal use)
@@ -351,13 +354,13 @@ export function findDifferences(
       if (i >= a.length) {
         differences.push({
           path: currentPath,
-          type: 'missing_key',
+          type: 'extra_key',
           actual: b[i],
         })
       } else if (i >= b.length) {
         differences.push({
           path: currentPath,
-          type: 'extra_key',
+          type: 'missing_key',
           expected: a[i],
         })
       } else {
@@ -399,13 +402,13 @@ export function findDifferences(
     if (hasKeyA && !hasKeyB) {
       differences.push({
         path: currentPath,
-        type: 'extra_key',
+        type: 'missing_key',
         expected: objA[key],
       })
     } else if (!hasKeyA && hasKeyB) {
       differences.push({
         path: currentPath,
-        type: 'missing_key',
+        type: 'extra_key',
         actual: objB[key],
       })
     } else if (hasKeyA && hasKeyB) {
@@ -448,7 +451,7 @@ export function isDeepEqual(
 /**
  * Convert an ignore path pattern to a RegExp.
  * Escapes all regex special chars first, then un-escapes our wildcard tokens:
- *   - `[*]` → matches any numeric array index (e.g. `[0]`, `[1]`)
+ *   - `[*]` → matches any array index: numeric (e.g. `[0]`, `[1]`) or named (e.g. `[name:foo]`)
  *   - `*`   → matches any characters except dots and brackets
  *   - `[name:X]` is matched literally (already escaped correctly)
  */
@@ -456,8 +459,11 @@ function ignorePatternToRegex(pathPattern: string): RegExp {
   // 1. Escape all regex special characters
   let regex = pathPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-  // 2. Un-escape and replace [*] → match only numeric array indices (matches intelligent-search)
-  regex = regex.replace(/\\\[\\\*\\\]/g, '\\[\\d+\\]')
+  // 2. Un-escape and replace [*] → match numeric or named array indices (matches intelligent-search)
+  regex = regex.replace(
+    /\\\[\\\*\\\]/g,
+    '(?:\\[\\d+\\]|\\[name:[^\\]]+\\])'
+  )
 
   // 3. Un-escape and replace remaining * → match any chars except dots/brackets
   regex = regex.replace(/\\\*/g, '[^.\\[\\]]*')
@@ -502,16 +508,27 @@ export function shouldIgnoreDifference(
 export function filterIgnoredDifferences(
   differences: ObjectDifference[],
   ignoredDifferences: IgnoredDifference[] = []
-): ObjectDifference[] {
+): { filtered: ObjectDifference[]; ignored: ObjectDifference[] } {
   if (ignoredDifferences.length === 0) {
-    return differences
+    return { filtered: differences, ignored: [] }
   }
 
-  return differences.filter((difference) => {
-    return !ignoredDifferences.some((pattern) =>
-      shouldIgnoreDifference(difference, pattern)
-    )
-  })
+  const filtered: ObjectDifference[] = []
+  const ignored: ObjectDifference[] = []
+
+  for (const difference of differences) {
+    if (
+      ignoredDifferences.some((pattern) =>
+        shouldIgnoreDifference(difference, pattern)
+      )
+    ) {
+      ignored.push(difference)
+    } else {
+      filtered.push(difference)
+    }
+  }
+
+  return { filtered, ignored }
 }
 
 /**
@@ -538,6 +555,61 @@ export type IgnoredDifference =
         | 'null_mismatch'
         | 'array_length_mismatch'
     }
+
+/** Default max length for Expected/Actual values in formatted diff output to avoid breaking console. */
+export const DEFAULT_MAX_DIFF_VALUE_LENGTH = 2000
+
+function truncateForLog(value: unknown, maxLength: number): string {
+  const s = JSON.stringify(value)
+  if (maxLength <= 0 || s.length <= maxLength) return s
+  return `${s.slice(0, maxLength)} ... (truncated, total ${s.length} chars)`
+}
+
+/**
+ * Format differences for human-readable output.
+ * Truncates large Expected/Actual values so console output doesn't break.
+ *
+ * Note: compareApiResults currently logs raw differences arrays; this helper is
+ * mainly for debugging.
+ */
+export function formatDifferences(
+  differences: ObjectDifference[],
+  ignoredCount = 0,
+  maxValueLength: number = DEFAULT_MAX_DIFF_VALUE_LENGTH
+): string {
+  const hasIgnored = ignoredCount > 0
+
+  if (differences.length === 0 && !hasIgnored) {
+    return 'No differences found'
+  }
+
+  if (differences.length === 0 && hasIgnored) {
+    return `No differences found (${ignoredCount} ignored)`
+  }
+
+  let output = `Found ${differences.length} difference(s)`
+
+  if (hasIgnored) {
+    output += ` (${ignoredCount} ignored)`
+  }
+
+  output += ':\n'
+
+  for (const diff of differences) {
+    output += `\n  Path:     ${diff.path}\n`
+    output += `  Type:     ${diff.type}\n`
+
+    if (diff.expected !== undefined) {
+      output += `  Expected: ${truncateForLog(diff.expected, maxValueLength)}\n`
+    }
+
+    if (diff.actual !== undefined) {
+      output += `  Actual:   ${truncateForLog(diff.actual, maxValueLength)}\n`
+    }
+  }
+
+  return output
+}
 
 /**
  * Options for the compareApiResults function
@@ -595,6 +667,7 @@ export async function compareApiResults<T>(
   let areEqual = false
   let differences: ObjectDifference[] = []
   let filteredDifferences: ObjectDifference[] = []
+  let ignored: ObjectDifference[] = []
 
   try {
     if (!hasError1 && !hasError2) {
@@ -603,10 +676,9 @@ export async function compareApiResults<T>(
       })
 
       differences = comparisonResult.differences
-      filteredDifferences = filterIgnoredDifferences(
-        differences,
-        ignoredDifferences
-      )
+      const result = filterIgnoredDifferences(differences, ignoredDifferences)
+      filteredDifferences = result.filtered
+      ignored = result.ignored
       areEqual = filteredDifferences.length === 0
     }
   } catch (error) {
@@ -623,7 +695,7 @@ export async function compareApiResults<T>(
       differences: filteredDifferences.slice(0, 10), // Limit to first 10 differences to avoid log overflow
       differenceCount: filteredDifferences.length,
       totalDifferences: differences.length,
-      ignoredDifferences: differences.length - filteredDifferences.length,
+      ignoredDifferences: ignored.length,
     })
   } else if (areEqual) {
     logger.info({
@@ -631,7 +703,7 @@ export async function compareApiResults<T>(
       message: `${logPrefix}: Results are equal`,
       params: JSON.stringify(options.args),
       totalDifferences: differences.length,
-      ignoredDifferences: differences.length - filteredDifferences.length,
+      ignoredDifferences: ignored.length,
     })
   }
 


### PR DESCRIPTION
#### What problem is this solving?

- Improve hte compare configs for ProductSearch, also compare requests with productOriginVtex on it.

- Start comparing PDP requests with our /v1/products endpoint. 
