### PR TITLE
Disable compare product-search shadow traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Disable compare product-search shadow traffic.
+
 ## [1.99.0] - 2026-03-30
 
 ### Changed

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -535,7 +535,7 @@ export async function fetchProductSearch(
 
       return omitRequestInfo(res)
     },
-    ctx.vtex.production ? 1 : 100,
+    ctx.vtex.production ? 0 : 100,
     ctx.vtex.logger,
     {
       logPrefix: 'ProductSearch',


### PR DESCRIPTION
#### What problem is this solving?

- Disable the shadow traffic to isolate and validate the current rollout accounts.