### PR TITLE
fix(intsch): align v1 pickup-in-point facets with API segment override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **Intelligent Search v1 (`intsch`):** `concatSelectedFacets` now normalizes `shipping/pickup-in-point-{id}` path facets to `pickup-in-point` for the attribute path (aligned with intelligent-search-api).
+- **Intelligent Search v1 (`intsch`):** When the URL includes a pickup-in-point id in the path, that id is sent as the `pickupPoint` query param and overrides the value from the segment cookie, matching search-context behavior on the API route.
+
 ## [1.100.0] - 2026-03-31
 
 ### Changed

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -226,22 +226,25 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     const authToken =
       this.context.storeUserAuthToken ?? this.context.adminUserAuthToken
 
-    return this.http.get(`/api/intelligent-search/v1/facets/${path}`, {
-      params: {
-        sc: segmentParams?.sc,
-        regionId: segmentParams?.regionId,
-        country: segmentParams?.country,
-        'zip-code': segmentParams?.['zip-code'],
-        coordinates: segmentParams?.coordinates,
-        pickupPoint: segmentParams?.pickupPoint,
-        deliveryZonesHash: segmentParams?.deliveryZonesHash,
-        pickupPointHash: segmentParams?.pickupPointHash,
-        ...params,
-        query: query && decodeQuery(query),
-        locale: this.locale ?? segmentParams?.locale,
-        bgy_leap: leap ? true : undefined,
-        ...parseState(searchState),
-      },
+    const facetsPath = `/api/intelligent-search/v1/facets/${path}`
+    const facetsParams = {
+      sc: segmentParams?.sc,
+      regionId: segmentParams?.regionId,
+      country: segmentParams?.country,
+      'zip-code': segmentParams?.['zip-code'],
+      coordinates: segmentParams?.coordinates,
+      pickupPoint: segmentParams?.pickupPoint,
+      deliveryZonesHash: segmentParams?.deliveryZonesHash,
+      pickupPointHash: segmentParams?.pickupPointHash,
+      ...params,
+      query: query && decodeQuery(query),
+      locale: this.locale ?? segmentParams?.locale,
+      bgy_leap: leap ? true : undefined,
+      ...parseState(searchState),
+    }
+
+    return this.http.get(facetsPath, {
+      params: facetsParams,
       metric: 'facets-new-v1',
       headers: {
         'x-vtex-shipping-options': shippingHeader ?? '',

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -1,3 +1,4 @@
+import type { SegmentParams } from '../utils/segment'
 import { removeDiacriticsFromURL } from '../utils/string'
 
 /**
@@ -44,13 +45,96 @@ export const convertOrderBy = (orderBy?: string | null): string => {
 const encodeSafeURI = (uri: string) => encodeURI(decodeURI(uri))
 
 /**
+ * Path URLs may encode the pickup point as `shipping/pickup-in-point-{pickupPointId}`.
+ * Intelligent Search expects `shipping/pickup-in-point` in the attribute path (same as
+ * intelligent-search-api's normalizePickupInPointShippingFacets). Values that are
+ * exactly `pickup-in-point` (no id suffix) are unchanged.
+ */
+const PICKUP_IN_POINT_SUFFIX_RE = /^pickup-in-point-(.+)$/
+
+function extractPickupPointIdFromShippingFacetValue(
+  value: string
+): string | undefined {
+  const match = PICKUP_IN_POINT_SUFFIX_RE.exec(value)
+
+  return match?.[1]
+}
+
+/**
+ * Reads `shipping/pickup-in-point-{id}` from path facets only (not segment extras).
+ * Matches intelligent-search-api searchContext: path pickup id wins over segment.
+ */
+export function extractPickupPointIdFromPathShippingFacet(
+  selectedFacetsFromPath: SelectedFacet[]
+): string | undefined {
+  const shipping = selectedFacetsFromPath.find((f) => f.key === 'shipping')
+  const rawId = shipping
+    ? extractPickupPointIdFromShippingFacetValue(shipping.value)
+    : undefined
+
+  if (rawId === undefined) {
+    return undefined
+  }
+
+  try {
+    return decodeURIComponent(rawId)
+  } catch {
+    return rawId
+  }
+}
+
+/**
+ * When the URL encodes `pickup-in-point-{id}`, that id must be sent as `pickupPoint`
+ * to intelligent-search v1 and override the segment cookie value — same as intsch
+ * searchContext merging path into shipping info.
+ */
+export function mergeSegmentParamsWithPickupFromPath(
+  segmentParams: SegmentParams | undefined,
+  selectedFacetsFromPath: SelectedFacet[]
+): SegmentParams | undefined {
+  const pathPickupId = extractPickupPointIdFromPathShippingFacet(
+    selectedFacetsFromPath
+  )
+
+  if (pathPickupId === undefined) {
+    return segmentParams
+  }
+
+  return {
+    ...(segmentParams ?? {}),
+    pickupPoint: pathPickupId,
+  }
+}
+
+function normalizePickupInPointShippingFacets(
+  selectedFacets: SelectedFacet[]
+): SelectedFacet[] {
+  return selectedFacets.map((facet) => {
+    if (facet.key !== 'shipping') {
+      return facet
+    }
+
+    const id = extractPickupPointIdFromShippingFacetValue(facet.value)
+
+    if (id === undefined) {
+      return facet
+    }
+
+    return { ...facet, value: 'pickup-in-point' }
+  })
+}
+
+/**
  * Concatenates path-selected facets with segment-derived facets, matching the
- * behavior of intelligent-search-api's concatSelectedFacets:
+ * behavior of intelligent-search-api's concatSelectedFacets, then applies the same
+ * pickup-in-point normalization used by intsch productSearch/facets:
  *
  * - The `shipping` facet from the path takes precedence: if the path already
  *   contains a `shipping` facet, segment `shipping` entries are skipped.
  * - A `shipping=ignore` value signals the user explicitly deselected a shipping
  *   filter present in the segment; when found, ALL `shipping` entries are removed.
+ * - `shipping/pickup-in-point-{id}` facet values are collapsed to `pickup-in-point`
+ *   so the attribute path matches what intelligent-search-api builds for the v2 route.
  */
 export function concatSelectedFacets(
   selectedFacets: SelectedFacet[],
@@ -69,7 +153,7 @@ export function concatSelectedFacets(
     result = result.filter((f) => f.key !== 'shipping')
   }
 
-  return result
+  return normalizePickupInPointShippingFacets(result)
 }
 
 export const buildAttributePath = (selectedFacets: SelectedFacet[]) => {

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -1,6 +1,7 @@
 import {
   buildAttributePath,
   concatSelectedFacets,
+  mergeSegmentParamsWithPickupFromPath,
 } from '../commons/compatibility-layer'
 import { extractSegmentData, getOrCreateSegment } from '../utils/segment'
 import type { FacetsInput } from '../typings/Search'
@@ -45,7 +46,10 @@ async function fetchFacetsFromIntsch(
     { ...intschArgs, query: args.fullText },
     intschPath,
     {
-      segmentParams: segmentData.segmentParams,
+      segmentParams: mergeSegmentParamsWithPickupFromPath(
+        segmentData.segmentParams,
+        selectedFacets
+      ),
       shippingHeader: shippingOptions,
     }
   )

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -2,6 +2,7 @@ import {
   buildAttributePath,
   concatSelectedFacets,
   convertOrderBy,
+  mergeSegmentParamsWithPickupFromPath,
 } from '../commons/compatibility-layer'
 import { extractSegmentData, getOrCreateSegment } from '../utils/segment'
 import {
@@ -406,7 +407,10 @@ async function fetchProductSearchFromIntsch(
     { ...intschArgs },
     buildAttributePath(allFacets),
     {
-      segmentParams: segmentData?.segmentParams,
+      segmentParams: mergeSegmentParamsWithPickupFromPath(
+        segmentData?.segmentParams,
+        selectedFacets
+      ),
       shippingHeader: shippingOptions,
     }
   )


### PR DESCRIPTION
#### What problem is this solving?

Normalize pickup-in-point shipping facets from URL paths
Path facets of the form shipping/pickup-in-point-{id} are normalized to shipping/pickup-in-point for outbound Intelligent Search requests, while the pickup id is taken from the URL (with priority over segment/query when present).
When seller-register fails, it returns the original pickupId. This change was made because we are about to migrate the accounts to use /intelligent-search/v0/pickup-point-availability/ which returns the id in the correct format

The same changes were made in https://github.com/vtex/intelligent-search-api/pull/238

#### How should this be manually tested?

[Workspace](https://dpcase1--vendemo.myvtex.com/)