### PR TITLE
Improve productSearch and facets query arguments used to call intsch and block requests without sales-channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Block requests (product, facets, productSearch) without sales-channel to intsch.
+- Improve arguments passed while making a request to intsch.
+
 ## [1.101.0] - 2026-04-08
 
 ### Changed

--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -4,8 +4,6 @@ import { ExternalClient } from '@vtex/api'
 import { parseState } from '../utils/searchState'
 import type {
   FacetsOptions,
-  ProductSearchOptions,
-  ProductSearchResult,
   FetchBannersArgs,
   IIntelligentSearchClient,
   FetchProductArgs,
@@ -15,8 +13,12 @@ import type {
   FetchBannersResponse,
   SearchSuggestionsResponse,
   TopSearchesResponse,
+  IntschFacetsParams,
+  IntschProductSearchParams,
+  ProductSearchOptions,
+  ProductSearchResult,
 } from './intsch/types'
-import type { Options, SearchResultArgs } from '../typings/Search'
+import type { SearchResultArgs } from '../typings/Search'
 
 export const isPathTraversal = (str: string) => str.indexOf('..') >= 0
 
@@ -32,21 +34,8 @@ interface AutocompleteSearchSuggestionsParams {
   query: string
 }
 
-export type FacetsArgs = {
-  query?: string
-  operator?: string
-  fuzzy?: string
-  leap?: boolean
-  tradePolicy?: number
-  searchState?: string
-  variant?: string
-  hideUnavailableItems?: boolean | null
-  removeHiddenFacets?: boolean | null
-  options?: Options
-  initialAttributes?: string
-  workspaceSearchParams?: object
-  regionId?: string | null
-}
+/** @deprecated Use IntschFacetsParams from clients/intsch/types (alias kept for compatibility). */
+export type FacetsArgs = IntschFacetsParams
 
 export const decodeQuery = (query: string) => {
   try {
@@ -123,7 +112,7 @@ export class IntelligentSearchApi
   }
 
   public async facets(
-    params: FacetsArgs,
+    params: IntschFacetsParams,
     path: string,
     options?: FacetsOptions
   ) {
@@ -154,7 +143,7 @@ export class IntelligentSearchApi
   }
 
   public async productSearch(
-    params: SearchResultArgs,
+    params: IntschProductSearchParams,
     path: string,
     options?: ProductSearchOptions
   ): Promise<ProductSearchResult> {

--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -34,14 +34,12 @@ interface AutocompleteSearchSuggestionsParams {
 
 export type FacetsArgs = {
   query?: string
-  page?: number
-  count?: number
-  sort?: string
   operator?: string
   fuzzy?: string
   leap?: boolean
   tradePolicy?: number
   searchState?: string
+  variant?: string
   hideUnavailableItems?: boolean | null
   removeHiddenFacets?: boolean | null
   options?: Options

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -172,7 +172,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     const requestPath = `/api/intelligent-search/v1/product-search/${path}`
 
     const merged = filterUndefined({
-      sc: segmentParams?.sc,
+      sc: params.salesChannel ?? segmentParams?.sc,
       regionId: params.regionId ?? segmentParams?.regionId,
       country: segmentParams?.country,
       'zip-code': segmentParams?.['zip-code'],

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -22,22 +22,15 @@ import type {
   SearchSuggestionsArgsV1,
   SearchSuggestionsResponse,
   TopSearchesResponse,
+  IntschFacetsParams,
+  IntschProductSearchParams,
 } from './types'
-import type { ProductSearchInput, SearchResultArgs } from '../../typings/Search'
-import type { FacetsArgs } from '../intelligent-search-api'
 import { decodeQuery, isPathTraversal } from '../intelligent-search-api'
 import { parseState } from '../../utils/searchState'
 import {
   filterUndefined,
   filterByAllowedIntelligentSearchQueryKeys,
 } from './utils'
-
-/** GraphQL layer passes `ProductSearchInput` fields through `SearchResultArgs`-shaped objects. */
-type ProductSearchRequestArgs = SearchResultArgs &
-  Partial<ProductSearchInput> & {
-    debugMode?: string | boolean
-    variant?: string | string[]
-  }
 
 export class Intsch extends JanusClient implements IIntelligentSearchClient {
   private locale: string | undefined
@@ -162,12 +155,11 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
   }
 
   public async productSearch(
-    params: SearchResultArgs,
+    params: IntschProductSearchParams,
     path: string,
     options?: ProductSearchOptions
   ): Promise<ProductSearchResult> {
     const { query, leap, searchState } = params
-    const p = params as ProductSearchRequestArgs
     const { segmentParams, shippingHeader } = options ?? {}
 
     if (isPathTraversal(path)) {
@@ -181,7 +173,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
 
     const merged = filterUndefined({
       sc: segmentParams?.sc,
-      regionId: p.regionId ?? segmentParams?.regionId,
+      regionId: params.regionId ?? segmentParams?.regionId,
       country: segmentParams?.country,
       'zip-code': segmentParams?.['zip-code'],
       coordinates: segmentParams?.coordinates,
@@ -194,30 +186,30 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
       campaigns: segmentParams?.campaigns,
       priceTables: segmentParams?.priceTables,
       query: query ? decodeQuery(query) : undefined,
-      sort: p.sort,
-      operator: p.operator,
-      fuzzy: p.fuzzy,
-      from: p.from ?? undefined,
-      to: p.to ?? undefined,
-      hideUnavailableItems: p.hideUnavailableItems ?? undefined,
-      initialAttributes: p.initialAttributes,
-      searchState: p.searchState,
+      sort: params.sort,
+      operator: params.operator,
+      fuzzy: params.fuzzy,
+      from: params.from ?? undefined,
+      to: params.to ?? undefined,
+      hideUnavailableItems: params.hideUnavailableItems ?? undefined,
+      initialAttributes: params.initialAttributes,
+      searchState: params.searchState,
       // Adds
-      showSponsored: p.showSponsored,
-      repeatSponsoredProducts: p.repeatSponsoredProducts,
-      advertisementPlacement: p.advertisementPlacement,
-      sponsoredCount: p.sponsoredCount,
-      allowRedirect: p.options?.allowRedirect,
+      showSponsored: params.showSponsored,
+      repeatSponsoredProducts: params.repeatSponsoredProducts,
+      advertisementPlacement: params.advertisementPlacement,
+      sponsoredCount: params.sponsoredCount,
+      allowRedirect: params.allowRedirect,
       locale: this.locale ?? segmentParams?.locale,
       bgy_leap: leap ? 'true' : undefined,
       productOriginVtex:
-        p.productOriginVtex !== undefined
-          ? String(p.productOriginVtex)
+        params.productOriginVtex !== undefined
+          ? String(params.productOriginVtex)
           : undefined,
-      simulationBehavior: p.simulationBehavior ?? undefined,
-      variant: p.variant,
+      simulationBehavior: params.simulationBehavior ?? undefined,
+      variant: params.variant,
       ...parseState(searchState),
-    } as Record<string, unknown>)
+    })
 
     const requestParams = filterByAllowedIntelligentSearchQueryKeys(merged)
 
@@ -245,7 +237,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
   }
 
   public facets(
-    params: FacetsArgs,
+    params: IntschFacetsParams,
     path: string,
     options?: FacetsOptions
   ): Promise<FacetsResponse> {

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -23,10 +23,21 @@ import type {
   SearchSuggestionsResponse,
   TopSearchesResponse,
 } from './types'
-import type { SearchResultArgs } from '../../typings/Search'
+import type { ProductSearchInput, SearchResultArgs } from '../../typings/Search'
 import type { FacetsArgs } from '../intelligent-search-api'
 import { decodeQuery, isPathTraversal } from '../intelligent-search-api'
 import { parseState } from '../../utils/searchState'
+import {
+  filterUndefined,
+  filterByAllowedIntelligentSearchQueryKeys,
+} from './utils'
+
+/** GraphQL layer passes `ProductSearchInput` fields through `SearchResultArgs`-shaped objects. */
+type ProductSearchRequestArgs = SearchResultArgs &
+  Partial<ProductSearchInput> & {
+    debugMode?: string | boolean
+    variant?: string | string[]
+  }
 
 export class Intsch extends JanusClient implements IIntelligentSearchClient {
   private locale: string | undefined
@@ -156,20 +167,21 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     options?: ProductSearchOptions
   ): Promise<ProductSearchResult> {
     const { query, leap, searchState } = params
+    const p = params as ProductSearchRequestArgs
     const { segmentParams, shippingHeader } = options ?? {}
 
     if (isPathTraversal(path)) {
       throw new Error('Malformed URL')
     }
 
-    // The admin auth token is releavant for CallCenter users when the sales channel is private.
     const authToken =
       this.context.storeUserAuthToken ?? this.context.adminUserAuthToken
 
     const requestPath = `/api/intelligent-search/v1/product-search/${path}`
-    const requestParams = {
+
+    const merged = filterUndefined({
       sc: segmentParams?.sc,
-      regionId: segmentParams?.regionId,
+      regionId: p.regionId ?? segmentParams?.regionId,
       country: segmentParams?.country,
       'zip-code': segmentParams?.['zip-code'],
       coordinates: segmentParams?.coordinates,
@@ -181,12 +193,33 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
       utmiCampaign: segmentParams?.utmiCampaign,
       campaigns: segmentParams?.campaigns,
       priceTables: segmentParams?.priceTables,
-      ...params,
-      query: query && decodeQuery(query),
+      query: query ? decodeQuery(query) : undefined,
+      sort: p.sort,
+      operator: p.operator,
+      fuzzy: p.fuzzy,
+      from: p.from ?? undefined,
+      to: p.to ?? undefined,
+      hideUnavailableItems: p.hideUnavailableItems ?? undefined,
+      initialAttributes: p.initialAttributes,
+      searchState: p.searchState,
+      // Adds
+      showSponsored: p.showSponsored,
+      repeatSponsoredProducts: p.repeatSponsoredProducts,
+      advertisementPlacement: p.advertisementPlacement,
+      sponsoredCount: p.sponsoredCount,
+      allowRedirect: p.options?.allowRedirect,
       locale: this.locale ?? segmentParams?.locale,
-      bgy_leap: leap ? true : undefined,
+      bgy_leap: leap ? 'true' : undefined,
+      productOriginVtex:
+        p.productOriginVtex !== undefined
+          ? String(p.productOriginVtex)
+          : undefined,
+      simulationBehavior: p.simulationBehavior ?? undefined,
+      variant: p.variant,
       ...parseState(searchState),
-    }
+    } as Record<string, unknown>)
+
+    const requestParams = filterByAllowedIntelligentSearchQueryKeys(merged)
 
     const requestHeaders: Record<string, string | string[]> = {
       'x-vtex-shipping-options': shippingHeader ?? '',
@@ -227,21 +260,30 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
       this.context.storeUserAuthToken ?? this.context.adminUserAuthToken
 
     const facetsPath = `/api/intelligent-search/v1/facets/${path}`
-    const facetsParams = {
+
+    const merged = filterUndefined({
       sc: segmentParams?.sc,
-      regionId: segmentParams?.regionId,
+      regionId: params.regionId ?? segmentParams?.regionId,
       country: segmentParams?.country,
       'zip-code': segmentParams?.['zip-code'],
       coordinates: segmentParams?.coordinates,
       pickupPoint: segmentParams?.pickupPoint,
       deliveryZonesHash: segmentParams?.deliveryZonesHash,
       pickupPointHash: segmentParams?.pickupPointHash,
-      ...params,
-      query: query && decodeQuery(query),
+      query: query ? decodeQuery(query) : undefined,
+      operator: params.operator,
+      fuzzy: params.fuzzy,
+      hideUnavailableItems: params.hideUnavailableItems ?? undefined,
+      initialAttributes: params.initialAttributes,
+      searchState: params.searchState,
+      allowRedirect: params.options?.allowRedirect,
       locale: this.locale ?? segmentParams?.locale,
-      bgy_leap: leap ? true : undefined,
+      bgy_leap: leap ? 'true' : undefined,
+      variant: params.variant,
       ...parseState(searchState),
-    }
+    } as Record<string, unknown>)
+
+    const facetsParams = filterByAllowedIntelligentSearchQueryKeys(merged)
 
     return this.http.get(facetsPath, {
       params: facetsParams,

--- a/node/clients/intsch/types.ts
+++ b/node/clients/intsch/types.ts
@@ -1,6 +1,40 @@
-import type { SearchResultArgs } from '../../typings/Search'
-import type { FacetsArgs } from '../intelligent-search-api'
+import type {
+  AdvertisementOptions,
+  FacetsInput,
+  Options,
+  ProductSearchInput,
+} from '../../typings/Search'
 import type { SegmentParams } from '../../utils/segment'
+
+/**
+ * HTTP params for facets after stripping `selectedFacets` and mapping `fullText`
+ * to `query` (see {@link fetchFacets}).
+ */
+export type IntschFacetsParams = Omit<FacetsInput, 'selectedFacets'> & {
+  query?: string
+  options?: Options
+  leap?: boolean
+  regionId?: string | null
+}
+
+/**
+ * HTTP params for product search after merging advertisement options, `options`,
+ * and dropping `selectedFacets` / nested `advertisementOptions` (see
+ * {@link fetchProductSearch}).
+ */
+export type IntschProductSearchParams = Omit<
+  ProductSearchInput,
+  'selectedFacets' | 'advertisementOptions' | 'options'
+> &
+  AdvertisementOptions & {
+    query?: string
+    sort?: string
+    allowRedirect?: boolean
+    regionId?: string | null
+    leap?: boolean
+    /** Used by intelligent-search / Biggy legacy client; not exposed on `productSearch` GraphQL. */
+    initialAttributes?: string
+  }
 
 export type AutocompleteSuggestionsArgs = {
   query: string
@@ -149,12 +183,12 @@ export interface IIntelligentSearchClient {
   fetchCorrectionV1(args: CorrectionArgsV1): Promise<CorrectionResponse>
   fetchBannersV1(args: FetchBannersArgsV1): Promise<FetchBannersResponse>
   productSearch(
-    args: SearchResultArgs,
+    args: IntschProductSearchParams,
     path: string,
     options?: ProductSearchOptions
   ): Promise<ProductSearchResult>
   facets(
-    params: FacetsArgs,
+    params: IntschFacetsParams,
     path: string,
     options?: FacetsOptions
   ): Promise<FacetsResponse>

--- a/node/clients/intsch/utils.ts
+++ b/node/clients/intsch/utils.ts
@@ -1,0 +1,102 @@
+/**
+ * Drops keys whose value is `undefined` from a plain object.
+ * Keeps `null`, `false`, and `0` (needed for valid API semantics).
+ */
+export function filterUndefined<T extends Record<string, unknown>>(
+  obj: T
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined)
+  ) as Partial<T>
+}
+
+/**
+ * Query parameter names accepted by intelligent-search API `GetQuery`
+ * (`intelligent-search-api` crate, `product_search_api.rs`).
+ * Used to strip unknown keys (e.g. from GraphQL args spread or `searchState` JSON).
+ *
+ * Includes serde `rename` query keys (`biggy-search`, `show-invisible-items`, `zip-code`)
+ * and common aliases (`q`, `p`, …).
+ */
+export const INTELLIGENT_SEARCH_PRODUCT_QUERY_KEYS = new Set<string>([
+  'an',
+  'query',
+  'q',
+  'page',
+  'p',
+  'count',
+  'c',
+  'sort',
+  's',
+  'operator',
+  'o',
+  'fuzzy',
+  'f',
+  'from',
+  'to',
+  'biggy-search',
+  'location',
+  'image',
+  'hideUnavailableItems',
+  'locale',
+  'letorEnabled',
+  'letorModel',
+  'merchRulesEnabled',
+  'priorityBoostsEnabled',
+  'secondaryBoostsEnabled',
+  'privateSellersFiltersEnabled',
+  'regionalizationTradePolicy',
+  'regionalizationV2',
+  'regionalizationBehavior',
+  'regionId',
+  'allowRedirect',
+  'bgy_leap',
+  'initialAttributes',
+  'searchState',
+  'term',
+  'letorWindowSize',
+  'v',
+  'dynamicRule',
+  'show-invisible-items',
+  'metaId',
+  'seller',
+  'deliveryChannel',
+  'deliveryZonesHash',
+  'pickupPointHash',
+  'pickupPoint',
+  'timeZone',
+  'semanticProducts',
+  'semanticModel',
+  'semanticCandidates',
+  'semanticRatio',
+  'semanticSimilarity',
+  'semanticBinning',
+  'semanticBinningPower',
+  'semanticFusionFunction',
+  'origin',
+  'sc',
+  'advertisementPlacement',
+  'showSponsored',
+  'sponsoredCount',
+  'repeatSponsoredProducts',
+  'productOriginVtex',
+  'zip-code',
+  'coordinates',
+  'country',
+  'utmSource',
+  'utmCampaign',
+  'utmiCampaign',
+  'campaigns',
+  'priceTables',
+  'simulationBehavior',
+  'variant',
+])
+
+export function filterByAllowedIntelligentSearchQueryKeys(
+  obj: Record<string, unknown>,
+  allowedKeys: Set<string> = INTELLIGENT_SEARCH_PRODUCT_QUERY_KEYS
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key]) => allowedKeys.has(key))
+  )
+}

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -78,10 +78,10 @@ const isLegacySearchFormat = ({
   query,
   map,
 }: {
-  query: string
+  query?: string
   map?: string
 }) => {
-  if (!map) {
+  if (!map || !query) {
     return false
   }
 
@@ -134,10 +134,19 @@ const inputToSearchCrossSelling = {
  * @param {QueryArgs} args
  * @returns
  */
-const getCompatibilityArgsFromSelectedFacets = async (
+/** Args that can be normalized via `map` / `query` / `selectedFacets` compatibility helpers. */
+type SelectedFacetsCompatibilityArgs = {
+  query?: string
+  map?: string
+  selectedFacets?: SelectedFacet[]
+}
+
+const getCompatibilityArgsFromSelectedFacets = async <
+  T extends SelectedFacetsCompatibilityArgs
+>(
   ctx: Context,
-  args: QueryArgs
-) => {
+  args: T
+): Promise<T> => {
   const { selectedFacets, query } = args
 
   if (!selectedFacets || selectedFacets.length === 0 || !query) {
@@ -154,7 +163,7 @@ const getCompatibilityArgsFromSelectedFacets = async (
     return args
   }
 
-  const compatibilityArgs = (await getCompatibilityArgs(ctx, args)) as QueryArgs
+  const compatibilityArgs = await getCompatibilityArgs(ctx, args as QueryArgs)
 
   const mapSegments = compatibilityArgs.map!.split(MAP_VALUES_SEP)
   const querySegments = compatibilityArgs.query!.split(PATH_SEPARATOR)
@@ -347,21 +356,22 @@ export const queries = {
       itemsReturned,
     }
   },
-  facets: async (_: any, args: FacetsInput, ctx: any) => {
+  facets: async (_: unknown, args: FacetsInput, ctx: Context) => {
     const [shippingOptions, facets] = getShippingOptionsFromSelectedFacets(
       args.selectedFacets
     )
 
     args.selectedFacets = facets
 
-    args = (await getCompatibilityArgsFromSelectedFacets(
-      ctx,
-      args
-    )) as FacetsInput
+    args = await getCompatibilityArgsFromSelectedFacets(ctx, args)
 
     const { selectedFacets } = args
 
-    return fetchFacets(ctx, { args, selectedFacets, shippingOptions })
+    return fetchFacets(ctx, {
+      args,
+      selectedFacets: selectedFacets ?? [],
+      shippingOptions,
+    })
   },
 
   product: async (_: any, rawArgs: ProductArgs, ctx: Context) => {
@@ -425,17 +435,14 @@ export const queries = {
     )
   },
 
-  productSearch: async (_: any, args: ProductSearchInput, ctx: any) => {
+  productSearch: async (_: unknown, args: ProductSearchInput, ctx: Context) => {
     const [shippingOptions, facets] = getShippingOptionsFromSelectedFacets(
       args.selectedFacets
     )
 
     args.selectedFacets = facets
 
-    args = (await getCompatibilityArgsFromSelectedFacets(
-      ctx,
-      args
-    )) as ProductSearchInput
+    args = await getCompatibilityArgsFromSelectedFacets(ctx, args)
 
     if (!validMapAndQuery(args.query, args.map)) {
       ctx.vtex.logger.warn({
@@ -447,7 +454,7 @@ export const queries = {
 
     const { selectedFacets } = args
 
-    return fetchProductSearch(ctx, args, selectedFacets, shippingOptions)
+    return fetchProductSearch(ctx, args, selectedFacets ?? [], shippingOptions)
   },
 
   sponsoredProducts: async (_: any, args: ProductSearchInput, ctx: any) => {
@@ -457,10 +464,7 @@ export const queries = {
 
     args.selectedFacets = facets
 
-    args = (await getCompatibilityArgsFromSelectedFacets(
-      ctx,
-      args
-    )) as ProductSearchInput
+    args = await getCompatibilityArgsFromSelectedFacets(ctx, args)
 
     if (!validMapAndQuery(args.query, args.map)) {
       ctx.vtex.logger.warn({
@@ -485,7 +489,7 @@ export const queries = {
 
     const result = await intelligentSearchApi.sponsoredProducts(
       { ...biggyArgs },
-      buildAttributePath(selectedFacets),
+      buildAttributePath(selectedFacets ?? []),
       shippingOptions
     )
 
@@ -515,8 +519,7 @@ export const queries = {
       productId = product!.productId
     }
 
-    const groupByProduct =
-      groupBy === CrossSellingGroupByInput.PRODUCT ? true : false
+    const groupByProduct = groupBy === CrossSellingGroupByInput.PRODUCT
 
     if (shouldUseNewPDPEndpoint) {
       ctx.translated = true

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -66,11 +66,8 @@ export async function fetchFacets(ctx: Context, options: FetchFacetsOptions) {
 
   const segmentData = extractSegmentData(segment)
 
-  if (segment && !segment.channel) {
-    ctx.vtex.logger.warn({
-      message: 'Segment is missing channel on facets',
-      segment,
-    })
+  if (segment && segment.channel === null) {
+    throw new Error('Couldnt detect a sales channel')
   }
 
   return fetchFacetsFromIntsch(ctx, options, segmentData)

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -3,6 +3,7 @@ import {
   concatSelectedFacets,
   mergeSegmentParamsWithPickupFromPath,
 } from '../commons/compatibility-layer'
+import type { IntschFacetsParams } from '../clients/intsch/types'
 import { extractSegmentData, getOrCreateSegment } from '../utils/segment'
 import type { FacetsInput } from '../typings/Search'
 
@@ -28,12 +29,12 @@ async function fetchFacetsFromIntsch(
     clients: { intsch },
   } = ctx
 
-  const intschArgs: { [key: string]: any } = {
-    ...args,
-  }
+  const { selectedFacets: _omitSelectedFacetsForPath, ...facetFieldArgs } = args
 
-  // unnecessary field. It's is an object and breaks the @vtex/api cache
-  delete intschArgs.selectedFacets
+  const intschArgs: IntschFacetsParams = {
+    ...facetFieldArgs,
+    query: args.fullText,
+  }
 
   const allFacets = concatSelectedFacets(
     selectedFacets,
@@ -42,17 +43,13 @@ async function fetchFacetsFromIntsch(
 
   const intschPath = buildAttributePath(allFacets)
 
-  const result: any = await intsch.facets(
-    { ...intschArgs, query: args.fullText },
-    intschPath,
-    {
-      segmentParams: mergeSegmentParamsWithPickupFromPath(
-        segmentData.segmentParams,
-        selectedFacets
-      ),
-      shippingHeader: shippingOptions,
-    }
-  )
+  const result: any = await intsch.facets(intschArgs, intschPath, {
+    segmentParams: mergeSegmentParamsWithPickupFromPath(
+      segmentData.segmentParams,
+      selectedFacets
+    ),
+    shippingHeader: shippingOptions,
+  })
 
   if (ctx.vtex.tenant) {
     ctx.translated = result.translated

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -66,7 +66,15 @@ async function fetchFacetsFromIntsch(
  */
 export async function fetchFacets(ctx: Context, options: FetchFacetsOptions) {
   const segment = await getOrCreateSegment(ctx)
+
   const segmentData = extractSegmentData(segment)
+
+  if (segment && !segment.channel) {
+    ctx.vtex.logger.warn({
+      message: 'Segment is missing channel on facets',
+      segment,
+    })
+  }
 
   return fetchFacetsFromIntsch(ctx, options, segmentData)
 }

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -118,6 +118,14 @@ export async function fetchProduct(
 
   // Get and create segment before calling intsch
   const segment = await getOrCreateSegment(ctx)
+
+  if (segment && !segment.channel) {
+    ctx.vtex.logger.warn({
+      message: 'Segment is missing channel on product',
+      segment,
+    })
+  }
+
   const segmentData = extractSegmentData(segment)
 
   // Check if current account should skip comparison and use intsch directly

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -119,11 +119,8 @@ export async function fetchProduct(
   // Get and create segment before calling intsch
   const segment = await getOrCreateSegment(ctx)
 
-  if (segment && !segment.channel) {
-    ctx.vtex.logger.warn({
-      message: 'Segment is missing channel on product',
-      segment,
-    })
+  if (segment && segment.channel === null) {
+    throw new Error('Couldnt detect a sales channel')
   }
 
   const segmentData = extractSegmentData(segment)

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -10,9 +10,15 @@ import {
   type ExistenceComparePattern,
   type IgnoredDifference,
 } from '../utils/compareResults'
+import type {
+  AdvertisementOptions,
+  ProductSearchInput,
+} from '../typings/Search'
+import type {
+  IntschProductSearchParams,
+  ProductSearchRequestInfo,
+} from '../clients/intsch/types'
 import { fetchAppSettings } from './settings'
-import type { ProductSearchInput } from '../typings/Search'
-import type { ProductSearchRequestInfo } from '../clients/intsch/types'
 
 type SegmentData = ReturnType<typeof extractSegmentData>
 
@@ -318,10 +324,31 @@ function omitRequestInfo<T extends { requestInfo: ProductSearchRequestInfo }>(
   return rest as Omit<T, 'requestInfo'>
 }
 
-const defaultAdvertisementOptions = {
+const defaultAdvertisementOptions: AdvertisementOptions = {
   showSponsored: false,
   sponsoredCount: 3,
   repeatSponsoredProducts: true,
+}
+
+function buildProductSearchRequestParams(
+  args: ProductSearchInput,
+  fullText: string | undefined,
+  advertisementOptionsResolved: AdvertisementOptions
+): IntschProductSearchParams {
+  const {
+    selectedFacets: _omitSelectedFacets,
+    advertisementOptions: _omitAdvertisementOptions,
+    options: searchOptions,
+    ...restSearchInput
+  } = args
+
+  return {
+    ...advertisementOptionsResolved,
+    ...restSearchInput,
+    query: fullText,
+    sort: convertOrderBy(args.orderBy),
+    ...(searchOptions ?? {}),
+  }
 }
 
 /**
@@ -335,19 +362,15 @@ async function fetchProductSearchFromBiggy(
   shippingOptions?: string[]
 ) {
   const { intelligentSearchApi } = ctx.clients
-  const { fullText, advertisementOptions = defaultAdvertisementOptions } = args
+  const { fullText } = args
+  const advertisementOptionsResolved =
+    args.advertisementOptions ?? defaultAdvertisementOptions
 
-  const biggyArgs: { [key: string]: any } = {
-    ...advertisementOptions,
-    ...args,
-    query: fullText,
-    sort: convertOrderBy(args.orderBy),
-    ...args.options,
-  }
-
-  // unnecessary field. It's is an object and breaks the @vtex/api cache
-  delete biggyArgs.selectedFacets
-  delete biggyArgs.advertisementOptions
+  const biggyArgs = buildProductSearchRequestParams(
+    args,
+    fullText,
+    advertisementOptionsResolved
+  )
 
   const raw = await intelligentSearchApi.productSearch(
     { ...biggyArgs },
@@ -385,19 +408,16 @@ async function fetchProductSearchFromIntsch(
   segmentData?: SegmentData
 ) {
   const { intsch } = ctx.clients
-  const { fullText, advertisementOptions = defaultAdvertisementOptions } = args
+  const { fullText } = args
 
-  const intschArgs: { [key: string]: any } = {
-    ...advertisementOptions,
-    ...args,
-    query: fullText,
-    sort: convertOrderBy(args.orderBy),
-    ...args.options,
-  }
+  const advertisementOptionsResolved =
+    args.advertisementOptions ?? defaultAdvertisementOptions
 
-  // unnecessary field. It's is an object and breaks the @vtex/api cache
-  delete intschArgs.selectedFacets
-  delete intschArgs.advertisementOptions
+  const intschArgs = buildProductSearchRequestParams(
+    args,
+    fullText,
+    advertisementOptionsResolved
+  )
 
   const allFacets = segmentData
     ? concatSelectedFacets(selectedFacets, segmentData.extraFacets)

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -483,11 +483,8 @@ export async function fetchProductSearch(
   const segment = await getOrCreateSegment(ctx)
   const segmentData = extractSegmentData(segment)
 
-  if (segment && !segment.channel) {
-    ctx.vtex.logger.warn({
-      message: 'Segment is missing channel on product search',
-      segment,
-    })
+  if (segment && segment.channel === null && !args.salesChannel) {
+    throw new Error('Couldnt detect a sales channel')
   }
 
   if (Math.random() < 0.1) {

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -463,6 +463,13 @@ export async function fetchProductSearch(
   const segment = await getOrCreateSegment(ctx)
   const segmentData = extractSegmentData(segment)
 
+  if (segment && !segment.channel) {
+    ctx.vtex.logger.warn({
+      message: 'Segment is missing channel on product search',
+      segment,
+    })
+  }
+
   if (Math.random() < 0.1) {
     const logMethod = shouldUseNewPLPEndpoint ? 'info' : 'warn'
 

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -18,8 +18,6 @@ export type IndexingType = 'API' | 'XML'
 export interface SearchResultArgs extends AdvertisementOptions {
   attributePath?: string
   query?: string
-  page?: number
-  count?: number
   sort?: string
   operator?: string
   fuzzy?: string

--- a/node/typings/Search.ts
+++ b/node/typings/Search.ts
@@ -15,11 +15,22 @@ export type SegmentData = {
 
 export type IndexingType = 'API' | 'XML'
 
+export type SearchOperator = 'and' | 'or'
+
+export type SimulationBehavior =
+  | 'default'
+  | 'only1P'
+  | 'skip'
+  | 'async'
+  | 'regionalize1p'
+
+export type CategoryTreeBehavior = 'default' | 'show' | 'hide'
+
 export interface SearchResultArgs extends AdvertisementOptions {
   attributePath?: string
   query?: string
   sort?: string
-  operator?: string
+  operator?: SearchOperator
   fuzzy?: string
   leap?: boolean
   tradePolicy?: number
@@ -51,7 +62,7 @@ export interface SuggestionProductsArgs {
   segment?: SegmentData
   indexingType?: IndexingType
   productOriginVtex: boolean
-  simulationBehavior: 'skip' | 'default' | 'only1P' | null
+  simulationBehavior: SimulationBehavior | null
   hideUnavailableItems?: boolean | null
   regionId?: string
   workspaceSearchParams?: object
@@ -62,9 +73,10 @@ export interface SuggestionProductsArgs {
   advertisementOptions: AdvertisementOptions
 }
 
-interface SelectedFacet {
-  value: string
+/** Facet chosen in the storefront / GraphQL (`SelectedFacetInput`). */
+export interface SelectedFacet {
   key: string
+  value: string
 }
 
 export interface Options {
@@ -78,37 +90,53 @@ export interface AdvertisementOptions {
   advertisementPlacement?: string
 }
 
+/** Arguments for the `facets` GraphQL query (see vtex.search-graphql schema). */
 export interface FacetsInput {
-  map: string
-  selectedFacets: SelectedFacet[]
-  fullText: string
-  query: string
+  query?: string
+  fullText?: string
+  map?: string
+  selectedFacets?: SelectedFacet[]
+  hideUnavailableItems?: boolean
+  removeHiddenFacets?: boolean
+  behavior?: string
+  operator?: SearchOperator
+  fuzzy?: string
   searchState?: string
-  removeHiddenFacets: boolean
-  hideUnavailableItems: boolean
+  // from?: number this shouldn't be used
+  // to?: number this shouldn't be used
+  categoryTreeBehavior?: CategoryTreeBehavior
   initialAttributes?: string
-  categoryTreeBehavior: 'default' | 'show' | 'hide'
+  variant?: string
 }
 
 export interface ProductsInput extends SearchArgs {
   advertisementOptions?: AdvertisementOptions
 }
 
+/** Arguments for the `productSearch` GraphQL query (see vtex.search-graphql schema). */
 export interface ProductSearchInput {
-  query: string
-  from: number
-  to: number
-  selectedFacets: SelectedFacet[]
-  fullText: string
-  fuzzy: string
-  operator: string
-  orderBy: string
-  productOriginVtex: boolean
-  searchState?: string
-  simulationBehavior: 'skip' | 'default' | null
-  hideUnavailableItems: boolean
+  query?: string
+  fullText?: string
   map?: string
+  selectedFacets?: SelectedFacet[]
+  category?: string
+  specificationFilters?: string[]
+  priceRange?: string
+  collection?: string
+  salesChannel?: string
+  orderBy?: string
+  from?: number
+  to?: number
+  hideUnavailableItems?: boolean
+  simulationBehavior?: SimulationBehavior
+  productOriginVtex?: boolean
+  operator?: SearchOperator
+  fuzzy?: string
+  searchState?: string
   options?: Options
+  variant?: string
+  /** @deprecated Prefer `advertisementOptions`. */
   showSponsored?: boolean
   advertisementOptions?: AdvertisementOptions
+  origin?: string
 }


### PR DESCRIPTION
 - Improve typing system using the search-graphl current schema as base model
 - Compared the arguments passed with our current query args on intsch to filter out the irrelevant ones...
 - Block requests without sales-channel, since they will fail in the intsch regardless
 