### PR TITLE
Fix salesChannel forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.102.1] - 2026-05-06
+### Fixed
+
+- SalesChannel forwarding while calling the intsch. 
+
+## [1.102.1] - 2026-05-06 [YANKED]
 
 ### Fixed
 
 - Removed that blocked requests without sales-channel.
 
-## [1.102.0] - 2026-05-06
+## [1.102.0] - 2026-05-06 [YANKED]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - SalesChannel forwarding while calling the intsch. 
 
+### Changed
+
+- Updated search-graphl version.
+
 ## [1.102.1] - 2026-05-06 [YANKED]
 
 ### Fixed

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -28,7 +28,7 @@ import type {
 import { decodeQuery, isPathTraversal } from '../intelligent-search-api'
 import { parseState } from '../../utils/searchState'
 import {
-  filterUndefined,
+  filterUndefinedNonNull,
   filterByAllowedIntelligentSearchQueryKeys,
 } from './utils'
 
@@ -171,8 +171,8 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
 
     const requestPath = `/api/intelligent-search/v1/product-search/${path}`
 
-    const merged = filterUndefined({
-      sc: params.salesChannel ?? segmentParams?.sc,
+    const merged = filterUndefinedNonNull({
+      sc: params.salesChannel !== '' ? params.salesChannel : segmentParams?.sc,
       regionId: params.regionId ?? segmentParams?.regionId,
       country: segmentParams?.country,
       'zip-code': segmentParams?.['zip-code'],
@@ -253,7 +253,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
 
     const facetsPath = `/api/intelligent-search/v1/facets/${path}`
 
-    const merged = filterUndefined({
+    const merged = filterUndefinedNonNull({
       sc: segmentParams?.sc,
       regionId: params.regionId ?? segmentParams?.regionId,
       country: segmentParams?.country,

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -172,7 +172,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     const requestPath = `/api/intelligent-search/v1/product-search/${path}`
 
     const merged = filterUndefinedNonNull({
-      sc: params.salesChannel !== '' ? params.salesChannel : segmentParams?.sc,
+      sc: params.salesChannel ? params.salesChannel : segmentParams?.sc,
       regionId: params.regionId ?? segmentParams?.regionId,
       country: segmentParams?.country,
       'zip-code': segmentParams?.['zip-code'],

--- a/node/clients/intsch/utils.ts
+++ b/node/clients/intsch/utils.ts
@@ -1,12 +1,12 @@
 /**
  * Drops keys whose value is `undefined` from a plain object.
- * Keeps `null`, `false`, and `0` (needed for valid API semantics).
+ * Keeps `false`, '' and `0` (needed for valid API semantics).
  */
-export function filterUndefined<T extends Record<string, unknown>>(
+export function filterUndefinedNonNull<T extends Record<string, unknown>>(
   obj: T
 ): Partial<T> {
   return Object.fromEntries(
-    Object.entries(obj).filter(([, v]) => v !== undefined)
+    Object.entries(obj).filter(([, v]) => v !== undefined && v !== null)
   ) as Partial<T>
 }
 

--- a/node/package.json
+++ b/node/package.json
@@ -14,7 +14,7 @@
     "qs": "^6.6.0",
     "ramda": "^0.27.1",
     "slugify": "^1.6.4",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.65.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.69.4/public"
   },
   "devDependencies": {
     "@types/camelcase": "^4.1.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4397,9 +4397,9 @@ vary@^1.1.2:
   version "1.53.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.53.4/public/@types/vtex.rewriter#6348993efde4106196bca60fd40dba00b3a354b6"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.65.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.69.4/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.65.0/public#fa3f6f4118ed92b27724643f493666c0c9f7d451"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.69.4/public#c48776a188c1d69e51bb307a0459268412b283bd"
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
#### What problem is this solving?

- The previous versions had issues with the sales-channel discovery/parsing. The main problem is that the params.salesChannel is always passed with '' which was winning over the segment