### PR TITLE
feat: add vtex.search-session as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `vtex.search-session` as an app dependency.
+
 ## [1.104.0] - 2026-05-25
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
     "vtex.search-graphql": "0.x",
     "vtex.rewriter": "1.x",
     "vtex.sae-analytics": "2.x",
-    "vtex.intelligent-search-api": "0.x"
+    "vtex.intelligent-search-api": "0.x",
+    "vtex.search-session": "0.x"
   },
   "settingsSchema": {
     "title": "Intelligent Search Resolver",


### PR DESCRIPTION
## Summary

- Add `vtex.search-session` (`0.x`) as an app dependency in `manifest.json`.
