### PR TITLE
Add enableHybridSearch app setting for Semantic Search demo workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `enableHybridSearch` app setting: when enabled, sends `semanticRatio` on `intsch` product-search requests to activate semantic ranking. `semanticModel` and the rest of the backend's `isSemanticEnabled()` inputs must already be configured on the account's `storeSearchSettings` — `semanticRatio` is the only one not set there. Only applies when `shouldUseNewPLPEndpoint` is also enabled; has no effect on the legacy Biggy search path. Intended for demo/test accounts linked to a workspace running this version.
+
 ## [1.104.1] - 2026-07-10
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,11 @@
         "title": "Feature flag to use the new PLP endpoint",
         "type": "boolean",
         "default": false
+      },
+      "enableHybridSearch": {
+        "title": "Enable Hybrid Search. Sends semanticRatio on product-search requests to activate semantic ranking (requires storeSearchSettings to already be configured on the account).",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/node/clients/intsch/index.test.ts
+++ b/node/clients/intsch/index.test.ts
@@ -1,0 +1,46 @@
+import type { IOContext } from '@vtex/api'
+import { Intsch } from './index'
+
+function createTestClient(): Intsch {
+  const ctx = {
+    account: 'testaccount',
+    workspace: 'master',
+    authToken: 'test-token',
+    production: true,
+    region: 'aws-us-east-1',
+    requestId: 'req-1',
+    operationId: 'op-1',
+  } as unknown as IOContext
+
+  const client = new Intsch(ctx)
+
+  ;(client as unknown as { http: unknown }).http = {
+    get: jest.fn().mockResolvedValue({ products: [] }),
+  }
+
+  return client
+}
+
+describe('Intsch#productSearch semantic params', () => {
+  it('forwards semanticRatio when set', async () => {
+    const client = createTestClient()
+
+    await client.productSearch({ semanticRatio: 0.5 } as any, 'some/path')
+
+    const httpGet = (client as any).http.get as jest.Mock
+    const [, requestConfig] = httpGet.mock.calls[0]
+
+    expect(requestConfig.params).toMatchObject({ semanticRatio: 0.5 })
+  })
+
+  it('omits semanticRatio when not provided', async () => {
+    const client = createTestClient()
+
+    await client.productSearch({} as any, 'some/path')
+
+    const httpGet = (client as any).http.get as jest.Mock
+    const [, requestConfig] = httpGet.mock.calls[0]
+
+    expect(requestConfig.params).not.toHaveProperty('semanticRatio')
+  })
+})

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -208,6 +208,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
           : undefined,
       simulationBehavior: params.simulationBehavior ?? undefined,
       variant: params.variant,
+      semanticRatio: params.semanticRatio,
       ...parseState(searchState),
     })
 

--- a/node/clients/intsch/types.ts
+++ b/node/clients/intsch/types.ts
@@ -34,6 +34,16 @@ export type IntschProductSearchParams = Omit<
     leap?: boolean
     /** Used by intelligent-search / Biggy legacy client; not exposed on `productSearch` GraphQL. */
     initialAttributes?: string
+    /**
+     * Semantic ranking blend ratio. `semanticModel` and the rest of the
+     * `isSemanticEnabled()` inputs (similarity, binning, products,
+     * candidates, fusion function) must already be configured on the
+     * account's storeSearchSettings — semanticModel is required there
+     * regardless for indexing, so setting it here would do nothing.
+     * semanticRatio is the one field NOT set on storeSearchSettings, so
+     * sending it is what actually activates semantic ranking.
+     */
+    semanticRatio?: number
   }
 
 export type AutocompleteSuggestionsArgs = {

--- a/node/services/productSearch.test.ts
+++ b/node/services/productSearch.test.ts
@@ -265,4 +265,68 @@ describe('fetchProductSearch service', () => {
       { shippingHeader: undefined }
     )
   })
+
+  it('sends semanticRatio to intsch when enableHybridSearch setting is true', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: true,
+        enableHybridSearch: true,
+      },
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.clients.intsch.productSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ semanticRatio: 0.5 }),
+      expect.any(String),
+      expect.any(Object)
+    )
+  })
+
+  it('does not send semanticRatio to intsch when enableHybridSearch setting is false', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: true,
+        enableHybridSearch: false,
+      },
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    const [callArgs] = (ctx.clients.intsch.productSearch as jest.Mock).mock
+      .calls[0]
+
+    expect(callArgs).not.toHaveProperty('semanticRatio')
+  })
+
+  it('never sends semanticRatio to the legacy Biggy client even when enableHybridSearch is true', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: false,
+        enableHybridSearch: true,
+      },
+      intelligentSearchApiSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    const [callArgs] = (ctx.clients.intelligentSearchApi
+      .productSearch as jest.Mock).mock.calls[0]
+
+    expect(callArgs).not.toHaveProperty('semanticRatio')
+  })
 })

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -20,6 +20,7 @@ import type {
   ProductSearchRequestInfo,
 } from '../clients/intsch/types'
 import { fetchAppSettings } from './settings'
+import { buildSemanticSearchParams } from '../utils/semanticSearch'
 
 type SegmentData = ReturnType<typeof extractSegmentData>
 
@@ -334,7 +335,8 @@ const defaultAdvertisementOptions: AdvertisementOptions = {
 function buildProductSearchRequestParams(
   args: ProductSearchInput,
   fullText: string | undefined,
-  advertisementOptionsResolved: AdvertisementOptions
+  advertisementOptionsResolved: AdvertisementOptions,
+  semanticParams: Partial<IntschProductSearchParams> = {}
 ): IntschProductSearchParams {
   const {
     selectedFacets: _omitSelectedFacets,
@@ -349,6 +351,7 @@ function buildProductSearchRequestParams(
     query: fullText,
     sort: convertOrderBy(args.orderBy),
     ...(searchOptions ?? {}),
+    ...semanticParams,
   }
 }
 
@@ -412,7 +415,8 @@ async function fetchProductSearchFromIntsch(
   args: ProductSearchInput,
   selectedFacets: SelectedFacet[],
   shippingOptions?: string[],
-  segmentData?: SegmentData
+  segmentData?: SegmentData,
+  enableHybridSearch = false
 ) {
   const { intsch } = ctx.clients
   const { fullText } = args
@@ -423,7 +427,8 @@ async function fetchProductSearchFromIntsch(
   const intschArgs = buildProductSearchRequestParams(
     args,
     fullText,
-    advertisementOptionsResolved
+    advertisementOptionsResolved,
+    buildSemanticSearchParams(enableHybridSearch)
   )
 
   const finalArgs = applyHideUnavailableItemsDefaultForDP(
@@ -491,7 +496,8 @@ export async function fetchProductSearch(
   selectedFacets: SelectedFacet[],
   shippingOptions?: string[]
 ) {
-  const { shouldUseNewPLPEndpoint } = await fetchAppSettings(ctx)
+  const { shouldUseNewPLPEndpoint, enableHybridSearch } =
+    await fetchAppSettings(ctx)
   const segment = await getOrCreateSegment(ctx)
   const segmentData = extractSegmentData(segment)
 
@@ -517,7 +523,8 @@ export async function fetchProductSearch(
       args,
       selectedFacets,
       shippingOptions,
-      segmentData
+      segmentData,
+      enableHybridSearch
     )
 
     logSponsoredProducts(ctx, result)
@@ -567,7 +574,8 @@ export async function fetchProductSearch(
         args,
         selectedFacets,
         shippingOptions,
-        segmentData
+        segmentData,
+        enableHybridSearch
       )
 
       logArgs.intschCurl = buildCurl(account, 'myvtex.com', {

--- a/node/services/settings.test.ts
+++ b/node/services/settings.test.ts
@@ -1,0 +1,43 @@
+import { fetchAppSettings } from './settings'
+import { createContext } from '../mocks/contextFactory'
+
+describe('fetchAppSettings', () => {
+  it('returns enableHybridSearch from app settings when set', async () => {
+    const ctx = createContext({
+      appSettings: {
+        shouldUseNewPDPEndpoint: false,
+        shouldUseNewPLPEndpoint: true,
+        enableHybridSearch: true,
+      },
+    })
+
+    const settings = await fetchAppSettings(ctx)
+
+    expect(settings.enableHybridSearch).toBe(true)
+  })
+
+  it('defaults enableHybridSearch to false when not set', async () => {
+    const ctx = createContext({
+      appSettings: {
+        shouldUseNewPDPEndpoint: false,
+        shouldUseNewPLPEndpoint: false,
+      },
+    })
+
+    const settings = await fetchAppSettings(ctx)
+
+    expect(settings.enableHybridSearch).toBe(false)
+  })
+
+  it('defaults enableHybridSearch to false when getAppSettings throws', async () => {
+    const ctx = createContext({})
+
+    ;(ctx as any).clients.apps.getAppSettings = jest
+      .fn()
+      .mockRejectedValue(new Error('boom'))
+
+    const settings = await fetchAppSettings(ctx)
+
+    expect(settings.enableHybridSearch).toBe(false)
+  })
+})

--- a/node/services/settings.ts
+++ b/node/services/settings.ts
@@ -1,6 +1,7 @@
 type AppSettings = {
   shouldUseNewPDPEndpoint: boolean
   shouldUseNewPLPEndpoint: boolean
+  enableHybridSearch: boolean
 }
 
 const FORCE_NEW_PLP_HEADER = 'x-vtex-force-new-plp-endpoint'
@@ -15,12 +16,16 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
   const forceNewPDP = ctx.get(FORCE_NEW_PDP_HEADER) === 'true'
 
   try {
-    const { shouldUseNewPDPEndpoint, shouldUseNewPLPEndpoint }: AppSettings =
-      await apps.getAppSettings('vtex.search-resolver@1.x')
+    const {
+      shouldUseNewPDPEndpoint,
+      shouldUseNewPLPEndpoint,
+      enableHybridSearch,
+    }: AppSettings = await apps.getAppSettings('vtex.search-resolver@1.x')
 
     return {
       shouldUseNewPDPEndpoint: forceNewPDP || shouldUseNewPDPEndpoint,
       shouldUseNewPLPEndpoint: forceNewPLP || shouldUseNewPLPEndpoint,
+      enableHybridSearch: enableHybridSearch ?? false,
     }
   } catch (error) {
     ctx.vtex.logger.error({
@@ -31,6 +36,7 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
     return {
       shouldUseNewPDPEndpoint: forceNewPDP,
       shouldUseNewPLPEndpoint: forceNewPLP,
+      enableHybridSearch: false,
     }
   }
 }

--- a/node/utils/semanticSearch.test.ts
+++ b/node/utils/semanticSearch.test.ts
@@ -1,0 +1,13 @@
+import { buildSemanticSearchParams } from './semanticSearch'
+
+describe('buildSemanticSearchParams', () => {
+  it('returns an empty object when hybrid search is disabled', () => {
+    expect(buildSemanticSearchParams(false)).toEqual({})
+  })
+
+  it('returns { semanticRatio } when hybrid search is enabled', () => {
+    expect(buildSemanticSearchParams(true)).toEqual({
+      semanticRatio: 0.5,
+    })
+  })
+})

--- a/node/utils/semanticSearch.ts
+++ b/node/utils/semanticSearch.ts
@@ -1,0 +1,25 @@
+export type SemanticSearchParams = {
+  semanticRatio?: number
+}
+
+/**
+ * Blend ratio sent when hybrid search is enabled. `semanticModel` and the
+ * rest of the backend's `isSemanticEnabled()` inputs (similarity, binning,
+ * products, candidates, fusion function) must already be configured on the
+ * account's storeSearchSettings — semanticModel is required there regardless
+ * for indexing, so search-resolver sending it would do nothing. semanticRatio
+ * is the one field NOT set on storeSearchSettings, so sending it is what
+ * actually activates semantic ranking.
+ */
+const SEMANTIC_RATIO = 0.5
+
+/**
+ * Builds the semantic-search query param subset sent to the intsch client.
+ * Returns `{}` when hybrid search is disabled; otherwise returns
+ * `{ semanticRatio }`.
+ */
+export function buildSemanticSearchParams(
+  enableHybridSearch: boolean
+): SemanticSearchParams {
+  return enableHybridSearch ? { semanticRatio: SEMANTIC_RATIO } : {}
+}


### PR DESCRIPTION
## Summary
- Adds a per-account `enableHybridSearch` app setting so a linked demo workspace can enable Semantic Search ranking on product-search requests, without a real production A/B test.
- Scoped to product-search only (gated by `shouldUseNewPLPEndpoint`); the legacy Biggy path never receives the new query param.

## Test plan
- [x] `yarn test` — all suites passing
- [x] `yarn lint` — clean, no TypeScript errors
- [x] Operational: link a workspace on a demo account, enable the setting, and diff product ranking for the same query

🤖 Generated with [Claude Code](https://claude.com/claude-code)