### PR TITLE
Add priceToken pass-through resolver on Offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `priceToken` resolver on the `Offer` type: passes through the signed price token (Pricing Fallback) from `commertialOffer.PriceToken` when present, `null` otherwise. Requires `vtex.search-graphql` with the matching `priceToken` field on `Offer`.
+
 ## [1.105.0] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `priceToken` resolver on the `Offer` type: passes through the signed price token (Pricing Fallback) from `commertialOffer.PriceToken` when present, `null` otherwise. Requires `vtex.search-graphql` with the matching `priceToken` field on `Offer`.
+- `priceToken` resolver on the `Offer` type: passes through the signed price token (Pricing Fallback) from `commertialOffer.PriceToken` when present, `null` otherwise. Requires `vtex.search-graphql@0.72.0` or later, which introduces the matching `priceToken` field on `Offer`.
 
 ## [1.105.0] - 2026-07-15
 

--- a/node/package.json
+++ b/node/package.json
@@ -14,7 +14,7 @@
     "qs": "^6.6.0",
     "ramda": "^0.27.1",
     "slugify": "^1.6.4",
-    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.71.0/public"
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.72.0/public"
   },
   "devDependencies": {
     "@types/camelcase": "^4.1.0",

--- a/node/resolvers/search/offer.test.ts
+++ b/node/resolvers/search/offer.test.ts
@@ -1,0 +1,19 @@
+import { resolvers } from './offer'
+
+describe('tests related to Offer type resolvers', () => {
+  describe('priceToken resolver', () => {
+    test('returns the token when present on commertialOffer', () => {
+      const offer = {
+        PriceToken: 'signed-jwt-token',
+      } as any
+
+      expect(resolvers.Offer.priceToken(offer)).toBe('signed-jwt-token')
+    })
+
+    test('returns null when absent (legacy search client or Pricing Fallback disabled)', () => {
+      const offer = {} as any
+
+      expect(resolvers.Offer.priceToken(offer)).toBeNull()
+    })
+  })
+})

--- a/node/resolvers/search/offer.ts
+++ b/node/resolvers/search/offer.ts
@@ -146,6 +146,9 @@ export const resolvers = {
       }
 
       return offer.Tax / offer.Price
-    }
+    },
+    priceToken: (offer: CommertialOffer) => {
+      return offer.PriceToken ?? null
+    },
   },
 }

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -245,6 +245,9 @@ interface CommertialOffer {
   // Supports the Intelligent Search API which
   // uses the same name from the simulation
   discountHighlights: any[]
+  // Signed price token (Pricing Fallback). Only present when intsch has
+  // price signing enabled for the account; absent on the legacy search client.
+  PriceToken?: string
 }
 
 interface Seller {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -4397,9 +4397,9 @@ vary@^1.1.2:
   version "1.53.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.rewriter@1.53.4/public/@types/vtex.rewriter#6348993efde4106196bca60fd40dba00b3a354b6"
 
-"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.71.0/public":
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.72.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.71.0/public#f488ce72c40461615a42d20aedbd3f9244e61210"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.72.0/public#7bc95c94800b8f09ce1e0b0cf4417bef8bca6e7b"
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
## Summary
- Adds `priceToken` resolver on the `Offer` GraphQL type, passing through `commertialOffer.PriceToken` (a signed price token used for Pricing Fallback) or `null` when absent.
- Only `intsch`/`intelligentSearchApi` responses currently populate this field; the legacy `search` client never returns it, so the resolver naturally resolves to `null` there — no new settings or feature flags needed.
- Adds `PriceToken?: string` to the `CommertialOffer` typing in `node/typings/Catalog.ts`.

## Coordination
- Requires `vtex.search-graphql@0.72.0` or later, which added the matching `priceToken: String` field on `Offer`. Already released.
- Related: [TIS-802](https://vtex-dev.atlassian.net/browse/TIS-802)

## Test plan
- [x] `yarn test` — 191 passed, 3 skipped, 194 total, all suites green
- [x] `yarn lint` (`tsc --noEmit`) — clean
- [x] New `node/resolvers/search/offer.test.ts` covers both the token-present and token-absent cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TIS-802]: https://vtex-dev.atlassian.net/browse/TIS-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ