### PR TITLE
feat(intsch): gate dpPreview behind enableDeliveryPromisePreview flag (DPT-67)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,7 @@
         "default": false
       },
       "enableDeliveryPromisePreview": {
-        "title": "Send dpPreview=true on Intelligent Search product-search and facets requests, activating the Delivery Promises QA preview without flipping deliveryPromisesEnabled.",
+        "title": "Enable Delivery Promises Preview for Intelligent Search",
         "type": "boolean",
         "default": false
       }

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,11 @@
         "title": "Enable Hybrid Search. Sends semanticRatio on product-search requests to activate semantic ranking (requires storeSearchSettings to already be configured on the account).",
         "type": "boolean",
         "default": false
+      },
+      "enableDeliveryPromisePreview": {
+        "title": "Send dpPreview=true on Intelligent Search product-search and facets requests, activating the Delivery Promises QA preview without flipping deliveryPromisesEnabled.",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -30,7 +30,6 @@ import { parseState } from '../../utils/searchState'
 import {
   filterUndefinedNonNull,
   filterByAllowedIntelligentSearchQueryKeys,
-  shouldInjectDPPreview,
 } from './utils'
 
 export class Intsch extends JanusClient implements IIntelligentSearchClient {
@@ -172,9 +171,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
 
     const requestPath = `/api/intelligent-search/v1/product-search/${path}`
 
-    const dpPreview = shouldInjectDPPreview(this.context.production)
-      ? 'true'
-      : undefined
+    const dpPreview = params.dpPreview ? 'true' : undefined
 
     const merged = filterUndefinedNonNull({
       sc: params.salesChannel ? params.salesChannel : segmentParams?.sc,
@@ -260,9 +257,7 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
 
     const facetsPath = `/api/intelligent-search/v1/facets/${path}`
 
-    const dpPreview = shouldInjectDPPreview(this.context.production)
-      ? 'true'
-      : undefined
+    const dpPreview = params.dpPreview ? 'true' : undefined
 
     const merged = filterUndefinedNonNull({
       sc: segmentParams?.sc,

--- a/node/clients/intsch/types.ts
+++ b/node/clients/intsch/types.ts
@@ -15,6 +15,8 @@ export type IntschFacetsParams = Omit<FacetsInput, 'selectedFacets'> & {
   options?: Options
   leap?: boolean
   regionId?: string | null
+  /** Delivery Promises QA preview. Gated by the `enableDeliveryPromisePreview` app setting. */
+  dpPreview?: boolean
 }
 
 /**
@@ -44,6 +46,8 @@ export type IntschProductSearchParams = Omit<
      * sending it is what actually activates semantic ranking.
      */
     semanticRatio?: number
+    /** Delivery Promises QA preview. Gated by the `enableDeliveryPromisePreview` app setting. */
+    dpPreview?: boolean
   }
 
 export type AutocompleteSuggestionsArgs = {

--- a/node/clients/intsch/utils.test.ts
+++ b/node/clients/intsch/utils.test.ts
@@ -1,7 +1,6 @@
 import {
   filterByAllowedIntelligentSearchQueryKeys,
   filterUndefinedNonNull,
-  shouldInjectDPPreview,
 } from './utils'
 
 describe('filterUndefinedNonNull', () => {
@@ -36,22 +35,5 @@ describe('filterByAllowedIntelligentSearchQueryKeys', () => {
       ignored: 'value',
     })
     expect(result).toEqual({ dpPreview: 'true' })
-  })
-})
-
-/**
- * DPT-67: production-driven QA mode. The storefront emits `dpPreview=true` on
- * non-production workspaces so the IS API activates the Delivery Promises code
- * path without the store having to flip `deliveryPromisesEnabled`. Production
- * traffic must never carry the param — including named workspaces promoted to
- * production, not just `master`.
- */
-describe('shouldInjectDPPreview', () => {
-  it('returns true for a non-production (QA/dev) workspace', () => {
-    expect(shouldInjectDPPreview(false)).toBe(true)
-  })
-
-  it('returns false for a production workspace', () => {
-    expect(shouldInjectDPPreview(true)).toBe(false)
   })
 })

--- a/node/clients/intsch/utils.ts
+++ b/node/clients/intsch/utils.ts
@@ -93,17 +93,6 @@ export const INTELLIGENT_SEARCH_PRODUCT_QUERY_KEYS = new Set<string>([
   'dpPreview',
 ])
 
-/**
- * Whether the IS API call should carry `dpPreview=true`. Non-production
- * workspaces are treated as QA and get DP activated end-to-end without the
- * store flipping `deliveryPromisesEnabled`. Production workspaces never carry
- * the param — including named workspaces promoted to production, not just
- * `master`.
- */
-export function shouldInjectDPPreview(production: boolean): boolean {
-  return !production
-}
-
 export function filterByAllowedIntelligentSearchQueryKeys(
   obj: Record<string, unknown>,
   allowedKeys: Set<string> = INTELLIGENT_SEARCH_PRODUCT_QUERY_KEYS

--- a/node/services/facets.test.ts
+++ b/node/services/facets.test.ts
@@ -99,6 +99,47 @@ describe('fetchFacets service', () => {
     )
   })
 
+  it('sends dpPreview=true to intsch when enableDeliveryPromisePreview is on', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        enableDeliveryPromisePreview: true,
+      },
+      intschSettings: {
+        facets: mockFacetsResponse,
+      },
+    })
+
+    await fetchFacets(ctx, {
+      args: mockArgs,
+      selectedFacets: mockSelectedFacets,
+    })
+
+    expect(ctx.clients.intsch.facets).toHaveBeenCalledWith(
+      expect.objectContaining({ dpPreview: true }),
+      expect.any(String),
+      expect.any(Object)
+    )
+  })
+
+  it('does not send dpPreview when enableDeliveryPromisePreview is off', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      intschSettings: {
+        facets: mockFacetsResponse,
+      },
+    })
+
+    await fetchFacets(ctx, {
+      args: mockArgs,
+      selectedFacets: mockSelectedFacets,
+    })
+
+    const [callArgs] = (ctx.clients.intsch.facets as jest.Mock).mock.calls[0]
+
+    expect(callArgs.dpPreview).toBe(false)
+  })
+
   it('should set translated flag in context when tenant is present', async () => {
     const ctx = createContext({
       accountName: 'testaccount',

--- a/node/services/facets.ts
+++ b/node/services/facets.ts
@@ -7,6 +7,7 @@ import type { IntschFacetsParams } from '../clients/intsch/types'
 import { extractSegmentData, getOrCreateSegment } from '../utils/segment'
 import { applyHideUnavailableItemsDefaultForDP } from '../utils/hideUnavailableItems'
 import type { FacetsInput } from '../typings/Search'
+import { fetchAppSettings } from './settings'
 
 type SegmentData = ReturnType<typeof extractSegmentData>
 
@@ -23,7 +24,8 @@ type FetchFacetsOptions = {
 async function fetchFacetsFromIntsch(
   ctx: Context,
   options: FetchFacetsOptions,
-  segmentData: SegmentData
+  segmentData: SegmentData,
+  enableDeliveryPromisePreview = false
 ) {
   const { args, selectedFacets, shippingOptions } = options
   const {
@@ -35,6 +37,7 @@ async function fetchFacetsFromIntsch(
   const intschArgs: IntschFacetsParams = {
     ...facetFieldArgs,
     query: args.fullText,
+    dpPreview: enableDeliveryPromisePreview,
   }
 
   const finalArgs = applyHideUnavailableItemsDefaultForDP(
@@ -72,6 +75,7 @@ async function fetchFacetsFromIntsch(
  * Facets service that extracts facets fetching logic and implements comparison or flag-based routing
  */
 export async function fetchFacets(ctx: Context, options: FetchFacetsOptions) {
+  const { enableDeliveryPromisePreview } = await fetchAppSettings(ctx)
   const segment = await getOrCreateSegment(ctx)
 
   const segmentData = extractSegmentData(segment)
@@ -82,5 +86,10 @@ export async function fetchFacets(ctx: Context, options: FetchFacetsOptions) {
     })
   }
 
-  return fetchFacetsFromIntsch(ctx, options, segmentData)
+  return fetchFacetsFromIntsch(
+    ctx,
+    options,
+    segmentData,
+    enableDeliveryPromisePreview
+  )
 }

--- a/node/services/productSearch.test.ts
+++ b/node/services/productSearch.test.ts
@@ -365,4 +365,44 @@ describe('fetchProductSearch service', () => {
 
     expect(callArgs).not.toHaveProperty('semanticRatio')
   })
+
+  it('sends dpPreview=true to intsch when enableDeliveryPromisePreview is on', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: true,
+        enableDeliveryPromisePreview: true,
+      },
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    expect(ctx.clients.intsch.productSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ dpPreview: true }),
+      expect.any(String),
+      expect.any(Object)
+    )
+  })
+
+  it('does not send dpPreview when enableDeliveryPromisePreview is off', async () => {
+    const ctx = createContext({
+      accountName: 'testaccount',
+      appSettings: {
+        shouldUseNewPLPEndpoint: true,
+      },
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
+      },
+    })
+
+    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
+
+    const [callArgs] = (ctx.clients.intsch.productSearch as jest.Mock).mock
+      .calls[0]
+
+    expect(callArgs.dpPreview).toBe(false)
+  })
 })

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -119,7 +119,8 @@ async function fetchProductSearchFromIntsch(
   selectedFacets: SelectedFacet[],
   shippingOptions?: string[],
   segmentData?: SegmentData,
-  enableHybridSearch = false
+  enableHybridSearch = false,
+  enableDeliveryPromisePreview = false
 ) {
   const { intsch } = ctx.clients
   const { fullText } = args
@@ -131,7 +132,10 @@ async function fetchProductSearchFromIntsch(
     args,
     fullText,
     advertisementOptionsResolved,
-    buildSemanticSearchParams(enableHybridSearch)
+    {
+      ...buildSemanticSearchParams(enableHybridSearch),
+      dpPreview: enableDeliveryPromisePreview,
+    }
   )
 
   const finalArgs = applyHideUnavailableItemsDefaultForDP(
@@ -200,8 +204,11 @@ export async function fetchProductSearch(
   selectedFacets: SelectedFacet[],
   shippingOptions?: string[]
 ) {
-  const { shouldUseNewPLPEndpoint, enableHybridSearch } =
-    await fetchAppSettings(ctx)
+  const {
+    shouldUseNewPLPEndpoint,
+    enableHybridSearch,
+    enableDeliveryPromisePreview,
+  } = await fetchAppSettings(ctx)
   const segment = await getOrCreateSegment(ctx)
   const segmentData = extractSegmentData(segment)
 
@@ -218,7 +225,8 @@ export async function fetchProductSearch(
       selectedFacets,
       shippingOptions,
       segmentData,
-      enableHybridSearch
+      enableHybridSearch,
+      enableDeliveryPromisePreview
     )
 
     logSponsoredProducts(ctx, result)

--- a/node/services/settings.ts
+++ b/node/services/settings.ts
@@ -2,6 +2,7 @@ type AppSettings = {
   shouldUseNewPDPEndpoint: boolean
   shouldUseNewPLPEndpoint: boolean
   enableHybridSearch: boolean
+  enableDeliveryPromisePreview: boolean
 }
 
 const FORCE_NEW_PLP_HEADER = 'x-vtex-force-new-plp-endpoint'
@@ -20,12 +21,14 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
       shouldUseNewPDPEndpoint,
       shouldUseNewPLPEndpoint,
       enableHybridSearch,
+      enableDeliveryPromisePreview,
     }: AppSettings = await apps.getAppSettings('vtex.search-resolver@1.x')
 
     return {
       shouldUseNewPDPEndpoint: forceNewPDP || shouldUseNewPDPEndpoint,
       shouldUseNewPLPEndpoint: forceNewPLP || (shouldUseNewPLPEndpoint ?? true),
       enableHybridSearch: enableHybridSearch ?? false,
+      enableDeliveryPromisePreview: enableDeliveryPromisePreview ?? false,
     }
   } catch (error) {
     ctx.vtex.logger.error({
@@ -39,6 +42,7 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
       // client is no longer the safe fallback when settings can't be read.
       shouldUseNewPLPEndpoint: true,
       enableHybridSearch: false,
+      enableDeliveryPromisePreview: false,
     }
   }
 }


### PR DESCRIPTION
## What

Commit 25bc04e added `dpPreview=true` automatically on all non-production workspaces (DPT-67). That workspace-as-a-rule behavior was a mistake — it activated the Delivery Promises preview on every QA/dev workspace with no way to opt out.

This PR replaces the rule with a per-account app setting `enableDeliveryPromisePreview` (default `false`), matching the existing `manifest.json` flags. The flag alone decides whether `dpPreview=true` is sent — the `context.production` gate is gone.

## How

- **`manifest.json`** — new `enableDeliveryPromisePreview` boolean setting, default `false`.
- **`settings.ts`** — flag added to `AppSettings` type, success read (`?? false`), and catch fallback.
- **PLP path** (`productSearch.ts`) — flag threaded into `fetchProductSearchFromIntsch`, landing as the `dpPreview` param on `intsch.productSearch`.
- **Facets path** (`facets.ts`) — `fetchFacets` now reads app settings and threads the flag into `intsch.facets`.
- **intsch client** (`index.ts`) — both methods read `params.dpPreview`; the `shouldInjectDPPreview(context.production)` gate is removed.
- **types.ts** — `dpPreview?: boolean` on `IntschProductSearchParams` and `IntschFacetsParams`.
- **utils.ts** — `shouldInjectDPPreview` helper deleted; `dpPreview` kept in the IS query-key allowlist.

Mirrors the established `enableHybridSearch` → `semanticRatio` threading pattern.

## Behavior change

`dpPreview=true` is no longer emitted just because a workspace is non-production. It is emitted only when an account enables `enableDeliveryPromisePreview`, and then in any workspace (production included).

## Testing

- `tsc --noEmit` clean.
- Jest: 211 passing (added on/off wiring coverage for both product-search and facets paths; removed the obsolete `shouldInjectDPPreview` unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)