### PR TITLE
Remove shouldUseNewPLPEndpoint and make PLP intsch-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ It is the resolver layer of the Intelligent Search stack. The GraphQL schema (th
 
 | File | What it defines |
 |---|---|
-| `manifest.json` | App identity (`vtex.search-resolver@1.102.2`), builders (`node`, `docs`), dependencies (`vtex.messages`, `vtex.catalog-api-proxy`, `vtex.search-graphql`, `vtex.rewriter`, `vtex.sae-analytics`, `vtex.intelligent-search-api`), `settingsSchema` (`slugifyLinks`, `shouldUseNewPDPEndpoint`, `shouldUseNewPLPEndpoint`), policies (`vtex.messages:translate-messages`, `vtex.catalog-api-proxy:catalog-proxy`/`authenticated-catalog-proxy`, …) |
+| `manifest.json` | App identity (`vtex.search-resolver@1.102.2`), builders (`node`, `docs`), dependencies (`vtex.messages`, `vtex.catalog-api-proxy`, `vtex.search-graphql`, `vtex.rewriter`, `vtex.sae-analytics`, `vtex.intelligent-search-api`), `settingsSchema` (`slugifyLinks`, `shouldUseNewPDPEndpoint`, `enableHybridSearch`, `enableDeliveryPromisePreview`), policies (`vtex.messages:translate-messages`, `vtex.catalog-api-proxy:catalog-proxy`/`authenticated-catalog-proxy`, …) |
 | `node/service.json` | Runtime: `nodejs` stack, 2048MB memory, 80 shared CPU @ 95%, ttl 30s, timeout 12s, 30–250 replicas, 2 workers. **No `routes`** — this service is a pure GraphQL plugin mounted by `vtex.search-graphql` via the schema. |
 | `node/index.ts` | Service composition, LRU caches (`segmentCache: 1000`, `searchCache: 3000`, `messagesCache: 3000`, `appsCache: 1500`, `intschCache: 3000`), per-client timeouts (default 3s, `search: 6s`, `intelligentSearchApi: 9s`), `metrics.trackCache` instrumentation. Imports `schema` from `vtex.search-graphql/graphql`. |
 | `node/resolvers/index.ts` | Composes `searchFieldResolvers`, `benefitsFieldResolvers`, `searchQueries`, `statsQueries`. **This is the resolver entry point.** |
@@ -69,13 +69,12 @@ GraphQL request ─► vtex.graphql-server / @vtex/api Service runtime
 
 ### Endpoint switching
 
-Three settings control the new-vs-legacy migration:
-
 | Setting | Default | Effect |
 |---|---|---|
 | `slugifyLinks` | `false` | When `true`, links use `slugify` instead of the default catalog slug |
 | `shouldUseNewPDPEndpoint` | `false` | When `true`, PDP queries hit the new IS endpoint via `intelligentSearchApi` / `intsch`; otherwise the legacy `search` client |
-| `shouldUseNewPLPEndpoint` | `true` | Same for PLP — per-account override still available to roll back to legacy |
+
+PLP (`productSearch` / `products` / `productSuggestions` / `facets`) always uses `intsch`. There is no `shouldUseNewPLPEndpoint` toggle.
 
 These are **per-account app settings**, not FeatureHub flags. Toggling them changes which client takes the hot path.
 
@@ -162,7 +161,7 @@ Part of the **`is-io-specs`** multi-repo workspace. SpecKit artifacts (`.specify
 - **`@gocommerce/utils`** branches behavior for go-commerce stores. Always go through the existing helpers; do not gate by account name.
 
 ### Endpoint switching
-- **`shouldUseNewPDPEndpoint` / `shouldUseNewPLPEndpoint`** are per-account flags. Adding a new flag requires updating `manifest.json:settingsSchema` and the corresponding read sites.
+- **`shouldUseNewPDPEndpoint`** is a per-account flag. Adding a new flag requires updating `manifest.json:settingsSchema` and the corresponding read sites. PLP product search/facets are intsch-only (no PLP flag).
 - **Never** call `intelligentSearchApi` and the legacy `search` client for the same field — pick one based on settings, or you'll double-bill and double-cache.
 
 ### Observability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `shouldUseNewPLPEndpoint` app setting and `x-vtex-force-new-plp-endpoint` header. `productSearch`, `products`, `productSuggestions`, and `facets` always use `intsch`; there is no runtime path back to `vtex.intelligent-search-api` for these routes. `sponsoredProducts` is unchanged.
+
 ## [1.110.0] - 2026-08-14
 
 ### Added

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -56,13 +56,16 @@ export const resolvers = {
 
 ## Settings (per-account behavior)
 
-`manifest.json:settingsSchema` exposes three boolean flags:
+Relevant `manifest.json:settingsSchema` flags:
 
 | Flag | Default | Effect |
 |---|---|---|
 | `slugifyLinks` | `false` | When `true`, links are slugified via `slugify`; when `false`, the default catalog slug is used. |
 | `shouldUseNewPDPEndpoint` | `false` | Routes PDP queries through the new IS endpoint instead of the legacy search backend. |
-| `shouldUseNewPLPEndpoint` | `true` | Same as above, for PLP queries. |
+| `enableHybridSearch` | `false` | When `true`, sends `semanticRatio` on `intsch` product-search requests. |
+| `enableDeliveryPromisePreview` | `false` | When `true`, sends `dpPreview` on `intsch` product-search/facets requests. |
+
+PLP (`productSearch` / `products` / `productSuggestions` / `facets`) always uses `intsch`; there is no PLP app-setting toggle.
 
 These are read from VTEX **app settings** at runtime, not from FeatureHub.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -15,7 +15,7 @@ Domain vocabulary used in `vtex.search-resolver`.
 | **Assembly Option** | Product configuration extension (gifts, customizations). Resolved by `node/resolvers/search/assemblyOption.ts`. |
 | **Rewriter** | `vtex.rewriter` app — maps URL slugs to entities (product, brand, category). Used here to resolve canonical paths. |
 | **Intelligent Search API (`intelligentSearchApi`, `intsch`)** | Two clients pointing to the IS backend. `intelligentSearchApi` (in `node/clients/intelligent-search-api.ts`) talks to `vtex.intelligent-search-api`; `intsch` (in `node/clients/intsch/`) talks directly to the IS platform service for lower-level endpoints. |
-| **Search (`search` client)** | Legacy VTEX search backend. Coexists with Intelligent Search during the migration controlled by `shouldUseNewPDPEndpoint` and `shouldUseNewPLPEndpoint` settings. |
-| **Feature Flag (app settings)** | Three boolean flags in `manifest.json:settingsSchema`: `slugifyLinks`, `shouldUseNewPDPEndpoint`, `shouldUseNewPLPEndpoint`. Read at runtime from app settings — not from FeatureHub. |
+| **Search (`search` client)** | Legacy VTEX search backend. Still used for some paths (e.g. PDP when `shouldUseNewPDPEndpoint` is off); PLP product search/facets always use `intsch`. |
+| **Feature Flag (app settings)** | Boolean flags in `manifest.json:settingsSchema`, including `slugifyLinks`, `shouldUseNewPDPEndpoint`, `enableHybridSearch`, `enableDeliveryPromisePreview`. Read at runtime from app settings — not from FeatureHub. |
 | **`@gocommerce/utils`** | Compatibility helpers for go-commerce store accounts. Imported in `node/utils/` and resolvers that branch by store type. |
 | **`vtex.search-tests`** | External Cypress test repo run on PR via `vtex/action-io-app-cypress` against the `biggy` account. |

--- a/manifest.json
+++ b/manifest.json
@@ -32,11 +32,6 @@
         "type": "boolean",
         "default": false
       },
-      "shouldUseNewPLPEndpoint": {
-        "title": "Feature flag to use the new PLP endpoint",
-        "type": "boolean",
-        "default": true
-      },
       "enableHybridSearch": {
         "title": "Enable Hybrid Search. Sends semanticRatio on product-search requests to activate semantic ranking (requires storeSearchSettings to already be configured on the account).",
         "type": "boolean",

--- a/node/services/productSearch.test.ts
+++ b/node/services/productSearch.test.ts
@@ -29,12 +29,9 @@ describe('fetchProductSearch service', () => {
     jest.clearAllMocks()
   })
 
-  it('should default hideUnavailableItems=true when DP is enabled and hideUnavailableItems is undefined (intsch path)', async () => {
+  it('should default hideUnavailableItems=true when DP is enabled and hideUnavailableItems is undefined', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: true,
-      },
       intschSettings: {
         productSearch: mockProductSearchResponse,
       },
@@ -55,42 +52,13 @@ describe('fetchProductSearch service', () => {
     )
   })
 
-  it('should default hideUnavailableItems=true when DP is enabled and hideUnavailableItems is undefined (biggy path)', async () => {
+  it('should always use intsch and never call intelligentSearchApi', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
+      intschSettings: {
+        productSearch: mockProductSearchResponse,
       },
       intelligentSearchApiSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-      intschSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-      segment: {
-        facets: 'deliveryZonesHash=dzHash',
-      } as any,
-    })
-
-    const { hideUnavailableItems: _ignored, ...argsWithoutHide } =
-      mockArgs as any
-
-    await fetchProductSearch(ctx, argsWithoutHide, mockSelectedFacets)
-
-    expect(ctx.clients.intelligentSearchApi.productSearch).toHaveBeenCalledWith(
-      expect.objectContaining({ hideUnavailableItems: true }),
-      expect.any(String),
-      expect.objectContaining({ shippingHeader: undefined })
-    )
-  })
-
-  it('should use intsch when shouldUseNewPLPEndpoint is true', async () => {
-    const ctx = createContext({
-      accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: true,
-      },
-      intschSettings: {
         productSearch: mockProductSearchResponse,
       },
     })
@@ -107,57 +75,9 @@ describe('fetchProductSearch service', () => {
     })
   })
 
-  it('should call only the legacy client, never intsch, when shouldUseNewPLPEndpoint is false', async () => {
+  it('should not log the legacy-path migration warning', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-      intschSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-    })
-
-    const result = await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
-
-    expect(
-      ctx.clients.intelligentSearchApi.productSearch
-    ).toHaveBeenCalledTimes(1)
-    expect(ctx.clients.intsch.productSearch).not.toHaveBeenCalled()
-    expect(result).toEqual({
-      searchState: undefined,
-      ...mockProductSearchResponse,
-    })
-  })
-
-  it('should log a warning when a PLP request is served without intsch', async () => {
-    const ctx = createContext({
-      accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-    })
-
-    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
-
-    expect(ctx.vtex.logger.warn).toHaveBeenCalledWith({
-      message: 'ProductSearch migration: intsch not used as final response',
-      account: 'testaccount',
-    })
-  })
-
-  it('should not log the "intsch not used" warning when shouldUseNewPLPEndpoint is true', async () => {
-    const ctx = createContext({
-      accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: true,
-      },
       intschSettings: {
         productSearch: mockProductSearchResponse,
       },
@@ -175,10 +95,7 @@ describe('fetchProductSearch service', () => {
   it('should handle shipping options correctly', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
+      intschSettings: {
         productSearch: mockProductSearchResponse,
       },
     })
@@ -187,20 +104,17 @@ describe('fetchProductSearch service', () => {
 
     await fetchProductSearch(ctx, mockArgs, mockSelectedFacets, shippingOptions)
 
-    expect(ctx.clients.intelligentSearchApi.productSearch).toHaveBeenCalledWith(
+    expect(ctx.clients.intsch.productSearch).toHaveBeenCalledWith(
       expect.objectContaining({ query: 'test query' }),
       expect.any(String),
-      { shippingHeader: shippingOptions }
+      expect.objectContaining({ shippingHeader: shippingOptions })
     )
   })
 
   it('should preserve searchState in response', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
+      intschSettings: {
         productSearch: mockProductSearchResponse,
       },
     })
@@ -227,10 +141,7 @@ describe('fetchProductSearch service', () => {
 
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
+      intschSettings: {
         productSearch: mockResponseWithTranslated,
       },
       tenantLocale: 'en-US',
@@ -249,10 +160,7 @@ describe('fetchProductSearch service', () => {
 
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
+      intschSettings: {
         productSearch: mockResponseWithTranslated,
       },
       tenantLocale: 'en-US',
@@ -271,10 +179,7 @@ describe('fetchProductSearch service', () => {
   it('should include advertisement options in the request', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-      },
-      intelligentSearchApiSettings: {
+      intschSettings: {
         productSearch: mockProductSearchResponse,
       },
     })
@@ -290,14 +195,14 @@ describe('fetchProductSearch service', () => {
 
     await fetchProductSearch(ctx, argsWithAdOptions, mockSelectedFacets)
 
-    expect(ctx.clients.intelligentSearchApi.productSearch).toHaveBeenCalledWith(
+    expect(ctx.clients.intsch.productSearch).toHaveBeenCalledWith(
       expect.objectContaining({
         showSponsored: true,
         sponsoredCount: 5,
         repeatSponsoredProducts: false,
       }),
       expect.any(String),
-      { shippingHeader: undefined }
+      expect.any(Object)
     )
   })
 
@@ -305,7 +210,6 @@ describe('fetchProductSearch service', () => {
     const ctx = createContext({
       accountName: 'testaccount',
       appSettings: {
-        shouldUseNewPLPEndpoint: true,
         enableHybridSearch: true,
       },
       intschSettings: {
@@ -326,7 +230,6 @@ describe('fetchProductSearch service', () => {
     const ctx = createContext({
       accountName: 'testaccount',
       appSettings: {
-        shouldUseNewPLPEndpoint: true,
         enableHybridSearch: false,
       },
       intschSettings: {
@@ -342,35 +245,10 @@ describe('fetchProductSearch service', () => {
     expect(callArgs).not.toHaveProperty('semanticRatio')
   })
 
-  it('never sends semanticRatio to the legacy Biggy client even when enableHybridSearch is true', async () => {
-    const ctx = createContext({
-      accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: false,
-        enableHybridSearch: true,
-      },
-      intelligentSearchApiSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-      intschSettings: {
-        productSearch: mockProductSearchResponse,
-      },
-    })
-
-    await fetchProductSearch(ctx, mockArgs, mockSelectedFacets)
-
-    const [callArgs] = (
-      ctx.clients.intelligentSearchApi.productSearch as jest.Mock
-    ).mock.calls[0]
-
-    expect(callArgs).not.toHaveProperty('semanticRatio')
-  })
-
   it('sends dpPreview=true to intsch when enableDeliveryPromisePreview is on', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
       appSettings: {
-        shouldUseNewPLPEndpoint: true,
         enableDeliveryPromisePreview: true,
       },
       intschSettings: {
@@ -390,9 +268,6 @@ describe('fetchProductSearch service', () => {
   it('does not send dpPreview when enableDeliveryPromisePreview is off', async () => {
     const ctx = createContext({
       accountName: 'testaccount',
-      appSettings: {
-        shouldUseNewPLPEndpoint: true,
-      },
       intschSettings: {
         productSearch: mockProductSearchResponse,
       },

--- a/node/services/productSearch.ts
+++ b/node/services/productSearch.ts
@@ -59,57 +59,6 @@ function buildProductSearchRequestParams(
 }
 
 /**
- * Fetches product search results using the intelligentSearchApi client (Biggy)
- */
-// eslint-disable-next-line max-params
-async function fetchProductSearchFromBiggy(
-  ctx: Context,
-  args: ProductSearchInput,
-  selectedFacets: SelectedFacet[],
-  shippingOptions?: string[],
-  segmentData?: SegmentData
-) {
-  const { intelligentSearchApi } = ctx.clients
-  const { fullText } = args
-  const advertisementOptionsResolved =
-    args.advertisementOptions ?? defaultAdvertisementOptions
-
-  const biggyArgs = buildProductSearchRequestParams(
-    args,
-    fullText,
-    advertisementOptionsResolved
-  )
-
-  const finalArgs = applyHideUnavailableItemsDefaultForDP(
-    biggyArgs,
-    segmentData?.segmentParams
-  )
-
-  const raw = await intelligentSearchApi.productSearch(
-    { ...finalArgs },
-    buildAttributePath(selectedFacets),
-    { shippingHeader: shippingOptions }
-  )
-
-  const { requestInfo, ...result } = raw
-
-  if (
-    ctx.vtex.tenant &&
-    !args.productOriginVtex &&
-    raw.translated !== undefined &&
-    raw.translated !== null
-  ) {
-    ctx.translated = raw.translated
-  }
-
-  return {
-    searchState: args.searchState,
-    ...result,
-    requestInfo,
-  }
-}
-
-/**
  * Fetches product search results using the intsch client (Intelligent Search)
  */
 // eslint-disable-next-line max-params
@@ -194,8 +143,7 @@ function logSponsoredProducts(ctx: Context, result: any) {
 }
 
 /**
- * ProductSearch service that routes PLP requests to intsch or the legacy
- * client based on the shouldUseNewPLPEndpoint flag.
+ * ProductSearch service that always routes PLP requests through intsch.
  */
 // eslint-disable-next-line max-params
 export async function fetchProductSearch(
@@ -204,11 +152,9 @@ export async function fetchProductSearch(
   selectedFacets: SelectedFacet[],
   shippingOptions?: string[]
 ) {
-  const {
-    shouldUseNewPLPEndpoint,
-    enableHybridSearch,
-    enableDeliveryPromisePreview,
-  } = await fetchAppSettings(ctx)
+  const { enableHybridSearch, enableDeliveryPromisePreview } =
+    await fetchAppSettings(ctx)
+
   const segment = await getOrCreateSegment(ctx)
   const segmentData = extractSegmentData(segment)
 
@@ -218,33 +164,14 @@ export async function fetchProductSearch(
     })
   }
 
-  if (shouldUseNewPLPEndpoint) {
-    const result = await fetchProductSearchFromIntsch(
-      ctx,
-      args,
-      selectedFacets,
-      shippingOptions,
-      segmentData,
-      enableHybridSearch,
-      enableDeliveryPromisePreview
-    )
-
-    logSponsoredProducts(ctx, result)
-
-    return omitRequestInfo(result)
-  }
-
-  ctx.vtex.logger.warn({
-    message: 'ProductSearch migration: intsch not used as final response',
-    account: ctx.vtex.account,
-  })
-
-  const result = await fetchProductSearchFromBiggy(
+  const result = await fetchProductSearchFromIntsch(
     ctx,
     args,
     selectedFacets,
     shippingOptions,
-    segmentData
+    segmentData,
+    enableHybridSearch,
+    enableDeliveryPromisePreview
   )
 
   logSponsoredProducts(ctx, result)

--- a/node/services/settings.test.ts
+++ b/node/services/settings.test.ts
@@ -6,7 +6,6 @@ describe('fetchAppSettings', () => {
     const ctx = createContext({
       appSettings: {
         shouldUseNewPDPEndpoint: false,
-        shouldUseNewPLPEndpoint: true,
         enableHybridSearch: true,
       },
     })
@@ -20,7 +19,6 @@ describe('fetchAppSettings', () => {
     const ctx = createContext({
       appSettings: {
         shouldUseNewPDPEndpoint: false,
-        shouldUseNewPLPEndpoint: false,
       },
     })
 
@@ -42,40 +40,16 @@ describe('fetchAppSettings', () => {
     expect(settings.enableHybridSearch).toBe(false)
   })
 
-  it('defaults shouldUseNewPLPEndpoint to true when not set', async () => {
+  it('does not expose shouldUseNewPLPEndpoint', async () => {
     const ctx = createContext({
       appSettings: {
         shouldUseNewPDPEndpoint: false,
-      },
-    })
-
-    const settings = await fetchAppSettings(ctx)
-
-    expect(settings.shouldUseNewPLPEndpoint).toBe(true)
-  })
-
-  it('respects an explicit shouldUseNewPLPEndpoint: false setting', async () => {
-    const ctx = createContext({
-      appSettings: {
         shouldUseNewPLPEndpoint: false,
-      },
+      } as any,
     })
 
     const settings = await fetchAppSettings(ctx)
 
-    expect(settings.shouldUseNewPLPEndpoint).toBe(false)
-  })
-
-  it('defaults shouldUseNewPLPEndpoint to true when getAppSettings throws', async () => {
-    const ctx = createContext({})
-
-    jest
-      .spyOn((ctx as any).clients.apps, 'getAppSettings')
-      .mockImplementation()
-      .mockRejectedValue(new Error('boom'))
-
-    const settings = await fetchAppSettings(ctx)
-
-    expect(settings.shouldUseNewPLPEndpoint).toBe(true)
+    expect(settings).not.toHaveProperty('shouldUseNewPLPEndpoint')
   })
 })

--- a/node/services/settings.ts
+++ b/node/services/settings.ts
@@ -1,11 +1,9 @@
 type AppSettings = {
   shouldUseNewPDPEndpoint: boolean
-  shouldUseNewPLPEndpoint: boolean
   enableHybridSearch: boolean
   enableDeliveryPromisePreview: boolean
 }
 
-const FORCE_NEW_PLP_HEADER = 'x-vtex-force-new-plp-endpoint'
 const FORCE_NEW_PDP_HEADER = 'x-vtex-force-new-pdp-endpoint'
 
 export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
@@ -13,20 +11,17 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
     clients: { apps },
   } = ctx
 
-  const forceNewPLP = ctx.get(FORCE_NEW_PLP_HEADER) === 'true'
   const forceNewPDP = ctx.get(FORCE_NEW_PDP_HEADER) === 'true'
 
   try {
     const {
       shouldUseNewPDPEndpoint,
-      shouldUseNewPLPEndpoint,
       enableHybridSearch,
       enableDeliveryPromisePreview,
     }: AppSettings = await apps.getAppSettings('vtex.search-resolver@1.x')
 
     return {
       shouldUseNewPDPEndpoint: forceNewPDP || shouldUseNewPDPEndpoint,
-      shouldUseNewPLPEndpoint: forceNewPLP || (shouldUseNewPLPEndpoint ?? true),
       enableHybridSearch: enableHybridSearch ?? false,
       enableDeliveryPromisePreview: enableDeliveryPromisePreview ?? false,
     }
@@ -38,9 +33,6 @@ export async function fetchAppSettings(ctx: Context): Promise<AppSettings> {
 
     return {
       shouldUseNewPDPEndpoint: forceNewPDP,
-      // Defaults to true (matches the new manifest default) — the legacy
-      // client is no longer the safe fallback when settings can't be read.
-      shouldUseNewPLPEndpoint: true,
       enableHybridSearch: false,
       enableDeliveryPromisePreview: false,
     }


### PR DESCRIPTION
#### What problem is this solving?

[TIS-906](https://vtex-dev.atlassian.net/browse/TIS-906) (under TIS-762): finish the PLP migration so `productSearch` / `products` / `productSuggestions` / `facets` always go through `intsch`, with no app setting or force header left to route those queries to `vtex.intelligent-search-api`.

**Example**

Before (account with `shouldUseNewPLPEndpoint: false`):

```ts
fetchProductSearch(...) → intelligentSearchApi.productSearch(...)
```

After (any account):

```ts
fetchProductSearch(...) → intsch.productSearch(...)
```

`sponsoredProducts` still uses `intelligentSearchApi` (out of scope).

#### How should this be manually tested?

[Workspace](url)

- Confirm a PLP (`productSearch` / facets) hits `intsch` only — no `vtex.intelligent-search-api` product-search/facets traffic for those routes.
- Confirm `sponsoredProducts` still works via `intelligentSearchApi`.
- Confirm hybrid search / DP preview settings still affect intsch PLP params.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

N/A — resolver routing change.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

- Removes `shouldUseNewPLPEndpoint` from `manifest.json` settingsSchema and `x-vtex-force-new-plp-endpoint`.
- Accounts that previously opted out of intsch for PLP can no longer do so via this setting.

Made with [Cursor](https://cursor.com)

[TIS-906]: https://vtex-dev.atlassian.net/browse/TIS-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ