### PR TITLE
Ignore catalog vs intsch PDP compare noise in Product: Results differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore `PromotionTeasers` and `completeSpecifications.Values` length/extra-key diffs in the PDP catalog vs intsch comparison. Those fields are unused by GraphQL (or duplicate mapping) and were inflating `Product: Results differ` logs.
+
 ## [1.111.0] - 2026-08-24
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Ignore `PromotionTeasers` and `completeSpecifications.Values` length/extra-key diffs in the PDP catalog vs intsch comparison. Those fields are unused by GraphQL (or duplicate mapping) and were inflating `Product: Results differ` logs.
+- Expand the PDP catalog vs intsch ignore list for `Product: Results differ`. Drop mapping-only extra keys (`offerOrigin`, `attributes`, `allSpecifications`, `allSpecificationsGroups`), intsch’s product-cluster cap of 50, `brandImageUrl`, `imageText` null vs string, GraphQL-unused offer/product payload (`PaymentOptions`, `FullSellingPrice`, `IsAvailable`, `DeliverySlaSamplesPerRegion`, `ItemMetadataAttachment`, `SellerVSS`, `PromotionTeasers`), and duplicate `completeSpecifications.Values`. `Teasers` content and extra specs by `Name` still log.
+- Support `**` in compare ignore paths so a field and its nested keys can be ignored together.
 
 ## [1.111.0] - 2026-08-24
 

--- a/node/services/pdpConfig.test.ts
+++ b/node/services/pdpConfig.test.ts
@@ -1,0 +1,500 @@
+import {
+  filterIgnoredDifferences,
+  findDifferences,
+} from '../utils/compareResults'
+import {
+  CATALOG_EXISTENCE_COMPARE_FIELDS,
+  CATALOG_IGNORED_DIFFERENCES,
+} from './pdpConfig'
+
+describe('CATALOG_IGNORED_DIFFERENCES', () => {
+  it('does not surface IS-only extra keys from product compare', () => {
+    const catalog = [
+      {
+        productId: '94631',
+        items: [{ itemId: '1' }],
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '94631',
+        items: [
+          {
+            itemId: '1',
+            offerOrigin: 'simulation',
+            attributes: [],
+          },
+        ],
+        allSpecifications: [],
+        allSpecificationsGroups: [],
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([])
+  })
+
+  it('still reports real value differences after ignoring extra keys', () => {
+    const catalog = [
+      {
+        productId: '94631',
+        productName: 'Catalog name',
+        items: [{ itemId: '1' }],
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '94631',
+        productName: 'IS name',
+        items: [
+          {
+            itemId: '1',
+            offerOrigin: 'simulation',
+            attributes: [{ key: 'foo', value: 'bar' }],
+          },
+        ],
+        allSpecifications: ['Color'],
+        allSpecificationsGroups: ['Info'],
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([
+      {
+        path: '[0].productName',
+        type: 'different_value',
+        expected: 'Catalog name',
+        actual: 'IS name',
+      },
+    ])
+  })
+
+  it('ignores catalog-only productClusters keys (intsch cap of 50)', () => {
+    const catalog = [
+      {
+        productId: '305546',
+        productClusters: {
+          '12': 'Kept',
+          '348': 'Cuidado Corporal Seleccionado a S/. 45 c/u',
+        },
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '305546',
+        productClusters: {
+          '12': 'Kept',
+        },
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([])
+  })
+
+  it('still reports extra or renamed productClusters after ignoring missing keys', () => {
+    const catalog = [
+      {
+        productId: '1',
+        productClusters: {
+          '12': 'Old name',
+        },
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '1',
+        productClusters: {
+          '12': 'New name',
+          '99': 'Only in IS',
+        },
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual(
+      expect.arrayContaining([
+        {
+          path: '[0].productClusters.12',
+          type: 'different_value',
+          expected: 'Old name',
+          actual: 'New name',
+        },
+        {
+          path: '[0].productClusters.99',
+          type: 'extra_key',
+          actual: 'Only in IS',
+        },
+      ])
+    )
+    expect(filtered).toHaveLength(2)
+  })
+
+  it('ignores brandImageUrl differences', () => {
+    const catalog = [
+      {
+        productId: '8934',
+        brandImageUrl: 'https://example.vteximg.com.br/arquivos/ids/1/logo.svg',
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '8934',
+        brandImageUrl: null,
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([])
+  })
+
+  it('ignores GraphQL-unused offer and product payload fields', () => {
+    const catalog = [
+      {
+        productId: '1',
+        SellerVSS: ['a', 'b'],
+        items: [
+          {
+            itemId: '1',
+            sellers: [
+              {
+                sellerId: '1',
+                commertialOffer: {
+                  AvailableQuantity: 10,
+                  FullSellingPrice: null,
+                  IsAvailable: true,
+                  PaymentOptions: null,
+                  DeliverySlaSamplesPerRegion: {
+                    '0': { DeliverySlaPerTypes: [], Region: null },
+                  },
+                  ItemMetadataAttachment: [{ Name: 'Extended warranty' }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '1',
+        SellerVSS: ['b', 'a'],
+        items: [
+          {
+            itemId: '1',
+            sellers: [
+              {
+                sellerId: '1',
+                commertialOffer: {
+                  AvailableQuantity: 99999,
+                  FullSellingPrice: 0,
+                  IsAvailable: false,
+                  PaymentOptions: {
+                    installmentOptions: [
+                      {
+                        installments: [
+                          {
+                            sellerMerchantInstallments: [{ id: 'X' }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  DeliverySlaSamplesPerRegion: {},
+                  ItemMetadataAttachment: [],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([
+      {
+        path: '[0].items[0].sellers[0].commertialOffer.AvailableQuantity',
+        type: 'different_value',
+        expected: 10,
+        actual: 99999,
+      },
+    ])
+  })
+
+  it('ignores imageText null vs empty-or-label mismatches', () => {
+    const catalog = [
+      {
+        productId: '1',
+        items: [
+          {
+            itemId: '1',
+            images: [
+              { imageId: 'a', imageText: null },
+              { imageId: 'b', imageText: null },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '1',
+        items: [
+          {
+            itemId: '1',
+            images: [
+              { imageId: 'a', imageText: '' },
+              { imageId: 'b', imageText: 'Product name as label' },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([])
+  })
+
+  it('ignores extra completeSpecifications Values and length, not extra specs', () => {
+    const catalog = [
+      {
+        productId: '1',
+        completeSpecifications: [
+          {
+            Name: 'Género',
+            Values: [{ Id: '1329', Value: 'Mujer' }],
+          },
+        ],
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '1',
+        completeSpecifications: [
+          {
+            Name: 'Género',
+            Values: [
+              { Id: '1329', Value: 'Mujer' },
+              { Id: 'Mujer', Value: 'Mujer' },
+            ],
+          },
+          {
+            Name: 'OnlyInIS',
+            Values: [{ Id: 'x', Value: 'x' }],
+          },
+        ],
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([
+      {
+        path: '[0].completeSpecifications[name:OnlyInIS]',
+        type: 'extra_key',
+        actual: {
+          Name: 'OnlyInIS',
+          Values: [{ Id: 'x', Value: 'x' }],
+        },
+      },
+    ])
+  })
+
+  it('still reports completeSpecifications value content differences', () => {
+    const catalog = [
+      {
+        productId: '1',
+        completeSpecifications: [
+          {
+            Name: 'Color',
+            Values: [{ Id: '1', Value: 'Black' }],
+          },
+        ],
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '1',
+        completeSpecifications: [
+          {
+            Name: 'Color',
+            Values: [{ Id: '1', Value: 'White' }],
+          },
+        ],
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered).toEqual([
+      {
+        path: '[0].completeSpecifications[name:Color].Values[0].Value',
+        type: 'different_value',
+        expected: 'Black',
+        actual: 'White',
+      },
+    ])
+  })
+
+  it('ignores PromotionTeasers but still reports Teasers differences', () => {
+    const catalog = [
+      {
+        productId: '1',
+        items: [
+          {
+            itemId: '1',
+            sellers: [
+              {
+                sellerId: '1',
+                commertialOffer: {
+                  Teasers: [{ Name: 'Promo', Conditions: { Parameters: [] } }],
+                  PromotionTeasers: [
+                    { Name: 'Promo', Conditions: { Parameters: [] } },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const intsch = [
+      {
+        productId: '1',
+        items: [
+          {
+            itemId: '1',
+            sellers: [
+              {
+                sellerId: '1',
+                commertialOffer: {
+                  Teasers: [
+                    {
+                      Name: 'Promo',
+                      Conditions: {
+                        Parameters: [
+                          { Name: 'PercentualDiscount', Value: '50' },
+                        ],
+                      },
+                    },
+                  ],
+                  PromotionTeasers: [
+                    {
+                      Name: 'Promo',
+                      Conditions: {
+                        Parameters: [
+                          { Name: 'PercentualDiscount', Value: '50' },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const differences = findDifferences(catalog, intsch, '', {
+      existenceCompareFields: CATALOG_EXISTENCE_COMPARE_FIELDS,
+    })
+
+    const { filtered } = filterIgnoredDifferences(
+      differences,
+      CATALOG_IGNORED_DIFFERENCES
+    )
+
+    expect(filtered.some((d) => d.path.includes('PromotionTeasers'))).toBe(
+      false
+    )
+    expect(filtered).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: '[0].items[0].sellers[0].commertialOffer.Teasers[0].Conditions.Parameters',
+          type: 'array_length_mismatch',
+        }),
+      ])
+    )
+  })
+})

--- a/node/services/pdpConfig.ts
+++ b/node/services/pdpConfig.ts
@@ -11,6 +11,11 @@ export const CATALOG_IGNORED_DIFFERENCES: IgnoredDifference[] = [
   // Actual
   { path: '[*].skuSpecifications[*].field.type', type: 'missing_key' },
   { path: '[*].origin', type: 'extra_key' },
+  // IS/intsch mapping adds these; catalog/portal search does not
+  { path: '[*].items[*].offerOrigin', type: 'extra_key' },
+  { path: '[*].items[*].attributes', type: 'extra_key' },
+  { path: '[*].allSpecifications', type: 'extra_key' },
+  { path: '[*].allSpecificationsGroups', type: 'extra_key' },
   // productReference: catalog data plane does not always carry the product-level refId
   { path: '[*].productReference', type: 'different_value' },
   // PriceToken: generated internally by the catalog search API, not available in simulation
@@ -48,6 +53,40 @@ export const CATALOG_IGNORED_DIFFERENCES: IgnoredDifference[] = [
   {
     path: '[*].allSpecifications[name:sellerId]',
     type: 'missing_key',
+  },
+  // Intsch caps product clusters at 50 (highlights first); catalog/portal can return more
+  { path: '[*].productClusters.*', type: 'missing_key' },
+  // Intsch often omits brand image while catalog/portal indexes the logo URL
+  { path: '[*].brandImageUrl' },
+  // Catalog serializes missing alt as null; intsch always emits a string ("" or label)
+  {
+    path: '[*].items[*].images[*].imageText',
+    type: 'null_mismatch',
+  },
+  // Not exposed on search-graphql Product/SKU/Offer — compare-only payload noise
+  { path: '[*].items[*].sellers[*].commertialOffer.PaymentOptions**' },
+  { path: '[*].items[*].sellers[*].commertialOffer.FullSellingPrice' },
+  { path: '[*].items[*].sellers[*].commertialOffer.IsAvailable' },
+  {
+    path: '[*].items[*].sellers[*].commertialOffer.DeliverySlaSamplesPerRegion**',
+  },
+  {
+    path: '[*].items[*].sellers[*].commertialOffer.ItemMetadataAttachment**',
+  },
+  { path: '[*].SellerVSS**' },
+  // PascalCase twin of Teasers; GraphQL Offer.teasers reads teasers ?? Teasers only
+  {
+    path: '[*].items[*].sellers[*].commertialOffer.PromotionTeasers**',
+  },
+  // completeSpecifications is not a GraphQL field; intsch often duplicates Values
+  // as numeric Id plus name-as-Id. Extra specs by Name still log.
+  {
+    path: '[*].completeSpecifications[*].Values',
+    type: 'array_length_mismatch',
+  },
+  {
+    path: '[*].completeSpecifications[*].Values[*]',
+    type: 'extra_key',
   },
   // Potential indexing differences
   {

--- a/node/utils/compareResults.test.ts
+++ b/node/utils/compareResults.test.ts
@@ -893,10 +893,10 @@ describe('nested existence-based comparison with ignore patterns', () => {
       { path: 'products[*].properties[name:sellerId]', type: 'missing_key' },
     ]
 
-    const filtered = filterIgnoredDifferences(
+    const { filtered } = filterIgnoredDifferences(
       result.differences,
       ignoredDifferences
-    ).filtered
+    )
 
     expect(filtered).toEqual([])
   })
@@ -953,7 +953,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'email', type: 'missing_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([
         {
@@ -985,7 +988,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'value', type: 'different_value' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([
         {
@@ -1007,7 +1013,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'name', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([{ path: 'age', type: 'extra_key', expected: 25 }])
     })
@@ -1031,7 +1040,10 @@ describe('filterIgnoredDifferences', () => {
         { path: '[0].brandImageUrl', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([
         {
@@ -1058,7 +1070,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'data[0].items[2].specs', type: 'missing_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([
         {
@@ -1097,7 +1112,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'user.settings.notifications', type: 'missing_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([
         {
@@ -1142,7 +1160,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'array', type: 'array_length_mismatch' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([
         {
@@ -1162,7 +1183,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'any', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([])
     })
@@ -1198,7 +1222,10 @@ describe('filterIgnoredDifferences', () => {
         { path: 'age', type: 'extra_key' },
       ]
 
-      const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+      const result = filterIgnoredDifferences(
+        differences,
+        ignoredDifferences
+      ).filtered
 
       expect(result).toEqual([])
     })
@@ -1301,6 +1328,54 @@ describe('shouldIgnoreDifference', () => {
           path: 'products[*].specificationGroups[name:allSpecifications]',
           type: 'missing_key',
         })
+      ).toBe(false)
+    })
+  })
+
+  describe('wildcard ** matching', () => {
+    it('matches the field itself and nested paths', () => {
+      const pattern: IgnoredDifference = {
+        path: '[*].items[*].sellers[*].commertialOffer.PaymentOptions**',
+      }
+
+      expect(
+        shouldIgnoreDifference(
+          {
+            path: '[0].items[0].sellers[0].commertialOffer.PaymentOptions',
+            type: 'null_mismatch',
+            expected: null,
+            actual: {},
+          },
+          pattern
+        )
+      ).toBe(true)
+
+      expect(
+        shouldIgnoreDifference(
+          {
+            path: '[0].items[0].sellers[0].commertialOffer.PaymentOptions.installmentOptions[0].installments[0].sellerMerchantInstallments[0].id',
+            type: 'different_value',
+            expected: 'A',
+            actual: 'B',
+          },
+          pattern
+        )
+      ).toBe(true)
+    })
+
+    it('does not match a sibling field', () => {
+      expect(
+        shouldIgnoreDifference(
+          {
+            path: '[0].items[0].sellers[0].commertialOffer.Installments[0].Value',
+            type: 'different_value',
+            expected: 1,
+            actual: 2,
+          },
+          {
+            path: '[*].items[*].sellers[*].commertialOffer.PaymentOptions**',
+          }
+        )
       ).toBe(false)
     })
   })
@@ -1428,7 +1503,10 @@ describe('filterIgnoredDifferences with wildcards', () => {
       { path: 'products[*].cacheId', type: 'different_value' },
     ]
 
-    const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+    const result = filterIgnoredDifferences(
+      differences,
+      ignoredDifferences
+    ).filtered
 
     expect(result).toEqual([
       {
@@ -1487,7 +1565,10 @@ describe('filterIgnoredDifferences with wildcards', () => {
       },
     ]
 
-    const result = filterIgnoredDifferences(differences, ignoredDifferences).filtered
+    const result = filterIgnoredDifferences(
+      differences,
+      ignoredDifferences
+    ).filtered
 
     expect(result).toEqual([
       {

--- a/node/utils/compareResults.ts
+++ b/node/utils/compareResults.ts
@@ -452,6 +452,7 @@ export function isDeepEqual(
  * Convert an ignore path pattern to a RegExp.
  * Escapes all regex special chars first, then un-escapes our wildcard tokens:
  *   - `[*]` → matches any array index: numeric (e.g. `[0]`, `[1]`) or named (e.g. `[name:foo]`)
+ *   - `**`  → matches the rest of the path, including nested keys and indices
  *   - `*`   → matches any characters except dots and brackets
  *   - `[name:X]` is matched literally (already escaped correctly)
  */
@@ -460,12 +461,12 @@ function ignorePatternToRegex(pathPattern: string): RegExp {
   let regex = pathPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
   // 2. Un-escape and replace [*] → match numeric or named array indices (matches intelligent-search)
-  regex = regex.replace(
-    /\\\[\\\*\\\]/g,
-    '(?:\\[\\d+\\]|\\[name:[^\\]]+\\])'
-  )
+  regex = regex.replace(/\\\[\\\*\\\]/g, '(?:\\[\\d+\\]|\\[name:[^\\]]+\\])')
 
-  // 3. Un-escape and replace remaining * → match any chars except dots/brackets
+  // 3. Un-escape ** → match this field and any nested path under it
+  regex = regex.replace(/\\\*\\\*/g, '.*')
+
+  // 4. Un-escape and replace remaining * → match any chars except dots/brackets
   regex = regex.replace(/\\\*/g, '[^.\\[\\]]*')
 
   return new RegExp(`^${regex}$`)
@@ -500,7 +501,7 @@ export function shouldIgnoreDifference(
 
 /**
  * Filters out differences that should be ignored based on path patterns and type.
- * Supports wildcard patterns in paths (`[*]`, `*`, `[name:X]`).
+ * Supports wildcard patterns in paths (`[*]`, `**`, `*`, `[name:X]`).
  * @param differences Array of differences to filter
  * @param ignoredDifferences Array of ignored difference configurations
  * @returns Filtered array of differences
@@ -561,7 +562,9 @@ export const DEFAULT_MAX_DIFF_VALUE_LENGTH = 2000
 
 function truncateForLog(value: unknown, maxLength: number): string {
   const s = JSON.stringify(value)
+
   if (maxLength <= 0 || s.length <= maxLength) return s
+
   return `${s.slice(0, maxLength)} ... (truncated, total ${s.length} chars)`
 }
 
@@ -677,6 +680,7 @@ export async function compareApiResults<T>(
 
       differences = comparisonResult.differences
       const result = filterIgnoredDifferences(differences, ignoredDifferences)
+
       filteredDifferences = result.filtered
       ignored = result.ignored
       areEqual = filteredDifferences.length === 0


### PR DESCRIPTION
#### What problem is this solving?

PDP compare (`productOriginVtex: true`) logs `Product: Results differ` whenever catalog/portal search and intsch `fetchProduct` disagree on **raw JSON**, before GraphQL mapping. A large share of those diffs never reach the storefront: IS-only extra keys, catalog-only cluster keys past intsch’s cap of 50, brand image URLs, unused offer payload, duplicate `completeSpecifications.Values`, and the unused `PromotionTeasers` twin of `Teasers`.

This PR ignores those known mapping/payload mismatches so the log stays on real live-vs-indexed offer drift (`AvailableQuantity`, `Installments`, GraphQL `Teasers`).

**Expected log reduction** (replay of 500 `Product: Results differ` events from `vtex.search-resolver@1.110.0`, ~2h window that had 26k such events):

- **~21% fewer logs (conservative):** every remaining diff in the event was in the payload (`differenceCount` ≤ 10) and all of them match the new ignore list.
- **~33% fewer logs (optimistic):** the first 10 diffs we can see would all be ignored. ~12% of events look fully ignored in those 10 but had a higher `differenceCount`, so they may still fire on diffs 11+.
- **~67% still log**, mostly `AvailableQuantity` (catalog stock buckets vs simulation caps). `Installments` and `Teasers` are left visible.

Example: catalog `completeSpecifications` for Género is one value `{ Id: "1329", Value: "Mujer" }`; intsch adds a duplicate `{ Id: "Mujer", Value: "Mujer" }`. That extra row is ignored. An extra spec **Name** still logs.

Ignore matching now supports `**` (this field and descendants), applied before single `*`.

#### How should this be manually tested?

Confirm `Product: Results differ` volume after release vs the same accounts/window. Remaining events should still show `AvailableQuantity`, `Installments`, or `Teasers` when those differ; they should no longer be only `offerOrigin` / `PaymentOptions` / `PromotionTeasers` / extra spec `Values`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

N/A — compare ignore list + unit tests.

#### Type of changes

✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Left **out** of the ignore list on purpose: `AvailableQuantity`, `Installments`, and `Teasers` (GraphQL `Offer.teasers`). Those can change PDP availability, installment price, or promo parameters.