### PR TITLE
Document Dependabot bumps since v1.111.1 in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@vtex/api` from 7.2.7 to 7.4.0 in `/node` (#565).
+- Bump `typescript` from 5.5.3 to 5.9.3 in `/node` (#566).
+- Bump `ts-jest` from 29.2.5 to 29.4.11 in `/node` (#562).
+- Bump `slugify` from 1.6.4 to 1.6.9 in `/node` (#564).
+- Bump `lodash` from 4.17.15 to 4.18.1 in `/node` (#581).
+- Bump `follow-redirects` from 1.14.6 to 1.16.0 in `/node` (#580).
+- Bump `js-yaml` from 3.14.1 to 3.15.1 (#585) and from 3.13.1 to 3.15.1 in `/node` (#586).
+- Bump `fast-uri` from 3.0.5 to 3.1.5 (#582).
+- Bump `brace-expansion` from 1.1.11 to 1.1.16 (#577) and from 1.1.11 to 1.1.18 in `/node` (#591).
+
 ## [1.111.1] - 2026-08-25
 
 ### Changed


### PR DESCRIPTION
#### What problem is this solving?

`v1.111.1` shipped with an empty `[Unreleased]` section. Eleven Dependabot merges landed on `main` after that release and were not recorded.

This fills `[Unreleased]` so the next `vtex release` can copy those bumps into the versioned notes.

Example (from `[Unreleased]`):

- Bump `@vtex/api` from 7.2.7 to 7.4.0 in `/node` (#565).
- Bump `lodash` from 4.17.15 to 4.18.1 in `/node` (#581).

#### How should this be manually tested?

Confirm `CHANGELOG.md` `[Unreleased]` lists the Dependabot PRs merged after `v1.111.1` (#577, #585, #582, #586, #564, #581, #580, #562, #565, #566, #591).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

N/A — changelog-only.

#### Type of changes

✔️ | Type of Change
---|---
_ | Bug fix
_ | New feature
_ | Breaking change
✔️ | Technical improvements

#### Notes

`main` is protected (changes must go through a pull request), so this is the path onto `main`.


Made with [Cursor](https://cursor.com)