### PR TITLE
Omit missing products from intsch productsByIdentifier batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `productsByIdentifier` on the intsch PDP path (`shouldUseNewPDPEndpoint`) no longer fails the whole batch when one identifier 404s. Missing products are omitted; other errors still propagate.
+
 ## [1.112.0] - 2026-08-26
 
 ### Changed

--- a/node/services/product.test.ts
+++ b/node/services/product.test.ts
@@ -1,5 +1,17 @@
-import { fetchProduct } from './product'
+import { fetchProduct, resolveProductsByIdentifier } from './product'
 import { createContext } from '../mocks/contextFactory'
+
+function createNotFoundError() {
+  return Object.assign(new Error('Request failed with status code 404'), {
+    response: { status: 404, data: { code: 'PRODUCT_NOT_FOUND' } },
+  })
+}
+
+function createServerError() {
+  return Object.assign(new Error('Request failed with status code 500'), {
+    response: { status: 500 },
+  })
+}
 
 describe('fetchProduct service', () => {
   const mockProduct = {
@@ -60,5 +72,99 @@ describe('fetchProduct service', () => {
 
     expect(ctx.clients.intsch.fetchProduct).toHaveBeenCalled()
     expect(result).toEqual([mockProduct])
+  })
+
+  it('should return empty array when intsch product is not found', async () => {
+    const ctx = createContext({
+      appSettings: { shouldUseNewPDPEndpoint: true },
+    })
+
+    jest
+      .spyOn(ctx.clients.intsch, 'fetchProduct')
+      .mockRejectedValue(createNotFoundError())
+
+    const result = await fetchProduct(ctx, {
+      identifier: { field: 'id', value: 'missing-id' },
+      salesChannel: 1,
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('should propagate non-404 intsch errors for single product fetch', async () => {
+    const ctx = createContext({
+      appSettings: { shouldUseNewPDPEndpoint: true },
+    })
+
+    jest
+      .spyOn(ctx.clients.intsch, 'fetchProduct')
+      .mockRejectedValue(createServerError())
+
+    await expect(
+      fetchProduct(ctx, {
+        identifier: { field: 'id', value: 'test-id' },
+        salesChannel: 1,
+      })
+    ).rejects.toThrow('Request failed with status code 500')
+  })
+})
+
+describe('resolveProductsByIdentifier service', () => {
+  const existingProduct = {
+    productId: '2000037',
+    productName: 'GMK Truffle Space',
+  } as SearchProduct
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return only found products when batch contains missing IDs', async () => {
+    const ctx = createContext({
+      appSettings: { shouldUseNewPDPEndpoint: true },
+    })
+
+    jest
+      .spyOn(ctx.clients.intsch, 'fetchProduct')
+      .mockImplementation(({ value }) => {
+        if (value === '2000037') {
+          return Promise.resolve(existingProduct)
+        }
+
+        return Promise.reject(createNotFoundError())
+      })
+
+    const result = await resolveProductsByIdentifier(ctx, {
+      field: 'id',
+      values: ['2000037', '2000045'],
+      salesChannel: '1',
+    })
+
+    expect(result).toEqual([existingProduct])
+    expect(ctx.clients.intsch.fetchProduct).toHaveBeenCalledTimes(2)
+  })
+
+  it('should propagate non-404 intsch errors in batch fetch', async () => {
+    const ctx = createContext({
+      appSettings: { shouldUseNewPDPEndpoint: true },
+    })
+
+    jest
+      .spyOn(ctx.clients.intsch, 'fetchProduct')
+      .mockImplementation(({ value }) => {
+        if (value === '2000037') {
+          return Promise.resolve(existingProduct)
+        }
+
+        return Promise.reject(createServerError())
+      })
+
+    await expect(
+      resolveProductsByIdentifier(ctx, {
+        field: 'id',
+        values: ['2000037', '2000045'],
+        salesChannel: '1',
+      })
+    ).rejects.toThrow('Request failed with status code 500')
   })
 })

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -6,6 +6,34 @@ import {
   CATALOG_EXISTENCE_COMPARE_FIELDS,
 } from './pdpConfig'
 
+function isProductNotFoundError(error: unknown): boolean {
+  const axiosError = error as {
+    response?: { status?: number; data?: { code?: string } }
+  }
+
+  const status = axiosError.response?.status
+  const code = axiosError.response?.data?.code
+
+  return status === 404 || code === 'PRODUCT_NOT_FOUND'
+}
+
+async function fetchIntschProductOrNull(
+  intsch: Context['clients']['intsch'],
+  args: Parameters<Context['clients']['intsch']['fetchProduct']>[0]
+): Promise<SearchProduct | null> {
+  try {
+    const product = await intsch.fetchProduct(args)
+
+    return product ?? null
+  } catch (error) {
+    if (isProductNotFoundError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
 export type ProductIdentifier = {
   field: 'id' | 'slug' | 'ean' | 'reference' | 'sku'
   value: string
@@ -92,7 +120,7 @@ async function fetchProductFromIntsch(
     }
   }
 
-  const product = await intsch.fetchProduct({
+  const product = await fetchIntschProductOrNull(intsch, {
     field,
     value,
     salesChannel: finalSalesChannel?.toString(),
@@ -101,8 +129,6 @@ async function fetchProductFromIntsch(
     productOriginVtex: true,
   })
 
-  // intsch.fetchProduct returns a single SearchProduct, but we need to return an array
-  // to match the search client interface
   return product ? [product] : []
 }
 
@@ -273,21 +299,23 @@ async function fetchProductsByIdentifierFromIntsch(
     }
   }
 
-  // Fetch all products in parallel
-  const productPromises = values.map((value) =>
-    intsch.fetchProduct({
-      field,
-      value,
-      salesChannel: finalSalesChannel?.toString(),
-      regionId: regionId ?? undefined,
-      locale: finalLocale,
-      productOriginVtex: true,
-    })
+  // Fetch all products in parallel, omitting IDs that intsch reports as not found
+  const productResults = await Promise.all(
+    values.map((value) =>
+      fetchIntschProductOrNull(intsch, {
+        field,
+        value,
+        salesChannel: finalSalesChannel?.toString(),
+        regionId: regionId ?? undefined,
+        locale: finalLocale,
+        productOriginVtex: true,
+      })
+    )
   )
 
-  const products = await Promise.all(productPromises)
-
-  return products as SearchProduct[]
+  return productResults.filter(
+    (product): product is SearchProduct => product != null
+  )
 }
 
 export async function resolveProductsByIdentifier(


### PR DESCRIPTION
#### What problem is this solving?

With `shouldUseNewPDPEndpoint` on, `productsByIdentifier` fetches each ID through `intsch.fetchProduct` and `Promise.all`. A 404 for one ID rejects the whole batch, so products that would have resolved on their own are dropped.

The legacy catalog path already returns the IDs that exist and silently omits the rest. This change makes the intsch path match that.

Example:

```
productsByIdentifier(field: id, values: ["2000037", "2000045"])
```

Before: `data.productsByIdentifier` is `null` and the response has a 404 error, even if `2000037` exists.

After: `[{ productId: "2000037", ... }]`. Only HTTP 404 / `PRODUCT_NOT_FOUND` are omitted. 5xx and timeouts still fail the request.

#### How should this be manually tested?

Do not turn `shouldUseNewPDPEndpoint` on a real account. Use a local/staging setup or mock `intsch.fetchProduct`.

- Mixed batch: one existing ID and one that 404s should return only the existing product.
- All missing: still surfaces as not found at the resolver.
- Non-404 (500) on one ID should still fail the batch.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

```
# mixed batch, intsch path
query T { productsByIdentifier(field: id, values: ["2000037", "2000045"], salesChannel: "1") { productId productName } }

# before
{ "data": { "productsByIdentifier": null }, "errors": [{ "message": "Request failed with status code 404" }] }

# after
{ "data": { "productsByIdentifier": [{ "productId": "2000037", "productName": "GMK Truffle Space" }] } }
```

#### Type of changes

✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Single-product `fetchProduct` on the intsch path treats 404 the same way (empty list → resolver `NotFoundError`) so a missing PDP does not throw a raw HTTP 404.

Made with [Cursor](https://cursor.com)