### PR TITLE
Forward segment price tables on PDP intsch product lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- PDP intsch product lookups (`shouldUseNewPDPEndpoint`) now forward segment `priceTables`, `regionId`, and other simulation fields with the same helper as PLP `productSearch`. GraphQL `salesChannel` still wins over the segment; `sc` is no longer defaulted to `1`.
+
 ## [1.113.1] - 2026-09-01
 
 ### Fixed

--- a/node/clients/intsch/index.test.ts
+++ b/node/clients/intsch/index.test.ts
@@ -1,4 +1,5 @@
 import type { IOContext } from '@vtex/api'
+
 import { Intsch } from './index'
 
 function createTestClient(): Intsch {
@@ -15,6 +16,7 @@ function createTestClient(): Intsch {
   const client = new Intsch(ctx)
 
   ;(client as unknown as { http: unknown }).http = {
+    get: jest.fn().mockResolvedValue({ productId: '1322' }),
     getRaw: jest
       .fn()
       .mockResolvedValue({ data: { products: [] }, headers: {} }),
@@ -44,5 +46,83 @@ describe('Intsch#productSearch semantic params', () => {
     const [, requestConfig] = httpGetRaw.mock.calls[0]
 
     expect(requestConfig.params).not.toHaveProperty('semanticRatio')
+  })
+
+  it('forwards priceTables from segmentParams and lets salesChannel win', async () => {
+    const client = createTestClient()
+
+    await client.productSearch({ salesChannel: '1' } as any, 'bravecto', {
+      segmentParams: {
+        sc: '2',
+        priceTables: 'pl-001',
+        regionId: 'v2.SEGMENT',
+      },
+    })
+
+    const httpGetRaw = (client as any).http.getRaw as jest.Mock
+    const [, requestConfig] = httpGetRaw.mock.calls[0]
+
+    expect(requestConfig.params).toMatchObject({
+      sc: '1',
+      priceTables: 'pl-001',
+      regionId: 'v2.SEGMENT',
+    })
+  })
+})
+
+describe('Intsch#fetchProduct segment params', () => {
+  const identifier = {
+    field: 'id' as const,
+    value: '1322',
+    productOriginVtex: true,
+  }
+
+  const segmentParams = {
+    sc: '2',
+    regionId: 'v2.1BB18CE648B5111D0933734ED83EC783',
+    priceTables: 'pl-001',
+  }
+
+  it('forwards priceTables and regionId from segmentParams', async () => {
+    const client = createTestClient()
+
+    await client.fetchProduct(identifier, { segmentParams })
+
+    const httpGet = (client as any).http.get as jest.Mock
+    const [, requestConfig] = httpGet.mock.calls[0]
+
+    expect(requestConfig.params).toMatchObject({
+      field: 'id',
+      value: '1322',
+      sc: '2',
+      regionId: 'v2.1BB18CE648B5111D0933734ED83EC783',
+      priceTables: 'pl-001',
+    })
+  })
+
+  it('lets args.salesChannel win over segment sc', async () => {
+    const client = createTestClient()
+
+    await client.fetchProduct(
+      { ...identifier, salesChannel: '1' },
+      { segmentParams }
+    )
+
+    const httpGet = (client as any).http.get as jest.Mock
+    const [, requestConfig] = httpGet.mock.calls[0]
+
+    expect(requestConfig.params.sc).toBe('1')
+    expect(requestConfig.params.priceTables).toBe('pl-001')
+  })
+
+  it('does not default sc to 1 when salesChannel and segment sc are absent', async () => {
+    const client = createTestClient()
+
+    await client.fetchProduct(identifier)
+
+    const httpGet = (client as any).http.get as jest.Mock
+    const [, requestConfig] = httpGet.mock.calls[0]
+
+    expect(requestConfig.params).not.toHaveProperty('sc')
   })
 })

--- a/node/clients/intsch/index.ts
+++ b/node/clients/intsch/index.ts
@@ -16,6 +16,7 @@ import type {
   FetchBannersArgsV1,
   FetchBannersResponse,
   FetchProductArgs,
+  FetchProductOptions,
   FetchProductResponse,
   IIntelligentSearchClient,
   SearchSuggestionsArgs,
@@ -30,6 +31,7 @@ import { parseState } from '../../utils/searchState'
 import {
   filterUndefinedNonNull,
   filterByAllowedIntelligentSearchQueryKeys,
+  segmentQueryParams,
 } from './utils'
 
 export class Intsch extends JanusClient implements IIntelligentSearchClient {
@@ -45,20 +47,27 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     this.locale = locale ?? tenant?.locale
   }
 
-  public fetchProduct(args: FetchProductArgs): Promise<FetchProductResponse> {
+  public fetchProduct(
+    args: FetchProductArgs,
+    options?: FetchProductOptions
+  ): Promise<FetchProductResponse> {
     // The admin auth token is releavant for CallCenter users when the sales channel is private.
     const authToken =
       this.context.storeUserAuthToken ?? this.context.adminUserAuthToken
 
+    const { segmentParams } = options ?? {}
+
     return this.http.get('/api/intelligent-search/v1/products', {
-      params: {
+      params: filterUndefinedNonNull({
         field: args.field,
         value: args.value,
-        sc: args.salesChannel ?? 1,
-        regionId: args.regionId,
-        locale: args.locale,
+        ...segmentQueryParams(segmentParams, {
+          salesChannel: args.salesChannel,
+          regionId: args.regionId,
+        }),
+        locale: this.locale ?? segmentParams?.locale,
         productOriginVtex: args.productOriginVtex,
-      },
+      }),
       metric: 'search-product-new',
       headers: {
         ...(authToken ? { VtexIdclientAutCookie: authToken } : {}),
@@ -174,19 +183,10 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     const dpPreview = params.dpPreview ? 'true' : undefined
 
     const merged = filterUndefinedNonNull({
-      sc: params.salesChannel ? params.salesChannel : segmentParams?.sc,
-      regionId: params.regionId ?? segmentParams?.regionId,
-      country: segmentParams?.country,
-      'zip-code': segmentParams?.['zip-code'],
-      coordinates: segmentParams?.coordinates,
-      pickupPoint: segmentParams?.pickupPoint,
-      deliveryZonesHash: segmentParams?.deliveryZonesHash,
-      pickupPointHash: segmentParams?.pickupPointHash,
-      utmSource: segmentParams?.utmSource,
-      utmCampaign: segmentParams?.utmCampaign,
-      utmiCampaign: segmentParams?.utmiCampaign,
-      campaigns: segmentParams?.campaigns,
-      priceTables: segmentParams?.priceTables,
+      ...segmentQueryParams(segmentParams, {
+        salesChannel: params.salesChannel,
+        regionId: params.regionId,
+      }),
       query: query ? decodeQuery(query) : undefined,
       sort: params.sort,
       operator: params.operator,
@@ -266,14 +266,9 @@ export class Intsch extends JanusClient implements IIntelligentSearchClient {
     const dpPreview = params.dpPreview ? 'true' : undefined
 
     const merged = filterUndefinedNonNull({
-      sc: segmentParams?.sc,
-      regionId: params.regionId ?? segmentParams?.regionId,
-      country: segmentParams?.country,
-      'zip-code': segmentParams?.['zip-code'],
-      coordinates: segmentParams?.coordinates,
-      pickupPoint: segmentParams?.pickupPoint,
-      deliveryZonesHash: segmentParams?.deliveryZonesHash,
-      pickupPointHash: segmentParams?.pickupPointHash,
+      ...segmentQueryParams(segmentParams, {
+        regionId: params.regionId,
+      }),
       query: query ? decodeQuery(query) : undefined,
       operator: params.operator,
       fuzzy: params.fuzzy,

--- a/node/clients/intsch/types.ts
+++ b/node/clients/intsch/types.ts
@@ -142,6 +142,10 @@ export type FetchProductArgs = {
   productOriginVtex?: boolean
 }
 
+export type FetchProductOptions = {
+  segmentParams?: SegmentParams
+}
+
 export type FetchProductResponse = SearchProduct
 
 export type ProductSearchResponse = {
@@ -186,7 +190,10 @@ export interface IIntelligentSearchClient {
   ): Promise<SearchSuggestionsResponse>
   fetchCorrection(args: CorrectionArgs): Promise<CorrectionResponse>
   fetchBanners(args: FetchBannersArgs): Promise<FetchBannersResponse>
-  fetchProduct(args: FetchProductArgs): Promise<FetchProductResponse>
+  fetchProduct(
+    args: FetchProductArgs,
+    options?: FetchProductOptions
+  ): Promise<FetchProductResponse>
   fetchAutocompleteSuggestionsV1(
     args: AutocompleteSuggestionsArgsV1
   ): Promise<AutocompleteSuggestionsResponse>

--- a/node/clients/intsch/utils.test.ts
+++ b/node/clients/intsch/utils.test.ts
@@ -1,6 +1,7 @@
 import {
   filterByAllowedIntelligentSearchQueryKeys,
   filterUndefinedNonNull,
+  segmentQueryParams,
 } from './utils'
 
 describe('filterUndefinedNonNull', () => {
@@ -26,6 +27,7 @@ describe('filterByAllowedIntelligentSearchQueryKeys', () => {
       foo: 'bar',
       regionId: 'r1',
     })
+
     expect(result).toEqual({ query: 'shoes', regionId: 'r1' })
   })
 
@@ -34,6 +36,49 @@ describe('filterByAllowedIntelligentSearchQueryKeys', () => {
       dpPreview: 'true',
       ignored: 'value',
     })
+
     expect(result).toEqual({ dpPreview: 'true' })
+  })
+})
+
+describe('segmentQueryParams', () => {
+  const segment = {
+    sc: '2',
+    regionId: 'v2.SEGMENT',
+    priceTables: 'pl-001',
+    country: 'CHL',
+    utmSource: 'news',
+    campaigns: 'camp-1',
+  }
+
+  it('lets explicit salesChannel win over segment sc', () => {
+    expect(segmentQueryParams(segment, { salesChannel: '1' }).sc).toBe('1')
+  })
+
+  it('uses segment sc when salesChannel is absent', () => {
+    expect(segmentQueryParams(segment).sc).toBe('2')
+  })
+
+  it('does not default sc to 1 when neither override nor segment has it', () => {
+    expect(segmentQueryParams(undefined).sc).toBeUndefined()
+    expect(segmentQueryParams({}).sc).toBeUndefined()
+  })
+
+  it('lets explicit regionId win over segment regionId', () => {
+    expect(segmentQueryParams(segment, { regionId: 'v2.ARG' }).regionId).toBe(
+      'v2.ARG'
+    )
+  })
+
+  it('forwards priceTables and other simulation fields from the segment', () => {
+    expect(segmentQueryParams(segment)).toEqual(
+      expect.objectContaining({
+        priceTables: 'pl-001',
+        regionId: 'v2.SEGMENT',
+        country: 'CHL',
+        utmSource: 'news',
+        campaigns: 'camp-1',
+      })
+    )
   })
 })

--- a/node/clients/intsch/utils.ts
+++ b/node/clients/intsch/utils.ts
@@ -1,3 +1,36 @@
+import type { SegmentParams } from '../../utils/segment'
+
+export type SegmentQueryOverrides = {
+  salesChannel?: string | number | null
+  regionId?: string | null
+}
+
+/**
+ * Maps segment + explicit request overrides onto Intelligent Search query params.
+ * PLP (`productSearch`) is the source of truth: `salesChannel` / `regionId` win
+ * when provided; there is no default `sc=1`.
+ */
+export function segmentQueryParams(
+  segmentParams?: SegmentParams,
+  overrides?: SegmentQueryOverrides
+): SegmentParams {
+  return {
+    sc: overrides?.salesChannel ? overrides.salesChannel : segmentParams?.sc,
+    regionId: overrides?.regionId ?? segmentParams?.regionId,
+    country: segmentParams?.country,
+    'zip-code': segmentParams?.['zip-code'],
+    coordinates: segmentParams?.coordinates,
+    pickupPoint: segmentParams?.pickupPoint,
+    deliveryZonesHash: segmentParams?.deliveryZonesHash,
+    pickupPointHash: segmentParams?.pickupPointHash,
+    utmSource: segmentParams?.utmSource,
+    utmCampaign: segmentParams?.utmCampaign,
+    utmiCampaign: segmentParams?.utmiCampaign,
+    campaigns: segmentParams?.campaigns,
+    priceTables: segmentParams?.priceTables,
+  }
+}
+
 /**
  * Drops keys whose value is `undefined` from a plain object.
  * Keeps `false`, '' and `0` (needed for valid API semantics).

--- a/node/services/product.test.ts
+++ b/node/services/product.test.ts
@@ -74,6 +74,43 @@ describe('fetchProduct service', () => {
     expect(result).toEqual([mockProduct])
   })
 
+  it('should forward segment priceTables to intsch and let salesChannel win', async () => {
+    const ctx = createContext({
+      appSettings: { shouldUseNewPDPEndpoint: true },
+      segment: {
+        channel: '2',
+        priceTables: 'pl-001',
+        regionId: 'v2.1BB18CE648B5111D0933734ED83EC783',
+        cultureInfo: 'es-CL',
+      } as any,
+    })
+
+    jest
+      .spyOn(ctx.clients.intsch, 'fetchProduct')
+      .mockResolvedValue(mockProduct)
+
+    await fetchProduct(ctx, {
+      identifier: { field: 'id', value: '1322' },
+      salesChannel: 1,
+    })
+
+    expect(ctx.clients.intsch.fetchProduct).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field: 'id',
+        value: '1322',
+        salesChannel: '1',
+        productOriginVtex: true,
+      }),
+      {
+        segmentParams: expect.objectContaining({
+          sc: '2',
+          priceTables: 'pl-001',
+          regionId: 'v2.1BB18CE648B5111D0933734ED83EC783',
+        }),
+      }
+    )
+  })
+
   it('should return empty array when intsch product is not found', async () => {
     const ctx = createContext({
       appSettings: { shouldUseNewPDPEndpoint: true },

--- a/node/services/product.ts
+++ b/node/services/product.ts
@@ -19,10 +19,11 @@ function isProductNotFoundError(error: unknown): boolean {
 
 async function fetchIntschProductOrNull(
   intsch: Context['clients']['intsch'],
-  args: Parameters<Context['clients']['intsch']['fetchProduct']>[0]
+  args: Parameters<Context['clients']['intsch']['fetchProduct']>[0],
+  options?: Parameters<Context['clients']['intsch']['fetchProduct']>[1]
 ): Promise<SearchProduct | null> {
   try {
-    const product = await intsch.fetchProduct(args)
+    const product = await intsch.fetchProduct(args, options)
 
     return product ?? null
   } catch (error) {
@@ -102,32 +103,17 @@ async function fetchProductFromIntsch(
   const { identifier, salesChannel, regionId } = args
   const { field, value } = identifier
 
-  // Get locale from context (fallback)
-  const defaultLocale = ctx.vtex.tenant?.locale ?? ctx.vtex.locale
-
-  // Default salesChannel from args
-  let finalSalesChannel = salesChannel ? `${salesChannel}` : undefined
-  let finalLocale = defaultLocale
-
-  // Extract locale and salesChannel from segment data
-  if (segmentData.segmentParams) {
-    if (segmentData.segmentParams.sc) {
-      finalSalesChannel = String(segmentData.segmentParams.sc)
-    }
-
-    if (segmentData.segmentParams.locale) {
-      finalLocale = segmentData.segmentParams.locale
-    }
-  }
-
-  const product = await fetchIntschProductOrNull(intsch, {
-    field,
-    value,
-    salesChannel: finalSalesChannel?.toString(),
-    regionId,
-    locale: finalLocale,
-    productOriginVtex: true,
-  })
+  const product = await fetchIntschProductOrNull(
+    intsch,
+    {
+      field,
+      value,
+      salesChannel: salesChannel ? `${salesChannel}` : undefined,
+      regionId,
+      productOriginVtex: true,
+    },
+    { segmentParams: segmentData.segmentParams }
+  )
 
   return product ? [product] : []
 }
@@ -281,35 +267,19 @@ async function fetchProductsByIdentifierFromIntsch(
   const { intsch } = ctx.clients
   const { field, values, salesChannel, regionId } = args
 
-  // Get locale from context (fallback)
-  const defaultLocale = ctx.vtex.tenant?.locale ?? ctx.vtex.locale
-
-  // Default salesChannel from args
-  let finalSalesChannel = salesChannel ? `${salesChannel}` : undefined
-  let finalLocale = defaultLocale
-
-  // Extract locale and salesChannel from segment data
-  if (segmentData.segmentParams) {
-    if (segmentData.segmentParams.sc) {
-      finalSalesChannel = String(segmentData.segmentParams.sc)
-    }
-
-    if (segmentData.segmentParams.locale) {
-      finalLocale = segmentData.segmentParams.locale
-    }
-  }
-
-  // Fetch all products in parallel, omitting IDs that intsch reports as not found
   const productResults = await Promise.all(
     values.map((value) =>
-      fetchIntschProductOrNull(intsch, {
-        field,
-        value,
-        salesChannel: finalSalesChannel?.toString(),
-        regionId: regionId ?? undefined,
-        locale: finalLocale,
-        productOriginVtex: true,
-      })
+      fetchIntschProductOrNull(
+        intsch,
+        {
+          field,
+          value,
+          salesChannel: salesChannel ? `${salesChannel}` : undefined,
+          regionId: regionId ?? undefined,
+          productOriginVtex: true,
+        },
+        { segmentParams: segmentData.segmentParams }
+      )
     )
   )
 


### PR DESCRIPTION
## What problem is this solving?

[INC-6296](https://app.incident.io/vtex/response/incidents/6296): with `shouldUseNewPDPEndpoint`, PDP intsch product lookups dropped segment `priceTables` (and did not fall back to segment `regionId`). PLP `productSearch` already forwarded them.

On `animalcare`, the same session showed SKU 1851 as **53,541** on PDP (public table) and **18,870** on PLP (`pl-001`). Intsch’s REST API returns 18,870 on both `/products` and `/product-search` when `priceTables=pl-001` and `regionId` are passed.

PDP now uses the same `segmentQueryParams` helper as PLP. GraphQL `salesChannel` still wins over the segment; `sc` is not defaulted to `1`.

**Example**

Before (PDP): `/api/intelligent-search/v1/products?field=id&value=1322&sc=1`

After (PDP, same session as PLP): `/api/intelligent-search/v1/products?field=id&value=1322&sc=1&regionId=v2.1BB18CE648B5111D0933734ED83EC783&priceTables=pl-001`

## How should this be manually tested?

On an account with a custom price table (e.g. `animalcare`, `pl-001`) and `shouldUseNewPDPEndpoint` enabled, load PLP and PDP for the same SKU in a session that has `priceTables` on the segment. PDP selling price should match PLP.

## Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to [INC-6296](https://app.incident.io/vtex/response/incidents/6296).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

## Screenshots or example usage

Live check on `animalcare` (CL), SKU **1851** / product **1322**, seller `1`. Both workspaces had `shouldUseNewPDPEndpoint` enabled.

| Workspace | Path | No segment | With `pl-001` segment |
|---|---|---:|---:|
| `inc6296` (old + flag on) | PDP `product` | 53,541 | **53,541 (wrong)** |
| `inc6296` (old + flag on) | PLP `productSearch` | 53,541 | **18,870 (correct)** |
| `chrs` (this patch + flag on) | PDP `product` | 53,541 | **18,870 (fixed)** |
| `chrs` (this patch + flag on) | PLP `productSearch` | 53,541 | **18,870 (correct)** |

```text
inc6296  PDP + segment → 53,541   ✗  public table
inc6296  PLP + segment → 18,870   ✓  pl-001
chrs     PDP + segment → 18,870   ✓  matches PLP
chrs     PLP + segment → 18,870   ✓
```

Old workspace reproduces the incident: same segment, PLP is right and PDP stays on the public price. Patched workspace makes PDP match PLP at 18,870. With no price-table segment, both workspaces still return 53,541, so the patch applies `pl-001` instead of changing the default table.

### Methodology

1. Workspaces: `inc6296--animalcare.myvtex.com` (unpatched search-resolver, flag on) vs `chrs--animalcare.myvtex.com` (this PR, flag on).
2. Same GraphQL over `POST /_v/segment/graphql/v1` with `@context(provider: "vtex.search-graphql")`.
3. PDP: `product(identifier: { field: sku, value: "1851" }, salesChannel: 1)` and read `items[].sellers[].commertialOffer.Price` for SKU 1851.
4. PLP: `productSearch(query: "bravecto plus gatos", …)` and the same SKU/seller fields, so the only variable is the resolver path.
5. Segment: each query was run twice — no `vtex_segment` cookie, then with a cookie/header whose payload is `channel=1`, `priceTables=pl-001`, `regionId=v2.1BB18CE648B5111D0933734ED83EC783` (Chile / CLP). No other headers changed.
6. Expected: without the segment, public price 53,541 on every cell. With the segment, PLP 18,870 on both workspaces; PDP 53,541 only on the old workspace, 18,870 on the patch.

## Type of changes

✔️ | Type of Change
---|---
✔️ | Bug fix
_ | New feature
_ | Breaking change
_ | Technical improvements

## Notes

Facets also go through `segmentQueryParams`, so they now receive the same simulation fields (`priceTables`, UTMs, campaigns) as product-search.
